### PR TITLE
[CSS] chore(ci): add build and test to pre-push hook

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,4 +1,4 @@
-pnpm lint && pnpm typecheck
+pnpm lint && pnpm typecheck && pnpm nx build css && pnpm test
 
-# Visual tests run in CI only (Docker QEMU has slight rendering differences)
+# Visual tests run in CI only (Docker rendering differences)
 # Run locally with: pnpm test:visual


### PR DESCRIPTION
## Summary

- Add `pnpm nx build css && pnpm test` to pre-push hook, mirroring CI pipeline
- Catches build and test failures before pushing instead of waiting for CI

**Note:** Two pre-existing test failures on main (input visual regression + grid alignment) need separate fixes.

Closes #169

## Test plan

- [ ] Verify hook runs on push
- [ ] Fix pre-existing test failures in separate PR