### PR TITLE
fix: use PAT for changeset release PR to trigger CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
           title: "Release @teseor/css"
           commit: "chore: version packages"
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.PUSH_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 


### PR DESCRIPTION
## Summary
- The changeset bot pushes to `changeset-release/main` using `GITHUB_TOKEN`, which never triggers CI checks
- Switch to `PUSH_TOKEN` (PAT) so CI runs automatically on the release PR
- Closes #235

## Test plan
- [ ] Merge this, then verify the release PR gets CI checks