### PR TITLE
[CSS] feat(docs): preserve sidebar scroll position on navigation

### DIFF
--- a/apps/docs/src/_includes/layouts/base.njk
+++ b/apps/docs/src/_includes/layouts/base.njk
@@ -92,5 +92,6 @@
       document.getElementById('theme-toggle').textContent = 'Light Mode';
     }
   </script>
+  <script src="/sidebar-scroll.js"></script>
 </body>
 </html>

--- a/apps/docs/src/public/sidebar-scroll.js
+++ b/apps/docs/src/public/sidebar-scroll.js
@@ -1,0 +1,15 @@
+// Preserve sidebar scroll position across page navigations
+(() => {
+  const STORAGE_KEY = 'sidebar-scroll';
+  const sidebar = document.querySelector('.ui-sidebar-nav__content');
+  if (!sidebar) return;
+
+  const saved = sessionStorage.getItem(STORAGE_KEY);
+  if (saved) sidebar.scrollTop = Number.parseInt(saved, 10);
+
+  for (const link of document.querySelectorAll('.ui-sidebar-nav a')) {
+    link.addEventListener('click', () => {
+      sessionStorage.setItem(STORAGE_KEY, sidebar.scrollTop);
+    });
+  }
+})();


### PR DESCRIPTION
## Summary
- Saves sidebar scroll position to sessionStorage before navigation
- Restores scroll position on page load
- Prevents scroll reset when clicking through docs pages

## Implementation
- New external script `apps/docs/src/public/sidebar-scroll.js`
- Uses sessionStorage (persists across page loads, clears on tab close)
- Listens to click events on sidebar nav links

## Test plan
- [ ] Navigate to a component deep in the sidebar
- [ ] Click a different doc page
- [ ] Verify sidebar scroll position is preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)