### PR TITLE
[CSS] fix(docs): prevent sidebar scroll jump using pagereveal

### DIFF
--- a/apps/docs/src/_includes/layouts/base.njk
+++ b/apps/docs/src/_includes/layouts/base.njk
@@ -6,6 +6,7 @@
   <meta name="view-transition" content="same-origin">
   <title>{{ title }} - UI Lib</title>
   <link rel="stylesheet" href="/styles.css">
+  <script src="/sidebar-scroll.js" defer></script>
 </head>
 <body class="ui-root ui-app-shell">
   <aside class="ui-sidebar">
@@ -85,6 +86,5 @@
       document.getElementById('theme-toggle').textContent = 'Light Mode';
     }
   </script>
-  <script src="/sidebar-scroll.js"></script>
 </body>
 </html>

--- a/apps/docs/src/public/sidebar-scroll.js
+++ b/apps/docs/src/public/sidebar-scroll.js
@@ -1,15 +1,36 @@
 // Preserve sidebar scroll position across page navigations
-(() => {
-  const STORAGE_KEY = 'sidebar-scroll';
+const STORAGE_KEY = 'sidebar-scroll';
+
+function restoreScroll() {
   const sidebar = document.querySelector('.ui-sidebar-nav__content');
   if (!sidebar) return;
 
   const saved = sessionStorage.getItem(STORAGE_KEY);
-  if (saved) sidebar.scrollTop = Number.parseInt(saved, 10);
-
-  for (const link of document.querySelectorAll('.ui-sidebar-nav a')) {
-    link.addEventListener('click', () => {
-      sessionStorage.setItem(STORAGE_KEY, sidebar.scrollTop);
-    });
+  if (saved) {
+    sidebar.style.scrollBehavior = 'auto';
+    sidebar.scrollTop = Number.parseInt(saved, 10);
+    sidebar.style.scrollBehavior = '';
   }
-})();
+}
+
+function setupSaveOnClick() {
+  const sidebar = document.querySelector('.ui-sidebar-nav__content');
+  if (!sidebar) return;
+
+  // Use event delegation on content area for all links
+  sidebar.addEventListener('click', (e) => {
+    if (e.target.closest('a')) {
+      sessionStorage.setItem(STORAGE_KEY, sidebar.scrollTop);
+    }
+  });
+}
+
+// For view transitions: restore before page is revealed
+if ('onpagereveal' in window) {
+  window.addEventListener('pagereveal', restoreScroll);
+} else {
+  // Fallback for browsers without view transitions
+  document.addEventListener('DOMContentLoaded', restoreScroll);
+}
+
+document.addEventListener('DOMContentLoaded', setupSaveOnClick);

--- a/packages/css/src/05-utilities/view-transition/view-transition.docs.json
+++ b/packages/css/src/05-utilities/view-transition/view-transition.docs.json
@@ -49,6 +49,15 @@
           "code": "<div class=\"ui-transition-name-none\">No transition</div>"
         }
       ]
+    },
+    {
+      "title": "Preserving scroll position",
+      "description": "View transitions snapshot elements, resetting scroll. Use `pagereveal` event to restore scroll before paint.",
+      "examples": [
+        {
+          "code": "// Save scroll on navigation\nlink.addEventListener('click', () => {\n  sessionStorage.setItem('scroll', sidebar.scrollTop);\n});\n\n// Restore before page reveals\nwindow.addEventListener('pagereveal', () => {\n  const saved = sessionStorage.getItem('scroll');\n  if (saved) sidebar.scrollTop = parseInt(saved, 10);\n});"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Move sidebar scroll script to head with defer for earlier execution
- Use pagereveal event for seamless restore with view transitions
- Use event delegation to capture all nested link clicks
- Add scroll position preservation docs to view-transition utility

## Test plan
- Navigate between pages in docs sidebar
- Verify scroll position is maintained without visible jump
- Test on nested component links (under subgroups)

🤖 Generated with [Claude Code](https://claude.com/claude-code)