### PR TITLE
chore: version packages

### DIFF
--- a/.changeset/initial-release.md
+++ b/.changeset/initial-release.md
@@ -1,7 +1,0 @@
----
-"@teseor/css": major
----
-
-Initial public release of @teseor/css
-
-CSS-first component library with design tokens, layout primitives, and UI components.

--- a/packages/css/CHANGELOG.md
+++ b/packages/css/CHANGELOG.md
@@ -1,0 +1,9 @@
+# @teseor/css
+
+## 1.0.0
+
+### Major Changes
+
+- [`c6dc063`](https://github.com/teseor/teseor/commit/c6dc063f8f5544620909335539246c810202fb3a) Thanks [@letanure](https://github.com/letanure)! - Initial public release of @teseor/css
+
+  CSS-first component library with design tokens, layout primitives, and UI components.

--- a/packages/css/package.json
+++ b/packages/css/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teseor/css",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "description": "CSS library - reset, primitives, components, utilities",
   "license": "MIT",
   "author": "letanure",


### PR DESCRIPTION
## Summary

Bumps @teseor/css from 0.1.0 to 1.0.0

## Changelog

- Initial public release of @teseor/css
- CSS-first component library with design tokens, layout primitives, and UI components