### PR TITLE
[CSS] feat: add heading component

### DIFF
--- a/packages/css/src/04-components/heading/heading.api.json
+++ b/packages/css/src/04-components/heading/heading.api.json
@@ -1,0 +1,19 @@
+{
+  "name": "heading",
+  "baseClass": "heading",
+  "element": "h1-h6",
+  "description": "Semantic headings with visual size control",
+  "modifiers": {
+    "size": {
+      "values": ["3xl", "2xl", "xl", "lg", "md", "sm"],
+      "default": null,
+      "description": "Visual size (decoupled from semantic level)"
+    },
+    "variant": {
+      "values": ["muted"],
+      "default": null,
+      "description": "Muted color variant"
+    }
+  },
+  "states": []
+}

--- a/packages/css/src/04-components/heading/heading.docs.json
+++ b/packages/css/src/04-components/heading/heading.docs.json
@@ -1,0 +1,38 @@
+{
+  "id": "heading",
+  "type": "component",
+  "title": "Heading",
+  "description": "Semantic headings with visual size control. Use semantic level (h1-h6) for structure, size modifier for visual styling.",
+  "sections": [
+    {
+      "title": "Sizes",
+      "examples": [
+        {
+          "layout": "stack",
+          "html": "<h1 class=\"ui-heading ui-heading--3xl\">Heading 3xl</h1><h2 class=\"ui-heading ui-heading--2xl\">Heading 2xl</h2><h3 class=\"ui-heading ui-heading--xl\">Heading xl</h3><h4 class=\"ui-heading ui-heading--lg\">Heading lg</h4><h5 class=\"ui-heading ui-heading--md\">Heading md</h5><h6 class=\"ui-heading ui-heading--sm\">Heading sm</h6>",
+          "code": "<h1 class=\"ui-heading ui-heading--3xl\">3xl</h1>\n<h2 class=\"ui-heading ui-heading--2xl\">2xl</h2>\n<h3 class=\"ui-heading ui-heading--xl\">xl</h3>\n<h4 class=\"ui-heading ui-heading--lg\">lg</h4>\n<h5 class=\"ui-heading ui-heading--md\">md</h5>\n<h6 class=\"ui-heading ui-heading--sm\">sm</h6>"
+        }
+      ]
+    },
+    {
+      "title": "Decoupled Sizing",
+      "description": "Use any size with any semantic level",
+      "examples": [
+        {
+          "layout": "stack",
+          "html": "<h2 class=\"ui-heading ui-heading--3xl\">h2 styled as 3xl</h2><h1 class=\"ui-heading ui-heading--lg\">h1 styled as lg</h1>",
+          "code": "<h2 class=\"ui-heading ui-heading--3xl\">h2 styled as 3xl</h2>\n<h1 class=\"ui-heading ui-heading--lg\">h1 styled as lg</h1>"
+        }
+      ]
+    },
+    {
+      "title": "Muted",
+      "examples": [
+        {
+          "html": "<h2 class=\"ui-heading ui-heading--2xl ui-heading--muted\">Muted heading</h2>",
+          "code": "<h2 class=\"ui-heading ui-heading--muted\">Muted</h2>"
+        }
+      ]
+    }
+  ]
+}

--- a/packages/css/src/04-components/heading/index.scss
+++ b/packages/css/src/04-components/heading/index.scss
@@ -1,0 +1,59 @@
+@use '../../00-config/tokens/variables' as t;
+
+// Heading component - semantic headings with visual size control
+// Sizes align to typography scale
+
+@layer components.tokens {
+  .heading {
+    --_font-size: var(--ui-heading-font-size, var(--ui-size-xl, #{t.$size-xl}));
+    --_line-height: var(--ui-heading-line-height, var(--ui-leading-xl, calc(#{t.$unit} * 4)));
+    --_weight: var(--ui-heading-weight, var(--ui-weight-bold, #{t.$weight-bold}));
+    --_color: var(--ui-heading-color, var(--ui-color-text, #{t.$color-text}));
+  }
+
+  // Visual size modifiers (decouple from semantic level)
+  .heading--3xl {
+    --_font-size: var(--ui-heading-font-size-3xl, var(--ui-size-3xl, #{t.$size-3xl}));
+    --_line-height: var(--ui-heading-line-height-3xl, var(--ui-leading-3xl, calc(#{t.$unit} * 5)));
+  }
+
+  .heading--2xl {
+    --_font-size: var(--ui-heading-font-size-2xl, var(--ui-size-2xl, #{t.$size-2xl}));
+    --_line-height: var(--ui-heading-line-height-2xl, var(--ui-leading-2xl, calc(#{t.$unit} * 4)));
+  }
+
+  .heading--xl {
+    --_font-size: var(--ui-heading-font-size-xl, var(--ui-size-xl, #{t.$size-xl}));
+    --_line-height: var(--ui-heading-line-height-xl, var(--ui-leading-xl, calc(#{t.$unit} * 4)));
+  }
+
+  .heading--lg {
+    --_font-size: var(--ui-heading-font-size-lg, var(--ui-size-lg, #{t.$size-lg}));
+    --_line-height: var(--ui-heading-line-height-lg, var(--ui-leading-lg, calc(#{t.$unit} * 3)));
+  }
+
+  .heading--md {
+    --_font-size: var(--ui-heading-font-size-md, var(--ui-size-md, #{t.$size-md}));
+    --_line-height: var(--ui-heading-line-height-md, var(--ui-leading-md, calc(#{t.$unit} * 3)));
+  }
+
+  .heading--sm {
+    --_font-size: var(--ui-heading-font-size-sm, var(--ui-size-sm, #{t.$size-sm}));
+    --_line-height: var(--ui-heading-line-height-sm, var(--ui-leading-sm, calc(#{t.$unit} * 2)));
+  }
+
+  .heading--muted {
+    --_color: var(--ui-heading-color-muted, var(--ui-color-text-muted, #{t.$color-text-muted}));
+  }
+}
+
+@layer components.styles {
+  .heading {
+    margin: 0;
+
+    font-size: var(--_font-size);
+    font-weight: var(--_weight);
+    line-height: var(--_line-height);
+    color: var(--_color);
+  }
+}

--- a/packages/css/src/04-components/index.scss
+++ b/packages/css/src/04-components/index.scss
@@ -5,6 +5,7 @@
 @forward './card/index';
 @forward './checkbox/index';
 @forward './code/index';
+@forward './heading/index';
 @forward './icon/index';
 @forward './input/index';
 @forward './label/index';


### PR DESCRIPTION
## Summary
- Semantic headings (h1-h6) with visual size control
- Sizes: 3xl, 2xl, xl, lg, md, sm (decoupled from semantic level)
- Muted color variant
- Grid-aligned line heights

Closes #11