### PR TITLE
[CSS] feat: add input component

### DIFF
--- a/packages/css/src/04-components/index.scss
+++ b/packages/css/src/04-components/index.scss
@@ -1,7 +1,8 @@
 @forward './badge/index';
 @forward './button/index';
 @forward './card/index';
-@forward './icon/index';
 @forward './code/index';
+@forward './icon/index';
+@forward './input/index';
 @forward './table/index';
 @forward './tabs/index';

--- a/packages/css/src/04-components/input/index.scss
+++ b/packages/css/src/04-components/input/index.scss
@@ -1,0 +1,154 @@
+@use '../../00-config/tokens/variables' as t;
+
+// Input component - text input field
+// Heights align to grid rows
+
+@layer components.tokens {
+  .input {
+    --_height: var(--ui-input-height, var(--ui-row-2, #{t.$row-2}));
+    --_padding-x: var(--ui-input-padding-x, var(--ui-space-1, #{t.$space-1}));
+    --_font-size: var(--ui-input-font-size, var(--ui-size-sm, #{t.$size-sm}));
+    --_radius: var(--ui-input-radius, var(--ui-radius-md, #{t.$radius-md}));
+    --_bg: var(--ui-input-bg, var(--ui-color-bg, #{t.$color-bg}));
+    --_border-color: var(--ui-input-border-color, var(--ui-color-border-strong, #{t.$color-border-strong}));
+    --_border-color-focus: var(--ui-input-border-color-focus, var(--ui-color-primary, #{t.$color-primary}));
+    --_text: var(--ui-input-text, var(--ui-color-text, #{t.$color-text}));
+    --_placeholder: var(--ui-input-placeholder, var(--ui-color-text-muted, #{t.$color-text-muted}));
+  }
+
+  // Size variants
+  .input--sm {
+    --_height: var(--ui-input-height-sm, calc(#{t.$row} * 1.5));
+    --_font-size: var(--ui-input-font-size-sm, var(--ui-size-xs, #{t.$size-xs}));
+  }
+
+  .input--lg {
+    --_height: var(--ui-input-height-lg, calc(#{t.$row} * 2.5));
+    --_padding-x: var(--ui-input-padding-x-lg, var(--ui-space-2, #{t.$space-2}));
+    --_font-size: var(--ui-input-font-size-lg, var(--ui-size-md, #{t.$size-md}));
+  }
+
+  // Style variants
+  .input--filled {
+    --_bg: var(--ui-input-filled-bg, var(--ui-color-bg-muted, #{t.$color-bg-muted}));
+    --_border-color: transparent;
+  }
+
+  .input--ghost {
+    --_bg: transparent;
+    --_border-color: transparent;
+  }
+
+  // State variants
+  .input--error {
+    --_border-color: var(--ui-input-error-border, var(--ui-color-danger, #{t.$color-danger}));
+    --_border-color-focus: var(--ui-input-error-border, var(--ui-color-danger, #{t.$color-danger}));
+  }
+
+  .input--success {
+    --_border-color: var(--ui-input-success-border, var(--ui-color-success, #{t.$color-success}));
+    --_border-color-focus: var(--ui-input-success-border, var(--ui-color-success, #{t.$color-success}));
+  }
+}
+
+@layer components.styles {
+  .input {
+    display: inline-flex;
+    align-items: center;
+
+    block-size: var(--_height);
+    padding-inline: var(--_padding-x);
+
+    font-family: inherit;
+    font-size: var(--_font-size);
+    line-height: 1;
+    color: var(--_text);
+
+    background: var(--_bg);
+    border: var(--ui-border-width-sm, #{t.$border-width-sm}) solid var(--_border-color);
+    border-radius: var(--_radius);
+
+    transition:
+      border-color var(--ui-duration-fast, 150ms) var(--ui-ease-default, ease),
+      box-shadow var(--ui-duration-fast, 150ms) var(--ui-ease-default, ease);
+
+    &::placeholder {
+      color: var(--_placeholder);
+    }
+
+    &:hover:not(:disabled, :focus) {
+      border-color: var(--ui-color-border-strong, #{t.$color-border-strong});
+    }
+
+    &:focus,
+    &--focus {
+      border-color: var(--_border-color-focus);
+      outline: none;
+      box-shadow: 0 0 0 var(--ui-border-width-md, #{t.$border-width-md}) var(--ui-color-focus, #{t.$color-focus});
+    }
+
+    &:disabled,
+    &--disabled {
+      opacity: 0.5;
+      cursor: not-allowed;
+    }
+
+    &:read-only {
+      background: var(--ui-color-bg-subtle, #{t.$color-bg-subtle});
+    }
+
+    // Full width
+    &--block {
+      inline-size: 100%;
+    }
+  }
+
+  // Input wrapper for prefix/suffix
+  .input-group {
+    display: inline-flex;
+    align-items: stretch;
+    position: relative;
+
+    .input {
+      flex: 1;
+    }
+
+    // With prefix
+    &--has-prefix .input {
+      padding-inline-start: calc(var(--_height) + var(--ui-space-half, #{t.$space-0}));
+    }
+
+    // With suffix
+    &--has-suffix .input {
+      padding-inline-end: calc(var(--_height) + var(--ui-space-half, #{t.$space-0}));
+    }
+  }
+
+  .input-group__addon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    position: absolute;
+    inset-block: 0;
+
+    inline-size: var(--_height, #{t.$row-2});
+
+    color: var(--ui-color-text-muted, #{t.$color-text-muted});
+
+    pointer-events: none;
+
+    &--start {
+      inset-inline-start: 0;
+    }
+
+    &--end {
+      inset-inline-end: 0;
+    }
+
+    // Interactive addon (buttons)
+    &--interactive {
+      cursor: pointer;
+      pointer-events: auto;
+    }
+  }
+}

--- a/packages/css/src/04-components/input/input.api.json
+++ b/packages/css/src/04-components/input/input.api.json
@@ -1,0 +1,52 @@
+{
+  "name": "input",
+  "baseClass": "input",
+  "element": "input",
+  "description": "Text input field with support for prefix/suffix slots",
+  "modifiers": {
+    "size": {
+      "values": ["sm", "lg"],
+      "default": null,
+      "description": "Size variant. Default is 32px / 2 rows."
+    },
+    "variant": {
+      "values": ["filled", "ghost"],
+      "default": null,
+      "description": "Visual style. Default is outline with border."
+    },
+    "state": {
+      "values": ["error", "success"],
+      "default": null,
+      "description": "Validation state styling."
+    },
+    "block": {
+      "type": "boolean",
+      "description": "Full width input."
+    }
+  },
+  "states": ["hover", "focus", "disabled", "readonly"],
+  "elements": {
+    "group": {
+      "class": "input-group",
+      "description": "Wrapper for input with prefix/suffix addons",
+      "modifiers": {
+        "has-prefix": { "type": "boolean" },
+        "has-suffix": { "type": "boolean" }
+      }
+    },
+    "addon": {
+      "class": "input-group__addon",
+      "description": "Prefix or suffix container",
+      "modifiers": {
+        "position": {
+          "values": ["start", "end"],
+          "description": "Addon position"
+        },
+        "interactive": {
+          "type": "boolean",
+          "description": "Enable pointer events for buttons"
+        }
+      }
+    }
+  }
+}

--- a/packages/css/src/04-components/input/input.docs.json
+++ b/packages/css/src/04-components/input/input.docs.json
@@ -1,0 +1,139 @@
+{
+  "id": "input",
+  "type": "component",
+  "title": "Input",
+  "description": "Text input field for user data entry. Heights align to grid rows.",
+  "sections": [
+    {
+      "title": "Default",
+      "examples": [
+        {
+          "html": "<input class=\"ui-input\" type=\"text\" placeholder=\"Enter text...\">"
+        }
+      ]
+    },
+    {
+      "title": "Sizes",
+      "examples": [
+        {
+          "layout": "stack",
+          "items": [
+            {
+              "tag": "input",
+              "class": "ui-input ui-input--sm",
+              "attrs": { "type": "text", "placeholder": "Small (1.5 rows)" }
+            },
+            {
+              "tag": "input",
+              "class": "ui-input",
+              "attrs": { "type": "text", "placeholder": "Default (2 rows)" }
+            },
+            {
+              "tag": "input",
+              "class": "ui-input ui-input--lg",
+              "attrs": { "type": "text", "placeholder": "Large (2.5 rows)" }
+            }
+          ],
+          "code": "<input class=\"ui-input ui-input--sm\" placeholder=\"Small\">\n<input class=\"ui-input\" placeholder=\"Default\">\n<input class=\"ui-input ui-input--lg\" placeholder=\"Large\">"
+        }
+      ]
+    },
+    {
+      "title": "Variants",
+      "examples": [
+        {
+          "layout": "stack",
+          "items": [
+            {
+              "tag": "input",
+              "class": "ui-input",
+              "attrs": { "type": "text", "placeholder": "Outline (default)" }
+            },
+            {
+              "tag": "input",
+              "class": "ui-input ui-input--filled",
+              "attrs": { "type": "text", "placeholder": "Filled" }
+            },
+            {
+              "tag": "input",
+              "class": "ui-input ui-input--ghost",
+              "attrs": { "type": "text", "placeholder": "Ghost" }
+            }
+          ],
+          "code": "<input class=\"ui-input\" placeholder=\"Outline\">\n<input class=\"ui-input ui-input--filled\" placeholder=\"Filled\">\n<input class=\"ui-input ui-input--ghost\" placeholder=\"Ghost\">"
+        }
+      ]
+    },
+    {
+      "title": "States",
+      "examples": [
+        {
+          "layout": "stack",
+          "items": [
+            {
+              "tag": "input",
+              "class": "ui-input",
+              "attrs": { "type": "text", "placeholder": "Default" }
+            },
+            {
+              "tag": "input",
+              "class": "ui-input ui-input--error",
+              "attrs": { "type": "text", "value": "Invalid input" }
+            },
+            {
+              "tag": "input",
+              "class": "ui-input ui-input--success",
+              "attrs": { "type": "text", "value": "Valid input" }
+            },
+            {
+              "tag": "input",
+              "class": "ui-input",
+              "attrs": { "type": "text", "placeholder": "Disabled", "disabled": "" }
+            },
+            {
+              "tag": "input",
+              "class": "ui-input",
+              "attrs": { "type": "text", "value": "Read only", "readonly": "" }
+            }
+          ],
+          "code": "<input class=\"ui-input\" placeholder=\"Default\">\n<input class=\"ui-input ui-input--error\" value=\"Invalid\">\n<input class=\"ui-input ui-input--success\" value=\"Valid\">\n<input class=\"ui-input\" disabled placeholder=\"Disabled\">\n<input class=\"ui-input\" readonly value=\"Read only\">"
+        }
+      ]
+    },
+    {
+      "title": "Full Width",
+      "examples": [
+        {
+          "html": "<input class=\"ui-input ui-input--block\" type=\"text\" placeholder=\"Full width input\">"
+        }
+      ]
+    },
+    {
+      "title": "With Prefix Icon",
+      "examples": [
+        {
+          "html": "<div class=\"ui-input-group ui-input-group--has-prefix\"><span class=\"ui-input-group__addon ui-input-group__addon--start\"><svg class=\"ui-icon\" xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\"><circle cx=\"11\" cy=\"11\" r=\"8\"/><path d=\"m21 21-4.3-4.3\"/></svg></span><input class=\"ui-input ui-input--block\" type=\"search\" placeholder=\"Search...\"></div>",
+          "code": "<div class=\"ui-input-group ui-input-group--has-prefix\">\n  <span class=\"ui-input-group__addon ui-input-group__addon--start\">\n    <svg class=\"ui-icon\"><!-- search icon --></svg>\n  </span>\n  <input class=\"ui-input ui-input--block\" type=\"search\" placeholder=\"Search...\">\n</div>"
+        }
+      ]
+    },
+    {
+      "title": "With Suffix Icon",
+      "examples": [
+        {
+          "html": "<div class=\"ui-input-group ui-input-group--has-suffix\"><input class=\"ui-input ui-input--block\" type=\"email\" placeholder=\"Email address\"><span class=\"ui-input-group__addon ui-input-group__addon--end\"><svg class=\"ui-icon\" xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\"><rect width=\"20\" height=\"16\" x=\"2\" y=\"4\" rx=\"2\"/><path d=\"m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7\"/></svg></span></div>",
+          "code": "<div class=\"ui-input-group ui-input-group--has-suffix\">\n  <input class=\"ui-input ui-input--block\" type=\"email\" placeholder=\"Email\">\n  <span class=\"ui-input-group__addon ui-input-group__addon--end\">\n    <svg class=\"ui-icon\"><!-- mail icon --></svg>\n  </span>\n</div>"
+        }
+      ]
+    },
+    {
+      "title": "With Both Addons",
+      "examples": [
+        {
+          "html": "<div class=\"ui-input-group ui-input-group--has-prefix ui-input-group--has-suffix\"><span class=\"ui-input-group__addon ui-input-group__addon--start\"><svg class=\"ui-icon\" xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\"><path d=\"M19 21v-2a4 4 0 0 0-4-4H9a4 4 0 0 0-4 4v2\"/><circle cx=\"12\" cy=\"7\" r=\"4\"/></svg></span><input class=\"ui-input ui-input--block\" type=\"text\" placeholder=\"Username\"><span class=\"ui-input-group__addon ui-input-group__addon--end ui-input-group__addon--interactive\"><svg class=\"ui-icon\" xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\"><path d=\"M18 6 6 18\"/><path d=\"m6 6 12 12\"/></svg></span></div>",
+          "code": "<div class=\"ui-input-group ui-input-group--has-prefix ui-input-group--has-suffix\">\n  <span class=\"ui-input-group__addon ui-input-group__addon--start\">...</span>\n  <input class=\"ui-input ui-input--block\" placeholder=\"Username\">\n  <span class=\"ui-input-group__addon ui-input-group__addon--end ui-input-group__addon--interactive\">...</span>\n</div>"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Add Input component with text field styling
- Sizes: sm (1.5 rows), default (2 rows), lg (2.5 rows)
- Variants: outline (default), filled, ghost
- States: error, success, disabled, readonly
- Input group with prefix/suffix addon slots
- Full width block modifier

Closes #21

## Test plan
- [ ] Verify input renders correctly at all sizes
- [ ] Test focus/hover states
- [ ] Test error/success states
- [ ] Verify prefix/suffix slots work