### PR TITLE
[CSS] feat: add checkbox component

### DIFF
--- a/packages/css/src/04-components/checkbox/checkbox.api.json
+++ b/packages/css/src/04-components/checkbox/checkbox.api.json
@@ -1,0 +1,19 @@
+{
+  "name": "checkbox",
+  "baseClass": "checkbox",
+  "element": "input[type=checkbox]",
+  "description": "Native checkbox with custom styling",
+  "modifiers": {
+    "size": {
+      "values": ["sm", "lg"],
+      "default": null,
+      "description": "Size variant. Default is 20px."
+    },
+    "state": {
+      "values": ["error"],
+      "default": null,
+      "description": "Error state styling."
+    }
+  },
+  "states": ["hover", "focus", "checked", "indeterminate", "disabled"]
+}

--- a/packages/css/src/04-components/checkbox/checkbox.docs.json
+++ b/packages/css/src/04-components/checkbox/checkbox.docs.json
@@ -1,0 +1,108 @@
+{
+  "id": "checkbox",
+  "type": "component",
+  "title": "Checkbox",
+  "description": "Native checkbox input with custom styling. Supports checked, indeterminate, and disabled states.",
+  "sections": [
+    {
+      "title": "Default",
+      "examples": [
+        {
+          "layout": "cluster",
+          "items": [
+            { "tag": "input", "class": "ui-checkbox", "attrs": { "type": "checkbox" } },
+            {
+              "tag": "input",
+              "class": "ui-checkbox",
+              "attrs": { "type": "checkbox", "checked": "" }
+            }
+          ],
+          "code": "<input type=\"checkbox\" class=\"ui-checkbox\">\n<input type=\"checkbox\" class=\"ui-checkbox\" checked>"
+        }
+      ]
+    },
+    {
+      "title": "Sizes",
+      "examples": [
+        {
+          "layout": "cluster",
+          "items": [
+            {
+              "tag": "input",
+              "class": "ui-checkbox ui-checkbox--sm",
+              "attrs": { "type": "checkbox", "checked": "" }
+            },
+            {
+              "tag": "input",
+              "class": "ui-checkbox",
+              "attrs": { "type": "checkbox", "checked": "" }
+            },
+            {
+              "tag": "input",
+              "class": "ui-checkbox ui-checkbox--lg",
+              "attrs": { "type": "checkbox", "checked": "" }
+            }
+          ],
+          "code": "<input type=\"checkbox\" class=\"ui-checkbox ui-checkbox--sm\" checked>\n<input type=\"checkbox\" class=\"ui-checkbox\" checked>\n<input type=\"checkbox\" class=\"ui-checkbox ui-checkbox--lg\" checked>"
+        }
+      ]
+    },
+    {
+      "title": "States",
+      "examples": [
+        {
+          "layout": "cluster",
+          "items": [
+            { "tag": "input", "class": "ui-checkbox", "attrs": { "type": "checkbox" } },
+            {
+              "tag": "input",
+              "class": "ui-checkbox",
+              "attrs": { "type": "checkbox", "checked": "" }
+            },
+            {
+              "tag": "input",
+              "class": "ui-checkbox",
+              "attrs": { "type": "checkbox", "disabled": "" }
+            },
+            {
+              "tag": "input",
+              "class": "ui-checkbox",
+              "attrs": { "type": "checkbox", "checked": "", "disabled": "" }
+            }
+          ],
+          "code": "<input type=\"checkbox\" class=\"ui-checkbox\">\n<input type=\"checkbox\" class=\"ui-checkbox\" checked>\n<input type=\"checkbox\" class=\"ui-checkbox\" disabled>\n<input type=\"checkbox\" class=\"ui-checkbox\" checked disabled>"
+        }
+      ]
+    },
+    {
+      "title": "Error State",
+      "examples": [
+        {
+          "layout": "cluster",
+          "items": [
+            {
+              "tag": "input",
+              "class": "ui-checkbox ui-checkbox--error",
+              "attrs": { "type": "checkbox" }
+            },
+            {
+              "tag": "input",
+              "class": "ui-checkbox ui-checkbox--error",
+              "attrs": { "type": "checkbox", "checked": "" }
+            }
+          ],
+          "code": "<input type=\"checkbox\" class=\"ui-checkbox ui-checkbox--error\">\n<input type=\"checkbox\" class=\"ui-checkbox ui-checkbox--error\" checked>"
+        }
+      ]
+    },
+    {
+      "title": "With Label",
+      "examples": [
+        {
+          "html": "<label class=\"ui-cluster\" style=\"gap: var(--ui-space-1); cursor: pointer;\"><input type=\"checkbox\" class=\"ui-checkbox\"><span>Accept terms and conditions</span></label>",
+          "code": "<label class=\"ui-cluster\">\n  <input type=\"checkbox\" class=\"ui-checkbox\">\n  <span>Accept terms</span>\n</label>"
+        }
+      ]
+    }
+  ]
+}

--- a/packages/css/src/04-components/checkbox/index.scss
+++ b/packages/css/src/04-components/checkbox/index.scss
@@ -1,0 +1,106 @@
+@use '../../00-config/tokens/variables' as t;
+
+// Checkbox component - native checkbox with custom styling
+// Sizes align to grid
+
+@layer components.tokens {
+  .checkbox {
+    --_size: var(--ui-checkbox-size, calc(#{t.$unit} * 2.5));
+    --_radius: var(--ui-checkbox-radius, var(--ui-radius-sm, #{t.$radius-sm}));
+    --_bg: var(--ui-checkbox-bg, var(--ui-color-bg, #{t.$color-bg}));
+    --_bg-checked: var(--ui-checkbox-bg-checked, var(--ui-color-primary, #{t.$color-primary}));
+    --_border-color: var(--ui-checkbox-border-color, var(--ui-color-border-strong, #{t.$color-border-strong}));
+    --_border-color-focus: var(--ui-checkbox-border-color-focus, var(--ui-color-primary, #{t.$color-primary}));
+    --_check-color: var(--ui-checkbox-check-color, var(--ui-color-text-inverse, #{t.$color-text-inverse}));
+  }
+
+  .checkbox--sm {
+    --_size: var(--ui-checkbox-size-sm, calc(#{t.$unit} * 2));
+  }
+
+  .checkbox--lg {
+    --_size: var(--ui-checkbox-size-lg, calc(#{t.$unit} * 3));
+  }
+
+  .checkbox--error {
+    --_border-color: var(--ui-checkbox-error-border, var(--ui-color-danger, #{t.$color-danger}));
+    --_border-color-focus: var(--ui-checkbox-error-border, var(--ui-color-danger, #{t.$color-danger}));
+  }
+}
+
+@layer components.styles {
+  .checkbox {
+
+    display: inline-flex;
+    flex-shrink: 0;
+    align-items: center;
+    justify-content: center;
+
+    block-size: var(--_size);
+    inline-size: var(--_size);
+    margin: 0;
+
+    vertical-align: middle;
+
+    background: var(--_bg);
+    border: var(--ui-border-width-sm, #{t.$border-width-sm}) solid var(--_border-color);
+    border-radius: var(--_radius);
+    cursor: pointer;
+    // Reset native checkbox
+    appearance: none;
+
+    transition:
+      background-color var(--ui-duration-fast, 150ms) var(--ui-ease-default, ease),
+      border-color var(--ui-duration-fast, 150ms) var(--ui-ease-default, ease),
+      box-shadow var(--ui-duration-fast, 150ms) var(--ui-ease-default, ease);
+
+    &::before {
+      content: '';
+
+      block-size: 65%;
+      inline-size: 65%;
+
+      background-color: var(--_check-color);
+      opacity: 0;
+      // Checkmark via clip-path
+      clip-path: polygon(20% 55%, 40% 75%, 80% 25%, 85% 30%, 40% 85%, 15% 60%);
+
+      transition: opacity var(--ui-duration-fast, 150ms) var(--ui-ease-default, ease);
+    }
+
+    &:hover:not(:disabled) {
+      border-color: var(--_border-color-focus);
+    }
+
+    &:focus-visible {
+      border-color: var(--_border-color-focus);
+      outline: none;
+      box-shadow: 0 0 0 var(--ui-border-width-md, #{t.$border-width-md}) var(--ui-color-focus, #{t.$color-focus});
+    }
+
+    &:checked {
+      background: var(--_bg-checked);
+      border-color: var(--_bg-checked);
+
+      &::before {
+        opacity: 1;
+      }
+    }
+
+    &:indeterminate {
+      background: var(--_bg-checked);
+      border-color: var(--_bg-checked);
+
+      &::before {
+        opacity: 1;
+        // Horizontal line for indeterminate
+        clip-path: polygon(15% 45%, 85% 45%, 85% 55%, 15% 55%);
+      }
+    }
+
+    &:disabled {
+      opacity: 0.5;
+      cursor: not-allowed;
+    }
+  }
+}

--- a/packages/css/src/04-components/index.scss
+++ b/packages/css/src/04-components/index.scss
@@ -1,6 +1,7 @@
 @forward './badge/index';
 @forward './button/index';
 @forward './card/index';
+@forward './checkbox/index';
 @forward './code/index';
 @forward './icon/index';
 @forward './input/index';


### PR DESCRIPTION
## Summary
- Native checkbox with appearance reset and custom styling
- Sizes: sm (16px), default (20px), lg (24px)
- States: checked, indeterminate, disabled, error
- Checkmark via clip-path, no external icons needed
- With label example using cluster layout

Closes #22