### PR TITLE
[CSS] feat: add textarea component

### DIFF
--- a/packages/css/src/04-components/index.scss
+++ b/packages/css/src/04-components/index.scss
@@ -6,3 +6,4 @@
 @forward './input/index';
 @forward './table/index';
 @forward './tabs/index';
+@forward './textarea/index';

--- a/packages/css/src/04-components/textarea/index.scss
+++ b/packages/css/src/04-components/textarea/index.scss
@@ -1,0 +1,121 @@
+@use '../../00-config/tokens/variables' as t;
+
+// Textarea component - multi-line text input
+// Shares token patterns with Input
+
+@layer components.tokens {
+  .textarea {
+    --_min-height: var(--ui-textarea-min-height, calc(#{t.$row} * 4));
+    --_padding-x: var(--ui-textarea-padding-x, var(--ui-space-1, #{t.$space-1}));
+    --_padding-y: var(--ui-textarea-padding-y, var(--ui-space-1, #{t.$space-1}));
+    --_font-size: var(--ui-textarea-font-size, var(--ui-size-sm, #{t.$size-sm}));
+    --_radius: var(--ui-textarea-radius, var(--ui-radius-md, #{t.$radius-md}));
+    --_bg: var(--ui-textarea-bg, var(--ui-color-bg, #{t.$color-bg}));
+    --_border-color: var(--ui-textarea-border-color, var(--ui-color-border-strong, #{t.$color-border-strong}));
+    --_border-color-focus: var(--ui-textarea-border-color-focus, var(--ui-color-primary, #{t.$color-primary}));
+    --_text: var(--ui-textarea-text, var(--ui-color-text, #{t.$color-text}));
+    --_placeholder: var(--ui-textarea-placeholder, var(--ui-color-text-muted, #{t.$color-text-muted}));
+  }
+
+  // Size variants
+  .textarea--sm {
+    --_min-height: var(--ui-textarea-min-height-sm, calc(#{t.$row} * 3));
+    --_font-size: var(--ui-textarea-font-size-sm, var(--ui-size-xs, #{t.$size-xs}));
+  }
+
+  .textarea--lg {
+    --_min-height: var(--ui-textarea-min-height-lg, calc(#{t.$row} * 6));
+    --_padding-x: var(--ui-textarea-padding-x-lg, var(--ui-space-2, #{t.$space-2}));
+    --_padding-y: var(--ui-textarea-padding-y-lg, var(--ui-space-2, #{t.$space-2}));
+    --_font-size: var(--ui-textarea-font-size-lg, var(--ui-size-md, #{t.$size-md}));
+  }
+
+  // Style variants
+  .textarea--filled {
+    --_bg: var(--ui-textarea-filled-bg, var(--ui-color-bg-muted, #{t.$color-bg-muted}));
+    --_border-color: transparent;
+  }
+
+  .textarea--ghost {
+    --_bg: transparent;
+    --_border-color: transparent;
+  }
+
+  // State variants
+  .textarea--error {
+    --_border-color: var(--ui-textarea-error-border, var(--ui-color-danger, #{t.$color-danger}));
+    --_border-color-focus: var(--ui-textarea-error-border, var(--ui-color-danger, #{t.$color-danger}));
+  }
+
+  .textarea--success {
+    --_border-color: var(--ui-textarea-success-border, var(--ui-color-success, #{t.$color-success}));
+    --_border-color-focus: var(--ui-textarea-success-border, var(--ui-color-success, #{t.$color-success}));
+  }
+}
+
+@layer components.styles {
+  .textarea {
+    display: block;
+
+    inline-size: 100%;
+    min-block-size: var(--_min-height);
+    padding-block: var(--_padding-y);
+    padding-inline: var(--_padding-x);
+
+    font-family: inherit;
+    font-size: var(--_font-size);
+    line-height: var(--ui-line-height-normal, 1.5);
+    color: var(--_text);
+
+    background: var(--_bg);
+    border: var(--ui-border-width-sm, #{t.$border-width-sm}) solid var(--_border-color);
+    border-radius: var(--_radius);
+
+    transition:
+      border-color var(--ui-duration-fast, 150ms) var(--ui-ease-default, ease),
+      box-shadow var(--ui-duration-fast, 150ms) var(--ui-ease-default, ease);
+
+    // Default resize behavior
+    resize: vertical;
+
+    &::placeholder {
+      color: var(--_placeholder);
+    }
+
+    &:hover:not(:disabled, :focus) {
+      border-color: var(--ui-color-border-strong, #{t.$color-border-strong});
+    }
+
+    &:focus,
+    &--focus {
+      border-color: var(--_border-color-focus);
+      outline: none;
+      box-shadow: 0 0 0 var(--ui-border-width-md, #{t.$border-width-md}) var(--ui-color-focus, #{t.$color-focus});
+    }
+
+    &:disabled,
+    &--disabled {
+      opacity: 0.5;
+      cursor: not-allowed;
+      resize: none;
+    }
+
+    &:read-only {
+      background: var(--ui-color-bg-subtle, #{t.$color-bg-subtle});
+      resize: none;
+    }
+
+    // Resize variants
+    &--resize-none {
+      resize: none;
+    }
+
+    &--resize-horizontal {
+      resize: horizontal;
+    }
+
+    &--resize-both {
+      resize: both;
+    }
+  }
+}

--- a/packages/css/src/04-components/textarea/textarea.api.json
+++ b/packages/css/src/04-components/textarea/textarea.api.json
@@ -1,0 +1,29 @@
+{
+  "name": "textarea",
+  "baseClass": "textarea",
+  "element": "textarea",
+  "description": "Multi-line text input field",
+  "modifiers": {
+    "size": {
+      "values": ["sm", "lg"],
+      "default": null,
+      "description": "Size variant. Default is 4 rows height."
+    },
+    "variant": {
+      "values": ["filled", "ghost"],
+      "default": null,
+      "description": "Visual style. Default is outline with border."
+    },
+    "state": {
+      "values": ["error", "success"],
+      "default": null,
+      "description": "Validation state styling."
+    },
+    "resize": {
+      "values": ["none", "horizontal", "both"],
+      "default": null,
+      "description": "Resize behavior. Default is vertical only."
+    }
+  },
+  "states": ["hover", "focus", "disabled", "readonly"]
+}

--- a/packages/css/src/04-components/textarea/textarea.docs.json
+++ b/packages/css/src/04-components/textarea/textarea.docs.json
@@ -1,0 +1,127 @@
+{
+  "id": "textarea",
+  "type": "component",
+  "title": "Textarea",
+  "description": "Multi-line text input for longer content like comments or descriptions.",
+  "sections": [
+    {
+      "title": "Default",
+      "examples": [
+        {
+          "html": "<textarea class=\"ui-textarea\" placeholder=\"Enter your message...\"></textarea>"
+        }
+      ]
+    },
+    {
+      "title": "Sizes",
+      "examples": [
+        {
+          "layout": "stack",
+          "items": [
+            {
+              "tag": "textarea",
+              "class": "ui-textarea ui-textarea--sm",
+              "attrs": { "placeholder": "Small (3 rows)" }
+            },
+            {
+              "tag": "textarea",
+              "class": "ui-textarea",
+              "attrs": { "placeholder": "Default (4 rows)" }
+            },
+            {
+              "tag": "textarea",
+              "class": "ui-textarea ui-textarea--lg",
+              "attrs": { "placeholder": "Large (6 rows)" }
+            }
+          ],
+          "code": "<textarea class=\"ui-textarea ui-textarea--sm\"></textarea>\n<textarea class=\"ui-textarea\"></textarea>\n<textarea class=\"ui-textarea ui-textarea--lg\"></textarea>"
+        }
+      ]
+    },
+    {
+      "title": "Variants",
+      "examples": [
+        {
+          "layout": "stack",
+          "items": [
+            {
+              "tag": "textarea",
+              "class": "ui-textarea",
+              "attrs": { "placeholder": "Outline (default)" }
+            },
+            {
+              "tag": "textarea",
+              "class": "ui-textarea ui-textarea--filled",
+              "attrs": { "placeholder": "Filled" }
+            },
+            {
+              "tag": "textarea",
+              "class": "ui-textarea ui-textarea--ghost",
+              "attrs": { "placeholder": "Ghost" }
+            }
+          ],
+          "code": "<textarea class=\"ui-textarea\"></textarea>\n<textarea class=\"ui-textarea ui-textarea--filled\"></textarea>\n<textarea class=\"ui-textarea ui-textarea--ghost\"></textarea>"
+        }
+      ]
+    },
+    {
+      "title": "States",
+      "examples": [
+        {
+          "layout": "stack",
+          "items": [
+            {
+              "tag": "textarea",
+              "class": "ui-textarea ui-textarea--error",
+              "text": "Invalid content"
+            },
+            {
+              "tag": "textarea",
+              "class": "ui-textarea ui-textarea--success",
+              "text": "Valid content"
+            },
+            {
+              "tag": "textarea",
+              "class": "ui-textarea",
+              "attrs": { "disabled": "", "placeholder": "Disabled" }
+            },
+            {
+              "tag": "textarea",
+              "class": "ui-textarea",
+              "attrs": { "readonly": "" },
+              "text": "Read only content"
+            }
+          ],
+          "code": "<textarea class=\"ui-textarea ui-textarea--error\">Invalid</textarea>\n<textarea class=\"ui-textarea ui-textarea--success\">Valid</textarea>\n<textarea class=\"ui-textarea\" disabled></textarea>\n<textarea class=\"ui-textarea\" readonly>Read only</textarea>"
+        }
+      ]
+    },
+    {
+      "title": "Resize Options",
+      "description": "Control how users can resize the textarea.",
+      "examples": [
+        {
+          "layout": "stack",
+          "items": [
+            {
+              "tag": "textarea",
+              "class": "ui-textarea",
+              "attrs": { "placeholder": "Vertical resize (default)" }
+            },
+            {
+              "tag": "textarea",
+              "class": "ui-textarea ui-textarea--resize-none",
+              "attrs": { "placeholder": "No resize" }
+            },
+            {
+              "tag": "textarea",
+              "class": "ui-textarea ui-textarea--resize-both",
+              "attrs": { "placeholder": "Resize both directions" }
+            }
+          ],
+          "code": "<textarea class=\"ui-textarea\">Vertical (default)</textarea>\n<textarea class=\"ui-textarea ui-textarea--resize-none\">No resize</textarea>\n<textarea class=\"ui-textarea ui-textarea--resize-both\">Both directions</textarea>"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Add Textarea component for multi-line text input
- Sizes: sm (3 rows), default (4 rows), lg (6 rows)
- Variants: outline (default), filled, ghost
- States: error, success, disabled, readonly
- Resize options: vertical (default), none, horizontal, both

Closes #25

## Test plan
- [ ] Verify textarea renders at all sizes
- [ ] Test resize behavior
- [ ] Test validation states