### PR TITLE
[CSS] feat: add radio component

### DIFF
--- a/packages/css/src/04-components/index.scss
+++ b/packages/css/src/04-components/index.scss
@@ -5,6 +5,7 @@
 @forward './code/index';
 @forward './icon/index';
 @forward './input/index';
+@forward './radio/index';
 @forward './select/index';
 @forward './table/index';
 @forward './tabs/index';

--- a/packages/css/src/04-components/radio/index.scss
+++ b/packages/css/src/04-components/radio/index.scss
@@ -1,0 +1,98 @@
+@use '../../00-config/tokens/variables' as t;
+
+// Radio component - native radio input with custom styling
+// Sizes align to grid
+
+@layer components.tokens {
+  .radio {
+    --_size: var(--ui-radio-size, calc(#{t.$unit} * 2.5));
+    --_bg: var(--ui-radio-bg, var(--ui-color-bg, #{t.$color-bg}));
+    --_bg-checked: var(--ui-radio-bg-checked, var(--ui-color-primary, #{t.$color-primary}));
+    --_border-color: var(--ui-radio-border-color, var(--ui-color-border-strong, #{t.$color-border-strong}));
+    --_border-color-focus: var(--ui-radio-border-color-focus, var(--ui-color-primary, #{t.$color-primary}));
+    --_dot-color: var(--ui-radio-dot-color, var(--ui-color-text-inverse, #{t.$color-text-inverse}));
+  }
+
+  .radio--sm {
+    --_size: var(--ui-radio-size-sm, calc(#{t.$unit} * 2));
+  }
+
+  .radio--lg {
+    --_size: var(--ui-radio-size-lg, calc(#{t.$unit} * 3));
+  }
+
+  .radio--error {
+    --_border-color: var(--ui-radio-error-border, var(--ui-color-danger, #{t.$color-danger}));
+    --_border-color-focus: var(--ui-radio-error-border, var(--ui-color-danger, #{t.$color-danger}));
+  }
+}
+
+@layer components.styles {
+  .radio {
+
+    display: inline-flex;
+    flex-shrink: 0;
+    align-items: center;
+    justify-content: center;
+
+    block-size: var(--_size);
+    inline-size: var(--_size);
+    margin: 0;
+
+    vertical-align: middle;
+
+    background: var(--_bg);
+    border: var(--ui-border-width-sm, #{t.$border-width-sm}) solid var(--_border-color);
+    border-radius: 50%;
+    cursor: pointer;
+    // Reset native radio
+    appearance: none;
+
+    transition:
+      background-color var(--ui-duration-fast, 150ms) var(--ui-ease-default, ease),
+      border-color var(--ui-duration-fast, 150ms) var(--ui-ease-default, ease),
+      box-shadow var(--ui-duration-fast, 150ms) var(--ui-ease-default, ease);
+
+    // Inner dot for checked state
+    &::before {
+      content: '';
+
+      block-size: 50%;
+      inline-size: 50%;
+
+      background-color: var(--_dot-color);
+      border-radius: 50%;
+      opacity: 0;
+      transform: scale(0);
+
+      transition:
+        opacity var(--ui-duration-fast, 150ms) var(--ui-ease-default, ease),
+        transform var(--ui-duration-fast, 150ms) var(--ui-ease-default, ease);
+    }
+
+    &:hover:not(:disabled) {
+      border-color: var(--_border-color-focus);
+    }
+
+    &:focus-visible {
+      border-color: var(--_border-color-focus);
+      outline: none;
+      box-shadow: 0 0 0 var(--ui-border-width-md, #{t.$border-width-md}) var(--ui-color-focus, #{t.$color-focus});
+    }
+
+    &:checked {
+      background: var(--_bg-checked);
+      border-color: var(--_bg-checked);
+
+      &::before {
+        opacity: 1;
+        transform: scale(1);
+      }
+    }
+
+    &:disabled {
+      opacity: 0.5;
+      cursor: not-allowed;
+    }
+  }
+}

--- a/packages/css/src/04-components/radio/radio.api.json
+++ b/packages/css/src/04-components/radio/radio.api.json
@@ -1,0 +1,19 @@
+{
+  "name": "radio",
+  "baseClass": "radio",
+  "element": "input[type=radio]",
+  "description": "Native radio button with custom styling",
+  "modifiers": {
+    "size": {
+      "values": ["sm", "lg"],
+      "default": null,
+      "description": "Size variant. Default is 20px."
+    },
+    "state": {
+      "values": ["error"],
+      "default": null,
+      "description": "Error state styling."
+    }
+  },
+  "states": ["hover", "focus", "checked", "disabled"]
+}

--- a/packages/css/src/04-components/radio/radio.docs.json
+++ b/packages/css/src/04-components/radio/radio.docs.json
@@ -1,0 +1,121 @@
+{
+  "id": "radio",
+  "type": "component",
+  "title": "Radio",
+  "description": "Native radio button with custom styling. Use for mutually exclusive options within a group.",
+  "sections": [
+    {
+      "title": "Default",
+      "examples": [
+        {
+          "layout": "cluster",
+          "items": [
+            { "tag": "input", "class": "ui-radio", "attrs": { "type": "radio", "name": "demo1" } },
+            {
+              "tag": "input",
+              "class": "ui-radio",
+              "attrs": { "type": "radio", "name": "demo1", "checked": "" }
+            }
+          ],
+          "code": "<input type=\"radio\" class=\"ui-radio\" name=\"group1\">\n<input type=\"radio\" class=\"ui-radio\" name=\"group1\" checked>"
+        }
+      ]
+    },
+    {
+      "title": "Sizes",
+      "examples": [
+        {
+          "layout": "cluster",
+          "items": [
+            {
+              "tag": "input",
+              "class": "ui-radio ui-radio--sm",
+              "attrs": { "type": "radio", "name": "sizes", "checked": "" }
+            },
+            {
+              "tag": "input",
+              "class": "ui-radio",
+              "attrs": { "type": "radio", "name": "sizes2", "checked": "" }
+            },
+            {
+              "tag": "input",
+              "class": "ui-radio ui-radio--lg",
+              "attrs": { "type": "radio", "name": "sizes3", "checked": "" }
+            }
+          ],
+          "code": "<input type=\"radio\" class=\"ui-radio ui-radio--sm\" checked>\n<input type=\"radio\" class=\"ui-radio\" checked>\n<input type=\"radio\" class=\"ui-radio ui-radio--lg\" checked>"
+        }
+      ]
+    },
+    {
+      "title": "States",
+      "examples": [
+        {
+          "layout": "cluster",
+          "items": [
+            {
+              "tag": "input",
+              "class": "ui-radio",
+              "attrs": { "type": "radio", "name": "states1" }
+            },
+            {
+              "tag": "input",
+              "class": "ui-radio",
+              "attrs": { "type": "radio", "name": "states2", "checked": "" }
+            },
+            {
+              "tag": "input",
+              "class": "ui-radio",
+              "attrs": { "type": "radio", "name": "states3", "disabled": "" }
+            },
+            {
+              "tag": "input",
+              "class": "ui-radio",
+              "attrs": { "type": "radio", "name": "states4", "checked": "", "disabled": "" }
+            }
+          ],
+          "code": "<input type=\"radio\" class=\"ui-radio\">\n<input type=\"radio\" class=\"ui-radio\" checked>\n<input type=\"radio\" class=\"ui-radio\" disabled>\n<input type=\"radio\" class=\"ui-radio\" checked disabled>"
+        }
+      ]
+    },
+    {
+      "title": "Error State",
+      "examples": [
+        {
+          "layout": "cluster",
+          "items": [
+            {
+              "tag": "input",
+              "class": "ui-radio ui-radio--error",
+              "attrs": { "type": "radio", "name": "error1" }
+            },
+            {
+              "tag": "input",
+              "class": "ui-radio ui-radio--error",
+              "attrs": { "type": "radio", "name": "error2", "checked": "" }
+            }
+          ],
+          "code": "<input type=\"radio\" class=\"ui-radio ui-radio--error\">\n<input type=\"radio\" class=\"ui-radio ui-radio--error\" checked>"
+        }
+      ]
+    },
+    {
+      "title": "With Label",
+      "examples": [
+        {
+          "html": "<label class=\"ui-cluster\" style=\"gap: var(--ui-space-1); cursor: pointer;\"><input type=\"radio\" class=\"ui-radio\" name=\"labeled\"><span>Option one</span></label>",
+          "code": "<label class=\"ui-cluster\">\n  <input type=\"radio\" class=\"ui-radio\" name=\"group\">\n  <span>Option one</span>\n</label>"
+        }
+      ]
+    },
+    {
+      "title": "Radio Group",
+      "examples": [
+        {
+          "html": "<fieldset style=\"border: none; padding: 0; margin: 0;\"><legend style=\"font-weight: 600; margin-block-end: var(--ui-space-1);\">Choose an option</legend><div class=\"ui-stack\" style=\"--stack-gap: var(--ui-space-1);\"><label class=\"ui-cluster\" style=\"gap: var(--ui-space-1); cursor: pointer;\"><input type=\"radio\" class=\"ui-radio\" name=\"group-demo\" checked><span>Option A</span></label><label class=\"ui-cluster\" style=\"gap: var(--ui-space-1); cursor: pointer;\"><input type=\"radio\" class=\"ui-radio\" name=\"group-demo\"><span>Option B</span></label><label class=\"ui-cluster\" style=\"gap: var(--ui-space-1); cursor: pointer;\"><input type=\"radio\" class=\"ui-radio\" name=\"group-demo\"><span>Option C</span></label></div></fieldset>",
+          "code": "<fieldset>\n  <legend>Choose an option</legend>\n  <div class=\"ui-stack\">\n    <label class=\"ui-cluster\">\n      <input type=\"radio\" class=\"ui-radio\" name=\"group\" checked>\n      <span>Option A</span>\n    </label>\n    <label class=\"ui-cluster\">\n      <input type=\"radio\" class=\"ui-radio\" name=\"group\">\n      <span>Option B</span>\n    </label>\n  </div>\n</fieldset>"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Native radio button with appearance reset and custom styling
- Sizes: sm (16px), default (20px), lg (24px)
- States: checked, disabled, error
- Inner dot via pseudo-element with scale transition
- Radio group example using fieldset

Closes #19