### PR TITLE
fix: include version in release PR title

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,17 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
+      - name: Update release PR title with version
+        if: steps.changesets.outputs.hasChangesets == 'true'
+        run: |
+          VERSION=$(jq -r '.version' packages/css/package.json)
+          PR=$(gh pr list --head changeset-release/main --json number --jq '.[0].number')
+          if [ -n "$PR" ]; then
+            gh pr edit "$PR" --title "Release @teseor/css v${VERSION}"
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.PUSH_TOKEN }}
+
       - name: Create GitHub Releases
         if: steps.changesets.outputs.published == 'true'
         run: |


### PR DESCRIPTION
## Summary
- Adds a step to the release workflow that updates the changeset PR title with the current version (e.g. "Release @teseor/css v0.5.0")
- Runs after the changeset action when pending changesets exist

## Test plan
- [ ] Verify next release PR title includes the version number

Closes #237