### PR TITLE
fix(ci): disable husky hooks in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,8 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    env:
+      HUSKY: '0'
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
## Summary
- Add `HUSKY: '0'` env var to release job to prevent pre-push hook from running in CI
- Pre-push hook runs Playwright tests which fail in release environment (no browsers installed)
- Unblocks NPM publishing (6 changesets pending since v1.1.0)

Closes #181

## Test plan
- [ ] Merge PR, verify release workflow creates "chore: version packages" PR
- [ ] Merge version PR, verify NPM publish succeeds