### PR TITLE
[CSS] feat: add select component

### DIFF
--- a/packages/css/src/04-components/index.scss
+++ b/packages/css/src/04-components/index.scss
@@ -4,6 +4,7 @@
 @forward './code/index';
 @forward './icon/index';
 @forward './input/index';
+@forward './select/index';
 @forward './table/index';
 @forward './tabs/index';
 @forward './textarea/index';

--- a/packages/css/src/04-components/select/index.scss
+++ b/packages/css/src/04-components/select/index.scss
@@ -1,0 +1,113 @@
+@use '../../00-config/tokens/variables' as t;
+
+// Select component - native select with custom styling
+// Heights align to grid rows, consistent with Input
+
+@layer components.tokens {
+  .select {
+    --_height: var(--ui-select-height, var(--ui-row-2, #{t.$row-2}));
+    --_padding-x: var(--ui-select-padding-x, var(--ui-space-1, #{t.$space-1}));
+    --_font-size: var(--ui-select-font-size, var(--ui-size-sm, #{t.$size-sm}));
+    --_radius: var(--ui-select-radius, var(--ui-radius-md, #{t.$radius-md}));
+    --_bg: var(--ui-select-bg, var(--ui-color-bg, #{t.$color-bg}));
+    --_border-color: var(--ui-select-border-color, var(--ui-color-border-strong, #{t.$color-border-strong}));
+    --_border-color-focus: var(--ui-select-border-color-focus, var(--ui-color-primary, #{t.$color-primary}));
+    --_text: var(--ui-select-text, var(--ui-color-text, #{t.$color-text}));
+    --_icon-color: var(--ui-select-icon-color, var(--ui-color-text-muted, #{t.$color-text-muted}));
+  }
+
+  // Size variants
+  .select--sm {
+    --_height: var(--ui-select-height-sm, calc(#{t.$row} * 1.5));
+    --_font-size: var(--ui-select-font-size-sm, var(--ui-size-xs, #{t.$size-xs}));
+  }
+
+  .select--lg {
+    --_height: var(--ui-select-height-lg, calc(#{t.$row} * 2.5));
+    --_padding-x: var(--ui-select-padding-x-lg, var(--ui-space-2, #{t.$space-2}));
+    --_font-size: var(--ui-select-font-size-lg, var(--ui-size-md, #{t.$size-md}));
+  }
+
+  // Style variants
+  .select--filled {
+    --_bg: var(--ui-select-filled-bg, var(--ui-color-bg-muted, #{t.$color-bg-muted}));
+    --_border-color: transparent;
+  }
+
+  .select--ghost {
+    --_bg: transparent;
+    --_border-color: transparent;
+  }
+
+  // State variants
+  .select--error {
+    --_border-color: var(--ui-select-error-border, var(--ui-color-danger, #{t.$color-danger}));
+    --_border-color-focus: var(--ui-select-error-border, var(--ui-color-danger, #{t.$color-danger}));
+  }
+
+  .select--success {
+    --_border-color: var(--ui-select-success-border, var(--ui-color-success, #{t.$color-success}));
+    --_border-color-focus: var(--ui-select-success-border, var(--ui-color-success, #{t.$color-success}));
+  }
+}
+
+@layer components.styles {
+  .select {
+
+    display: inline-block;
+
+    block-size: var(--_height);
+    // Extra padding for arrow
+    padding-inline-start: var(--_padding-x);
+    padding-inline-end: calc(var(--_height) - var(--ui-space-half, #{t.$space-0}));
+
+    font-family: inherit;
+    font-size: var(--_font-size);
+    line-height: 1;
+    color: var(--_text);
+
+    background-color: var(--_bg);
+    // Chevron down arrow
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%23666' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='m6 9 6 6 6-6'/%3E%3C/svg%3E");
+    border: var(--ui-border-width-sm, #{t.$border-width-sm}) solid var(--_border-color);
+    border-radius: var(--_radius);
+    cursor: pointer;
+    // Reset native select
+    appearance: none;
+
+    transition:
+      border-color var(--ui-duration-fast, 150ms) var(--ui-ease-default, ease),
+      box-shadow var(--ui-duration-fast, 150ms) var(--ui-ease-default, ease);
+    background-repeat: no-repeat;
+    background-position: right var(--ui-space-half, #{t.$space-0}) center;
+    background-size: calc(var(--_height) * 0.5);
+
+    &:hover:not(:disabled, :focus) {
+      border-color: var(--ui-color-border-strong, #{t.$color-border-strong});
+    }
+
+    &:focus,
+    &--focus {
+      border-color: var(--_border-color-focus);
+      outline: none;
+      box-shadow: 0 0 0 var(--ui-border-width-md, #{t.$border-width-md}) var(--ui-color-focus, #{t.$color-focus});
+    }
+
+    &:disabled,
+    &--disabled {
+      opacity: 0.5;
+      cursor: not-allowed;
+    }
+
+    // Full width
+    &--block {
+      inline-size: 100%;
+    }
+
+    // Placeholder option styling
+    &:invalid,
+    &--placeholder {
+      color: var(--ui-color-text-muted, #{t.$color-text-muted});
+    }
+  }
+}

--- a/packages/css/src/04-components/select/select.api.json
+++ b/packages/css/src/04-components/select/select.api.json
@@ -1,0 +1,28 @@
+{
+  "name": "select",
+  "baseClass": "select",
+  "element": "select",
+  "description": "Native select dropdown with custom styling",
+  "modifiers": {
+    "size": {
+      "values": ["sm", "lg"],
+      "default": null,
+      "description": "Size variant. Default is 32px / 2 rows."
+    },
+    "variant": {
+      "values": ["filled", "ghost"],
+      "default": null,
+      "description": "Visual style. Default is outline with border."
+    },
+    "state": {
+      "values": ["error", "success"],
+      "default": null,
+      "description": "Validation state styling."
+    },
+    "block": {
+      "type": "boolean",
+      "description": "Full width select."
+    }
+  },
+  "states": ["hover", "focus", "disabled"]
+}

--- a/packages/css/src/04-components/select/select.docs.json
+++ b/packages/css/src/04-components/select/select.docs.json
@@ -1,0 +1,108 @@
+{
+  "id": "select",
+  "type": "component",
+  "title": "Select",
+  "description": "Native select dropdown with custom styling. Dropdown options use browser default styles.",
+  "sections": [
+    {
+      "title": "Default",
+      "examples": [
+        {
+          "html": "<select class=\"ui-select\"><option value=\"\" disabled selected>Choose option...</option><option value=\"1\">Option 1</option><option value=\"2\">Option 2</option><option value=\"3\">Option 3</option></select>"
+        }
+      ]
+    },
+    {
+      "title": "Sizes",
+      "examples": [
+        {
+          "layout": "stack",
+          "items": [
+            {
+              "tag": "select",
+              "class": "ui-select ui-select--sm",
+              "html": "<option>Small</option><option>Option 2</option>"
+            },
+            {
+              "tag": "select",
+              "class": "ui-select",
+              "html": "<option>Default</option><option>Option 2</option>"
+            },
+            {
+              "tag": "select",
+              "class": "ui-select ui-select--lg",
+              "html": "<option>Large</option><option>Option 2</option>"
+            }
+          ],
+          "code": "<select class=\"ui-select ui-select--sm\">...</select>\n<select class=\"ui-select\">...</select>\n<select class=\"ui-select ui-select--lg\">...</select>"
+        }
+      ]
+    },
+    {
+      "title": "Variants",
+      "examples": [
+        {
+          "layout": "stack",
+          "items": [
+            { "tag": "select", "class": "ui-select", "html": "<option>Outline (default)</option>" },
+            {
+              "tag": "select",
+              "class": "ui-select ui-select--filled",
+              "html": "<option>Filled</option>"
+            },
+            {
+              "tag": "select",
+              "class": "ui-select ui-select--ghost",
+              "html": "<option>Ghost</option>"
+            }
+          ],
+          "code": "<select class=\"ui-select\">...</select>\n<select class=\"ui-select ui-select--filled\">...</select>\n<select class=\"ui-select ui-select--ghost\">...</select>"
+        }
+      ]
+    },
+    {
+      "title": "States",
+      "examples": [
+        {
+          "layout": "stack",
+          "items": [
+            {
+              "tag": "select",
+              "class": "ui-select ui-select--error",
+              "html": "<option>Error state</option>"
+            },
+            {
+              "tag": "select",
+              "class": "ui-select ui-select--success",
+              "html": "<option>Success state</option>"
+            },
+            {
+              "tag": "select",
+              "class": "ui-select",
+              "attrs": { "disabled": "" },
+              "html": "<option>Disabled</option>"
+            }
+          ],
+          "code": "<select class=\"ui-select ui-select--error\">...</select>\n<select class=\"ui-select ui-select--success\">...</select>\n<select class=\"ui-select\" disabled>...</select>"
+        }
+      ]
+    },
+    {
+      "title": "Full Width",
+      "examples": [
+        {
+          "html": "<select class=\"ui-select ui-select--block\"><option value=\"\">Full width select...</option><option value=\"1\">Option 1</option></select>"
+        }
+      ]
+    },
+    {
+      "title": "With Option Groups",
+      "examples": [
+        {
+          "html": "<select class=\"ui-select ui-select--block\"><option value=\"\" disabled selected>Choose a fruit...</option><optgroup label=\"Citrus\"><option value=\"orange\">Orange</option><option value=\"lemon\">Lemon</option></optgroup><optgroup label=\"Berries\"><option value=\"strawberry\">Strawberry</option><option value=\"blueberry\">Blueberry</option></optgroup></select>",
+          "code": "<select class=\"ui-select\">\n  <optgroup label=\"Citrus\">\n    <option>Orange</option>\n    <option>Lemon</option>\n  </optgroup>\n  <optgroup label=\"Berries\">\n    <option>Strawberry</option>\n  </optgroup>\n</select>"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Add Select component for native select dropdowns
- Sizes: sm, default, lg (matches Input)
- Variants: outline (default), filled, ghost
- States: error, success, disabled
- Custom chevron arrow via SVG background
- Support for optgroup

Closes #24

## Test plan
- [ ] Verify select renders at all sizes
- [ ] Test focus/hover states
- [ ] Verify arrow displays correctly