### PR TITLE
fix: use PAT for snapshot push to auto-retrigger CI

### DIFF
--- a/.github/workflows/update-snapshots.yml
+++ b/.github/workflows/update-snapshots.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.branch }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.PUSH_TOKEN }}
 
       - uses: pnpm/action-setup@v4
 


### PR DESCRIPTION
## Summary
- Use `PUSH_TOKEN` (PAT) instead of `GITHUB_TOKEN` in the Update Snapshots workflow
- Pushes from `GITHUB_TOKEN` don't trigger CI (GitHub prevents loops), requiring manual empty commits to retrigger
- With a PAT, the snapshot commit automatically triggers CI checks on the PR

## Setup required
Add a `PUSH_TOKEN` repository secret with a fine-grained PAT (see PR comment for steps)

## Test plan
- [ ] Create the PAT and add as repo secret
- [ ] Run "Update Snapshots" on a branch and verify CI triggers automatically