### PR TITLE
Test release: verify GitHub Packages publish

### DIFF
--- a/.changeset/test-github-packages.md
+++ b/.changeset/test-github-packages.md
@@ -1,0 +1,5 @@
+---
+"@teseor/css": patch
+---
+
+Add GitHub Packages registry publishing to release workflow


### PR DESCRIPTION
## Summary
- Adds a patch changeset to trigger a release cycle
- Verifies npmjs + GitHub Packages dual publishing works

## Test plan
- [ ] Merge this PR
- [ ] Release workflow creates version PR
- [ ] Merge version PR → publishes to npmjs + GitHub Packages
- [ ] Package appears in repo "Packages" section