### PR TITLE
[CSS] fix(data-list): account for border in grid rhythm

### DIFF
--- a/.changeset/fix-data-list-grid.md
+++ b/.changeset/fix-data-list-grid.md
@@ -1,0 +1,5 @@
+---
+"@teseor/css": patch
+---
+
+Fix data-list divided variant border breaking grid rhythm

--- a/packages/css/src/04-components/data-list/index.scss
+++ b/packages/css/src/04-components/data-list/index.scss
@@ -61,9 +61,10 @@
 
   // With dividers
   .data-list--divided .data-list__item {
-    padding-block-end: var(--_gap);
+    // Subtract border from padding to keep total on grid
+    padding-block-end: calc(var(--_gap) - var(--ui-border-width-sm, #{t.$border-width-sm}));
 
-    border-block-end: 1px solid var(--ui-color-border, #{t.$color-border});
+    border-block-end: var(--ui-border-width-sm, #{t.$border-width-sm}) solid var(--ui-color-border, #{t.$color-border});
   }
 
   .data-list--divided .data-list__item:last-child {


### PR DESCRIPTION
## Summary
- Fix 1px border in divided variant breaking 8px grid rhythm
- Adjust padding to discount border thickness
- Re-enable grid rhythm validation in visual spec

Closes #179

## Test plan
- [ ] Visual tests pass with validateGridRhythm enabled
- [ ] Divided variant still shows visible separator borders