### PR TITLE
Fix: auto-format files after changeset version

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "storybook": "nx run docs:storybook",
     "storybook:build": "nx run docs:build-storybook",
     "changeset": "changeset",
-    "changeset:version": "changeset version",
+    "changeset:version": "changeset version && biome format --write .",
     "changeset:publish": "pnpm build && changeset publish",
     "prepare": "husky",
     "clean": "nx reset && pnpm -r exec rm -rf dist node_modules",


### PR DESCRIPTION
Closes #192

## Summary
- Add `biome format --write .` to `changeset:version` script so files modified by the changesets bot (package.json, CHANGELOG.md) are auto-formatted before being committed

## Test plan
- [ ] Merge to main with a pending changeset
- [ ] Verify the release PR has properly formatted files