### PR TITLE
feat: add accordion and disclosure components

### DIFF
--- a/apps/docs/src/generated/docs-content.html
+++ b/apps/docs/src/generated/docs-content.html
@@ -511,6 +511,78 @@
 </section>
 
 <!-- Components -->
+<section id="accordion" class="ui-docs-section" data-type="component">
+  <h2>Accordion</h2>
+  <p>Container for grouped expandable sections. Use with disclosure components.</p>
+
+  <h3>Default</h3>
+<div class="ui-tabs ui-mb-2">
+  <div class="ui-tabs__list">
+    <button class="ui-tabs__tab ui-tabs__tab--active">Preview</button>
+    <button class="ui-tabs__tab">HTML</button>
+    
+  </div>
+  <div class="ui-tabs__panel ui-tabs__panel--active">
+    <div class="ui-accordion"><details class="ui-disclosure"><summary class="ui-disclosure__trigger">Section 1<span class="ui-disclosure__icon">&#9662;</span></summary><div class="ui-disclosure__content"><p>Content for section 1</p></div></details><details class="ui-disclosure"><summary class="ui-disclosure__trigger">Section 2<span class="ui-disclosure__icon">&#9662;</span></summary><div class="ui-disclosure__content"><p>Content for section 2</p></div></details><details class="ui-disclosure"><summary class="ui-disclosure__trigger">Section 3<span class="ui-disclosure__icon">&#9662;</span></summary><div class="ui-disclosure__content"><p>Content for section 3</p></div></details></div>
+  </div>
+  <div class="ui-tabs__panel">
+    <pre class="ui-code-block"><code>&lt;div class="ui-accordion"&gt;
+  &lt;details class="ui-disclosure"&gt;
+    &lt;summary class="ui-disclosure__trigger"&gt;Section 1&lt;/summary&gt;
+    &lt;div class="ui-disclosure__content"&gt;...&lt;/div&gt;
+  &lt;/details&gt;
+  &lt;details class="ui-disclosure"&gt;
+    &lt;summary class="ui-disclosure__trigger"&gt;Section 2&lt;/summary&gt;
+    &lt;div class="ui-disclosure__content"&gt;...&lt;/div&gt;
+  &lt;/details&gt;
+&lt;/div&gt;</code></pre>
+  </div>
+  
+</div>
+
+<h3>Separated</h3>
+<p>Gap between accordion items</p>
+<div class="ui-tabs ui-mb-2">
+  <div class="ui-tabs__list">
+    <button class="ui-tabs__tab ui-tabs__tab--active">Preview</button>
+    <button class="ui-tabs__tab">HTML</button>
+    
+  </div>
+  <div class="ui-tabs__panel ui-tabs__panel--active">
+    <div class="ui-accordion ui-accordion--separated"><details class="ui-disclosure"><summary class="ui-disclosure__trigger">Section 1<span class="ui-disclosure__icon">&#9662;</span></summary><div class="ui-disclosure__content"><p>Content for section 1</p></div></details><details class="ui-disclosure"><summary class="ui-disclosure__trigger">Section 2<span class="ui-disclosure__icon">&#9662;</span></summary><div class="ui-disclosure__content"><p>Content for section 2</p></div></details></div>
+  </div>
+  <div class="ui-tabs__panel">
+    <pre class="ui-code-block"><code>&lt;div class="ui-accordion ui-accordion--separated"&gt;
+  ...
+&lt;/div&gt;</code></pre>
+  </div>
+  
+</div>
+
+<h3>With One Open</h3>
+<div class="ui-tabs ui-mb-2">
+  <div class="ui-tabs__list">
+    <button class="ui-tabs__tab ui-tabs__tab--active">Preview</button>
+    <button class="ui-tabs__tab">HTML</button>
+    
+  </div>
+  <div class="ui-tabs__panel ui-tabs__panel--active">
+    <div class="ui-accordion"><details class="ui-disclosure" open><summary class="ui-disclosure__trigger">Open Section<span class="ui-disclosure__icon">&#9662;</span></summary><div class="ui-disclosure__content"><p>This section starts open</p></div></details><details class="ui-disclosure"><summary class="ui-disclosure__trigger">Closed Section<span class="ui-disclosure__icon">&#9662;</span></summary><div class="ui-disclosure__content"><p>Click to open</p></div></details></div>
+  </div>
+  <div class="ui-tabs__panel">
+    <pre class="ui-code-block"><code>&lt;div class="ui-accordion"&gt;
+  &lt;details class="ui-disclosure" open&gt;
+    &lt;summary class="ui-disclosure__trigger"&gt;Open Section&lt;/summary&gt;
+    &lt;div class="ui-disclosure__content"&gt;...&lt;/div&gt;
+  &lt;/details&gt;
+  &lt;details class="ui-disclosure"&gt;
+    ...
+  &lt;/details&gt;
+&lt;/div&gt;</code></pre>
+  </div>
+  
+</div>
+</section>
 <section id="alert" class="ui-docs-section" data-type="component">
   <h2>Alert</h2>
   <p>Informational banner for important messages. Use variants for different message types.</p>
@@ -1624,6 +1696,89 @@
     &lt;/footer&gt;
   &lt;/div&gt;
 &lt;/div&gt;</code></pre>
+  </div>
+  
+</div>
+</section>
+<section id="disclosure" class="ui-docs-section" data-type="component">
+  <h2>Disclosure</h2>
+  <p>Expandable/collapsible content section. Uses native details/summary for accessibility without JS.</p>
+
+  <h3>Default</h3>
+<div class="ui-tabs ui-mb-2">
+  <div class="ui-tabs__list">
+    <button class="ui-tabs__tab ui-tabs__tab--active">Preview</button>
+    <button class="ui-tabs__tab">HTML</button>
+    
+  </div>
+  <div class="ui-tabs__panel ui-tabs__panel--active">
+    <details class="ui-disclosure"><summary class="ui-disclosure__trigger">Click to expand<span class="ui-disclosure__icon">&#9662;</span></summary><div class="ui-disclosure__content"><p>Hidden content that expands when clicked.</p></div></details>
+  </div>
+  <div class="ui-tabs__panel">
+    <pre class="ui-code-block"><code>&lt;details class="ui-disclosure"&gt;
+  &lt;summary class="ui-disclosure__trigger"&gt;
+    Click to expand
+    &lt;span class="ui-disclosure__icon"&gt;&amp;#9662;&lt;/span&gt;
+  &lt;/summary&gt;
+  &lt;div class="ui-disclosure__content"&gt;
+    &lt;p&gt;Hidden content that expands when clicked.&lt;/p&gt;
+  &lt;/div&gt;
+&lt;/details&gt;</code></pre>
+  </div>
+  
+</div>
+
+<h3>Open by Default</h3>
+<div class="ui-tabs ui-mb-2">
+  <div class="ui-tabs__list">
+    <button class="ui-tabs__tab ui-tabs__tab--active">Preview</button>
+    <button class="ui-tabs__tab">HTML</button>
+    
+  </div>
+  <div class="ui-tabs__panel ui-tabs__panel--active">
+    <details class="ui-disclosure" open><summary class="ui-disclosure__trigger">Already expanded<span class="ui-disclosure__icon">&#9662;</span></summary><div class="ui-disclosure__content"><p>This content is visible by default.</p></div></details>
+  </div>
+  <div class="ui-tabs__panel">
+    <pre class="ui-code-block"><code>&lt;details class="ui-disclosure" open&gt;
+  &lt;summary class="ui-disclosure__trigger"&gt;Already expanded&lt;/summary&gt;
+  &lt;div class="ui-disclosure__content"&gt;...&lt;/div&gt;
+&lt;/details&gt;</code></pre>
+  </div>
+  
+</div>
+
+<h3>Borderless</h3>
+<div class="ui-tabs ui-mb-2">
+  <div class="ui-tabs__list">
+    <button class="ui-tabs__tab ui-tabs__tab--active">Preview</button>
+    <button class="ui-tabs__tab">HTML</button>
+    
+  </div>
+  <div class="ui-tabs__panel ui-tabs__panel--active">
+    <details class="ui-disclosure ui-disclosure--borderless"><summary class="ui-disclosure__trigger">Borderless disclosure<span class="ui-disclosure__icon">&#9662;</span></summary><div class="ui-disclosure__content"><p>No border around the disclosure.</p></div></details>
+  </div>
+  <div class="ui-tabs__panel">
+    <pre class="ui-code-block"><code>&lt;details class="ui-disclosure ui-disclosure--borderless"&gt;
+  ...
+&lt;/details&gt;</code></pre>
+  </div>
+  
+</div>
+
+<h3>Animated</h3>
+<div class="ui-tabs ui-mb-2">
+  <div class="ui-tabs__list">
+    <button class="ui-tabs__tab ui-tabs__tab--active">Preview</button>
+    <button class="ui-tabs__tab">HTML</button>
+    
+  </div>
+  <div class="ui-tabs__panel ui-tabs__panel--active">
+    <details class="ui-disclosure ui-disclosure--animate"><summary class="ui-disclosure__trigger">Animated expansion<span class="ui-disclosure__icon">&#9662;</span></summary><div class="ui-disclosure__content"><p>Content animates in when opened.</p></div></details>
+  </div>
+  <div class="ui-tabs__panel">
+    <pre class="ui-code-block"><code>&lt;details class="ui-disclosure ui-disclosure--animate"&gt;
+  ...
+&lt;/details&gt;</code></pre>
   </div>
   
 </div>

--- a/apps/docs/src/index.html
+++ b/apps/docs/src/index.html
@@ -30,6 +30,7 @@
       <a class="ui-nav-link" href="#stack">Stack</a>
 
       <h2 class="ui-text-xs ui-font-bold ui-uppercase ui-text-muted ui-mt-4">Components</h2>
+      <a class="ui-nav-link" href="#accordion">Accordion</a>
       <a class="ui-nav-link" href="#alert">Alert</a>
       <a class="ui-nav-link" href="#avatar">Avatar</a>
       <a class="ui-nav-link" href="#badge">Badge</a>
@@ -38,6 +39,7 @@
       <a class="ui-nav-link" href="#checkbox">Checkbox</a>
       <a class="ui-nav-link" href="#code">Code</a>
       <a class="ui-nav-link" href="#dialog">Dialog</a>
+      <a class="ui-nav-link" href="#disclosure">Disclosure</a>
       <a class="ui-nav-link" href="#field">Field</a>
       <a class="ui-nav-link" href="#form-error">Form Error</a>
       <a class="ui-nav-link" href="#form-helper">Form Helper</a>
@@ -593,6 +595,78 @@
 </section>
 
 <!-- Components -->
+<section id="accordion" class="ui-docs-section" data-type="component">
+  <h2>Accordion</h2>
+  <p>Container for grouped expandable sections. Use with disclosure components.</p>
+
+  <h3>Default</h3>
+<div class="ui-tabs ui-mb-2">
+  <div class="ui-tabs__list">
+    <button class="ui-tabs__tab ui-tabs__tab--active">Preview</button>
+    <button class="ui-tabs__tab">HTML</button>
+    
+  </div>
+  <div class="ui-tabs__panel ui-tabs__panel--active">
+    <div class="ui-accordion"><details class="ui-disclosure"><summary class="ui-disclosure__trigger">Section 1<span class="ui-disclosure__icon">&#9662;</span></summary><div class="ui-disclosure__content"><p>Content for section 1</p></div></details><details class="ui-disclosure"><summary class="ui-disclosure__trigger">Section 2<span class="ui-disclosure__icon">&#9662;</span></summary><div class="ui-disclosure__content"><p>Content for section 2</p></div></details><details class="ui-disclosure"><summary class="ui-disclosure__trigger">Section 3<span class="ui-disclosure__icon">&#9662;</span></summary><div class="ui-disclosure__content"><p>Content for section 3</p></div></details></div>
+  </div>
+  <div class="ui-tabs__panel">
+    <pre class="ui-code-block"><code>&lt;div class="ui-accordion"&gt;
+  &lt;details class="ui-disclosure"&gt;
+    &lt;summary class="ui-disclosure__trigger"&gt;Section 1&lt;/summary&gt;
+    &lt;div class="ui-disclosure__content"&gt;...&lt;/div&gt;
+  &lt;/details&gt;
+  &lt;details class="ui-disclosure"&gt;
+    &lt;summary class="ui-disclosure__trigger"&gt;Section 2&lt;/summary&gt;
+    &lt;div class="ui-disclosure__content"&gt;...&lt;/div&gt;
+  &lt;/details&gt;
+&lt;/div&gt;</code></pre>
+  </div>
+  
+</div>
+
+<h3>Separated</h3>
+<p>Gap between accordion items</p>
+<div class="ui-tabs ui-mb-2">
+  <div class="ui-tabs__list">
+    <button class="ui-tabs__tab ui-tabs__tab--active">Preview</button>
+    <button class="ui-tabs__tab">HTML</button>
+    
+  </div>
+  <div class="ui-tabs__panel ui-tabs__panel--active">
+    <div class="ui-accordion ui-accordion--separated"><details class="ui-disclosure"><summary class="ui-disclosure__trigger">Section 1<span class="ui-disclosure__icon">&#9662;</span></summary><div class="ui-disclosure__content"><p>Content for section 1</p></div></details><details class="ui-disclosure"><summary class="ui-disclosure__trigger">Section 2<span class="ui-disclosure__icon">&#9662;</span></summary><div class="ui-disclosure__content"><p>Content for section 2</p></div></details></div>
+  </div>
+  <div class="ui-tabs__panel">
+    <pre class="ui-code-block"><code>&lt;div class="ui-accordion ui-accordion--separated"&gt;
+  ...
+&lt;/div&gt;</code></pre>
+  </div>
+  
+</div>
+
+<h3>With One Open</h3>
+<div class="ui-tabs ui-mb-2">
+  <div class="ui-tabs__list">
+    <button class="ui-tabs__tab ui-tabs__tab--active">Preview</button>
+    <button class="ui-tabs__tab">HTML</button>
+    
+  </div>
+  <div class="ui-tabs__panel ui-tabs__panel--active">
+    <div class="ui-accordion"><details class="ui-disclosure" open><summary class="ui-disclosure__trigger">Open Section<span class="ui-disclosure__icon">&#9662;</span></summary><div class="ui-disclosure__content"><p>This section starts open</p></div></details><details class="ui-disclosure"><summary class="ui-disclosure__trigger">Closed Section<span class="ui-disclosure__icon">&#9662;</span></summary><div class="ui-disclosure__content"><p>Click to open</p></div></details></div>
+  </div>
+  <div class="ui-tabs__panel">
+    <pre class="ui-code-block"><code>&lt;div class="ui-accordion"&gt;
+  &lt;details class="ui-disclosure" open&gt;
+    &lt;summary class="ui-disclosure__trigger"&gt;Open Section&lt;/summary&gt;
+    &lt;div class="ui-disclosure__content"&gt;...&lt;/div&gt;
+  &lt;/details&gt;
+  &lt;details class="ui-disclosure"&gt;
+    ...
+  &lt;/details&gt;
+&lt;/div&gt;</code></pre>
+  </div>
+  
+</div>
+</section>
 <section id="alert" class="ui-docs-section" data-type="component">
   <h2>Alert</h2>
   <p>Informational banner for important messages. Use variants for different message types.</p>
@@ -1706,6 +1780,89 @@
     &lt;/footer&gt;
   &lt;/div&gt;
 &lt;/div&gt;</code></pre>
+  </div>
+  
+</div>
+</section>
+<section id="disclosure" class="ui-docs-section" data-type="component">
+  <h2>Disclosure</h2>
+  <p>Expandable/collapsible content section. Uses native details/summary for accessibility without JS.</p>
+
+  <h3>Default</h3>
+<div class="ui-tabs ui-mb-2">
+  <div class="ui-tabs__list">
+    <button class="ui-tabs__tab ui-tabs__tab--active">Preview</button>
+    <button class="ui-tabs__tab">HTML</button>
+    
+  </div>
+  <div class="ui-tabs__panel ui-tabs__panel--active">
+    <details class="ui-disclosure"><summary class="ui-disclosure__trigger">Click to expand<span class="ui-disclosure__icon">&#9662;</span></summary><div class="ui-disclosure__content"><p>Hidden content that expands when clicked.</p></div></details>
+  </div>
+  <div class="ui-tabs__panel">
+    <pre class="ui-code-block"><code>&lt;details class="ui-disclosure"&gt;
+  &lt;summary class="ui-disclosure__trigger"&gt;
+    Click to expand
+    &lt;span class="ui-disclosure__icon"&gt;&amp;#9662;&lt;/span&gt;
+  &lt;/summary&gt;
+  &lt;div class="ui-disclosure__content"&gt;
+    &lt;p&gt;Hidden content that expands when clicked.&lt;/p&gt;
+  &lt;/div&gt;
+&lt;/details&gt;</code></pre>
+  </div>
+  
+</div>
+
+<h3>Open by Default</h3>
+<div class="ui-tabs ui-mb-2">
+  <div class="ui-tabs__list">
+    <button class="ui-tabs__tab ui-tabs__tab--active">Preview</button>
+    <button class="ui-tabs__tab">HTML</button>
+    
+  </div>
+  <div class="ui-tabs__panel ui-tabs__panel--active">
+    <details class="ui-disclosure" open><summary class="ui-disclosure__trigger">Already expanded<span class="ui-disclosure__icon">&#9662;</span></summary><div class="ui-disclosure__content"><p>This content is visible by default.</p></div></details>
+  </div>
+  <div class="ui-tabs__panel">
+    <pre class="ui-code-block"><code>&lt;details class="ui-disclosure" open&gt;
+  &lt;summary class="ui-disclosure__trigger"&gt;Already expanded&lt;/summary&gt;
+  &lt;div class="ui-disclosure__content"&gt;...&lt;/div&gt;
+&lt;/details&gt;</code></pre>
+  </div>
+  
+</div>
+
+<h3>Borderless</h3>
+<div class="ui-tabs ui-mb-2">
+  <div class="ui-tabs__list">
+    <button class="ui-tabs__tab ui-tabs__tab--active">Preview</button>
+    <button class="ui-tabs__tab">HTML</button>
+    
+  </div>
+  <div class="ui-tabs__panel ui-tabs__panel--active">
+    <details class="ui-disclosure ui-disclosure--borderless"><summary class="ui-disclosure__trigger">Borderless disclosure<span class="ui-disclosure__icon">&#9662;</span></summary><div class="ui-disclosure__content"><p>No border around the disclosure.</p></div></details>
+  </div>
+  <div class="ui-tabs__panel">
+    <pre class="ui-code-block"><code>&lt;details class="ui-disclosure ui-disclosure--borderless"&gt;
+  ...
+&lt;/details&gt;</code></pre>
+  </div>
+  
+</div>
+
+<h3>Animated</h3>
+<div class="ui-tabs ui-mb-2">
+  <div class="ui-tabs__list">
+    <button class="ui-tabs__tab ui-tabs__tab--active">Preview</button>
+    <button class="ui-tabs__tab">HTML</button>
+    
+  </div>
+  <div class="ui-tabs__panel ui-tabs__panel--active">
+    <details class="ui-disclosure ui-disclosure--animate"><summary class="ui-disclosure__trigger">Animated expansion<span class="ui-disclosure__icon">&#9662;</span></summary><div class="ui-disclosure__content"><p>Content animates in when opened.</p></div></details>
+  </div>
+  <div class="ui-tabs__panel">
+    <pre class="ui-code-block"><code>&lt;details class="ui-disclosure ui-disclosure--animate"&gt;
+  ...
+&lt;/details&gt;</code></pre>
   </div>
   
 </div>

--- a/packages/css/src/04-components/accordion/accordion.api.json
+++ b/packages/css/src/04-components/accordion/accordion.api.json
@@ -1,0 +1,14 @@
+{
+  "name": "accordion",
+  "baseClass": "accordion",
+  "element": "div",
+  "description": "Container for grouped expandable disclosure sections",
+  "modifiers": {
+    "variant": {
+      "values": ["borderless", "separated"],
+      "default": null,
+      "description": "Visual variants. Borderless removes outer border, separated adds gap between items."
+    }
+  },
+  "states": []
+}

--- a/packages/css/src/04-components/accordion/accordion.docs.json
+++ b/packages/css/src/04-components/accordion/accordion.docs.json
@@ -1,0 +1,36 @@
+{
+  "id": "accordion",
+  "type": "component",
+  "title": "Accordion",
+  "description": "Container for grouped expandable sections. Use with disclosure components.",
+  "sections": [
+    {
+      "title": "Default",
+      "examples": [
+        {
+          "html": "<div class=\"ui-accordion\"><details class=\"ui-disclosure\"><summary class=\"ui-disclosure__trigger\">Section 1<span class=\"ui-disclosure__icon\">&#9662;</span></summary><div class=\"ui-disclosure__content\"><p>Content for section 1</p></div></details><details class=\"ui-disclosure\"><summary class=\"ui-disclosure__trigger\">Section 2<span class=\"ui-disclosure__icon\">&#9662;</span></summary><div class=\"ui-disclosure__content\"><p>Content for section 2</p></div></details><details class=\"ui-disclosure\"><summary class=\"ui-disclosure__trigger\">Section 3<span class=\"ui-disclosure__icon\">&#9662;</span></summary><div class=\"ui-disclosure__content\"><p>Content for section 3</p></div></details></div>",
+          "code": "<div class=\"ui-accordion\">\n  <details class=\"ui-disclosure\">\n    <summary class=\"ui-disclosure__trigger\">Section 1</summary>\n    <div class=\"ui-disclosure__content\">...</div>\n  </details>\n  <details class=\"ui-disclosure\">\n    <summary class=\"ui-disclosure__trigger\">Section 2</summary>\n    <div class=\"ui-disclosure__content\">...</div>\n  </details>\n</div>"
+        }
+      ]
+    },
+    {
+      "title": "Separated",
+      "description": "Gap between accordion items",
+      "examples": [
+        {
+          "html": "<div class=\"ui-accordion ui-accordion--separated\"><details class=\"ui-disclosure\"><summary class=\"ui-disclosure__trigger\">Section 1<span class=\"ui-disclosure__icon\">&#9662;</span></summary><div class=\"ui-disclosure__content\"><p>Content for section 1</p></div></details><details class=\"ui-disclosure\"><summary class=\"ui-disclosure__trigger\">Section 2<span class=\"ui-disclosure__icon\">&#9662;</span></summary><div class=\"ui-disclosure__content\"><p>Content for section 2</p></div></details></div>",
+          "code": "<div class=\"ui-accordion ui-accordion--separated\">\n  ...\n</div>"
+        }
+      ]
+    },
+    {
+      "title": "With One Open",
+      "examples": [
+        {
+          "html": "<div class=\"ui-accordion\"><details class=\"ui-disclosure\" open><summary class=\"ui-disclosure__trigger\">Open Section<span class=\"ui-disclosure__icon\">&#9662;</span></summary><div class=\"ui-disclosure__content\"><p>This section starts open</p></div></details><details class=\"ui-disclosure\"><summary class=\"ui-disclosure__trigger\">Closed Section<span class=\"ui-disclosure__icon\">&#9662;</span></summary><div class=\"ui-disclosure__content\"><p>Click to open</p></div></details></div>",
+          "code": "<div class=\"ui-accordion\">\n  <details class=\"ui-disclosure\" open>\n    <summary class=\"ui-disclosure__trigger\">Open Section</summary>\n    <div class=\"ui-disclosure__content\">...</div>\n  </details>\n  <details class=\"ui-disclosure\">\n    ...\n  </details>\n</div>"
+        }
+      ]
+    }
+  ]
+}

--- a/packages/css/src/04-components/accordion/index.scss
+++ b/packages/css/src/04-components/accordion/index.scss
@@ -1,0 +1,73 @@
+@use '../../00-config/tokens/variables' as t;
+
+// Accordion - grouped expandable sections
+// Container for multiple disclosure items
+
+@layer components.tokens {
+  .accordion {
+    --_border-color: var(--ui-accordion-border-color, var(--ui-color-border, rgb(0 0 0 / 0.1)));
+    --_radius: var(--ui-accordion-radius, var(--ui-radius-md, calc(#{t.$unit} * 1)));
+  }
+}
+
+@layer components.styles {
+  .accordion {
+    border: 1px solid var(--_border-color);
+    border-radius: var(--_radius);
+  }
+
+  // Remove individual borders from nested disclosures
+  .accordion > .disclosure {
+    border: none;
+    border-radius: 0;
+  }
+
+  // Add dividers between items
+  .accordion > .disclosure + .disclosure {
+    border-block-start: 1px solid var(--_border-color);
+  }
+
+  // Round first and last items
+  .accordion > .disclosure:first-child .disclosure__trigger {
+    border-start-start-radius: var(--_radius);
+    border-start-end-radius: var(--_radius);
+  }
+
+  .accordion > .disclosure:last-child .disclosure__trigger {
+    border-end-start-radius: var(--_radius);
+    border-end-end-radius: var(--_radius);
+  }
+
+  // When last item is open, content needs rounding
+  .accordion > .disclosure:last-child .disclosure__content {
+    border-end-start-radius: var(--_radius);
+    border-end-end-radius: var(--_radius);
+  }
+
+  // Borderless variant
+  .accordion--borderless {
+    border: none;
+  }
+
+  .accordion--borderless > .disclosure + .disclosure {
+    border-block-start: none;
+  }
+
+  // Separated variant - gap between items
+  .accordion--separated {
+    display: flex;
+    flex-direction: column;
+    gap: calc(#{t.$unit} * 1);
+
+    border: none;
+  }
+
+  .accordion--separated > .disclosure {
+    border: 1px solid var(--_border-color);
+    border-radius: var(--_radius);
+  }
+
+  .accordion--separated > .disclosure + .disclosure {
+    border-block-start: 1px solid var(--_border-color);
+  }
+}

--- a/packages/css/src/04-components/disclosure/disclosure.api.json
+++ b/packages/css/src/04-components/disclosure/disclosure.api.json
@@ -1,0 +1,14 @@
+{
+  "name": "disclosure",
+  "baseClass": "disclosure",
+  "element": "details",
+  "description": "Expandable/collapsible content section using native details/summary",
+  "modifiers": {
+    "variant": {
+      "values": ["borderless", "flush", "animate"],
+      "default": null,
+      "description": "Visual variants. Borderless removes border, flush removes padding, animate adds enter animation."
+    }
+  },
+  "states": ["open"]
+}

--- a/packages/css/src/04-components/disclosure/disclosure.docs.json
+++ b/packages/css/src/04-components/disclosure/disclosure.docs.json
@@ -1,0 +1,44 @@
+{
+  "id": "disclosure",
+  "type": "component",
+  "title": "Disclosure",
+  "description": "Expandable/collapsible content section. Uses native details/summary for accessibility without JS.",
+  "sections": [
+    {
+      "title": "Default",
+      "examples": [
+        {
+          "html": "<details class=\"ui-disclosure\"><summary class=\"ui-disclosure__trigger\">Click to expand<span class=\"ui-disclosure__icon\">&#9662;</span></summary><div class=\"ui-disclosure__content\"><p>Hidden content that expands when clicked.</p></div></details>",
+          "code": "<details class=\"ui-disclosure\">\n  <summary class=\"ui-disclosure__trigger\">\n    Click to expand\n    <span class=\"ui-disclosure__icon\">&#9662;</span>\n  </summary>\n  <div class=\"ui-disclosure__content\">\n    <p>Hidden content that expands when clicked.</p>\n  </div>\n</details>"
+        }
+      ]
+    },
+    {
+      "title": "Open by Default",
+      "examples": [
+        {
+          "html": "<details class=\"ui-disclosure\" open><summary class=\"ui-disclosure__trigger\">Already expanded<span class=\"ui-disclosure__icon\">&#9662;</span></summary><div class=\"ui-disclosure__content\"><p>This content is visible by default.</p></div></details>",
+          "code": "<details class=\"ui-disclosure\" open>\n  <summary class=\"ui-disclosure__trigger\">Already expanded</summary>\n  <div class=\"ui-disclosure__content\">...</div>\n</details>"
+        }
+      ]
+    },
+    {
+      "title": "Borderless",
+      "examples": [
+        {
+          "html": "<details class=\"ui-disclosure ui-disclosure--borderless\"><summary class=\"ui-disclosure__trigger\">Borderless disclosure<span class=\"ui-disclosure__icon\">&#9662;</span></summary><div class=\"ui-disclosure__content\"><p>No border around the disclosure.</p></div></details>",
+          "code": "<details class=\"ui-disclosure ui-disclosure--borderless\">\n  ...\n</details>"
+        }
+      ]
+    },
+    {
+      "title": "Animated",
+      "examples": [
+        {
+          "html": "<details class=\"ui-disclosure ui-disclosure--animate\"><summary class=\"ui-disclosure__trigger\">Animated expansion<span class=\"ui-disclosure__icon\">&#9662;</span></summary><div class=\"ui-disclosure__content\"><p>Content animates in when opened.</p></div></details>",
+          "code": "<details class=\"ui-disclosure ui-disclosure--animate\">\n  ...\n</details>"
+        }
+      ]
+    }
+  ]
+}

--- a/packages/css/src/04-components/disclosure/index.scss
+++ b/packages/css/src/04-components/disclosure/index.scss
@@ -1,0 +1,96 @@
+@use '../../00-config/tokens/variables' as t;
+
+// Disclosure - expandable/collapsible content section
+// Uses native details/summary for no-JS accessibility
+
+@layer components.tokens {
+  .disclosure {
+    --_border-color: var(--ui-disclosure-border-color, var(--ui-color-border, rgb(0 0 0 / 0.1)));
+    --_radius: var(--ui-disclosure-radius, var(--ui-radius-md, calc(#{t.$unit} * 1)));
+    --_padding: var(--ui-disclosure-padding, calc(#{t.$unit} * 2));
+  }
+}
+
+@layer components.styles {
+  .disclosure {
+    border: 1px solid var(--_border-color);
+    border-radius: var(--_radius);
+  }
+
+  .disclosure__trigger {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: calc(#{t.$unit} * 2);
+
+    inline-size: 100%;
+    padding: var(--_padding);
+
+    font-weight: var(--ui-weight-medium, 500);
+    text-align: start;
+
+    cursor: pointer;
+    list-style: none;
+
+    &::-webkit-details-marker {
+      display: none;
+    }
+
+    &::marker {
+      display: none;
+    }
+  }
+
+  // Trigger hover state
+  .disclosure__trigger:hover {
+    background: var(--ui-color-bg-subtle, rgb(0 0 0 / 0.02));
+  }
+
+  // Icon that rotates when open
+  .disclosure__icon {
+    flex-shrink: 0;
+
+    transition: transform var(--ui-duration-fast, 100ms) var(--ui-ease-default, ease);
+  }
+
+  .disclosure[open] .disclosure__icon {
+    transform: rotate(180deg);
+  }
+
+  // Content panel
+  .disclosure__content {
+    padding: 0 var(--_padding) var(--_padding);
+  }
+
+  // Animation for content
+  .disclosure--animate .disclosure__content {
+    animation: disclosure-open var(--ui-duration-normal, 200ms) var(--ui-ease-default, ease);
+  }
+
+  @keyframes disclosure-open {
+    from {
+      opacity: 0;
+      transform: translateY(calc(#{t.$unit} * -1));
+    }
+
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+
+  // Borderless variant
+  .disclosure--borderless {
+    border: none;
+    border-radius: 0;
+  }
+
+  // Flush variant (no padding on trigger)
+  .disclosure--flush .disclosure__trigger {
+    padding: calc(#{t.$unit} * 1.5) 0;
+  }
+
+  .disclosure--flush .disclosure__content {
+    padding: 0 0 calc(#{t.$unit} * 1.5);
+  }
+}

--- a/packages/css/src/04-components/index.scss
+++ b/packages/css/src/04-components/index.scss
@@ -1,3 +1,4 @@
+@forward './accordion/index';
 @forward './alert/index';
 @forward './avatar/index';
 @forward './badge/index';
@@ -6,6 +7,7 @@
 @forward './checkbox/index';
 @forward './code/index';
 @forward './dialog/index';
+@forward './disclosure/index';
 @forward './field/index';
 @forward './form-error/index';
 @forward './form-helper/index';


### PR DESCRIPTION
## Summary
- Adds Disclosure component - single expandable/collapsible section using native details/summary
- Adds Accordion component - container for grouped disclosure sections
- Disclosure uses native HTML for accessibility without JS
- Accordion variants: default (connected), borderless, separated

Closes #48, #46
Also closes #45 (Collapsible - same as Disclosure)