### PR TITLE
[CSS] fix: align icon sizes to grid rhythm

### DIFF
--- a/packages/css/src/04-components/icon/icon.docs.json
+++ b/packages/css/src/04-components/icon/icon.docs.json
@@ -26,11 +26,11 @@
       "title": "Sizes",
       "data": {
         "sizes": [
-          { "mod": "xs", "label": "1.5u" },
-          { "mod": "sm", "label": "2u" },
-          { "mod": "md", "label": "2.5u" },
-          { "mod": "lg", "label": "3u" },
-          { "mod": "xl", "label": "4u" }
+          { "mod": "xs", "label": "2u" },
+          { "mod": "sm", "label": "3u" },
+          { "mod": "md", "label": "4u" },
+          { "mod": "lg", "label": "5u" },
+          { "mod": "xl", "label": "6u" }
         ]
       },
       "examples": [

--- a/packages/css/src/04-components/icon/index.scss
+++ b/packages/css/src/04-components/icon/index.scss
@@ -10,23 +10,23 @@
   }
 
   .icon--xs {
-    --_size: var(--ui-icon-size-xs, calc(#{t.$unit} * 1.5));
+    --_size: var(--ui-icon-size-xs, calc(#{t.$unit} * 2));
   }
 
   .icon--sm {
-    --_size: var(--ui-icon-size-sm, calc(#{t.$unit} * 2));
+    --_size: var(--ui-icon-size-sm, calc(#{t.$unit} * 3));
   }
 
   .icon--md {
-    --_size: var(--ui-icon-size-md, calc(#{t.$unit} * 2.5));
+    --_size: var(--ui-icon-size-md, calc(#{t.$unit} * 4));
   }
 
   .icon--lg {
-    --_size: var(--ui-icon-size-lg, calc(#{t.$unit} * 3));
+    --_size: var(--ui-icon-size-lg, calc(#{t.$unit} * 5));
   }
 
   .icon--xl {
-    --_size: var(--ui-icon-size-xl, calc(#{t.$unit} * 4));
+    --_size: var(--ui-icon-size-xl, calc(#{t.$unit} * 6));
   }
 
   // Stroke width variants (for stroke-based icons like Lucide)


### PR DESCRIPTION
## Summary
Fix icon sizes to align with 8px grid:
- xs: 2u (16px) - was 1.5u (12px)
- sm: 3u (24px) - was 2u (16px)
- md: 4u (32px) - was 2.5u (20px) 
- lg: 5u (40px) - was 3u (24px)
- xl: 6u (48px) - was 4u (32px)

All sizes now on grid rhythm.

## Test plan
- [ ] Verify icon sizes visually