### PR TITLE
[CSS] feat(utilities): add scroll-driven animation utilities

### DIFF
--- a/.changeset/scroll-driven-animations.md
+++ b/.changeset/scroll-driven-animations.md
@@ -1,0 +1,5 @@
+---
+"@teseor/css": minor
+---
+
+Add scroll-driven animation utilities with progress indicator and viewport-triggered effects

--- a/packages/css/src/utilities/index.scss
+++ b/packages/css/src/utilities/index.scss
@@ -5,4 +5,5 @@
 @forward "./visually-hidden/index";
 @forward "./view-transition/index";
 @forward "./scroll-snap/index";
+@forward "./scroll-animation/index";
 @forward "./container/index";

--- a/packages/css/src/utilities/scroll-animation/index.scss
+++ b/packages/css/src/utilities/scroll-animation/index.scss
@@ -1,0 +1,136 @@
+@use '../../config/tokens/variables' as t;
+// Scroll-driven animation utilities
+// Progressive enhancement: all rules wrapped in @supports
+
+@layer utilities {
+  @supports (animation-timeline: scroll()) {
+    // ========================================================================
+    // SCROLL PROGRESS INDICATOR
+    // Fixed bar at top of viewport showing page scroll progress
+    // ========================================================================
+    .scroll-progress {
+      position: fixed;
+      inset-block-start: 0;
+      inset-inline-start: 0;
+      z-index: var(--ui-z-toast, #{t.$z-toast});
+
+      block-size: var(--ui-scroll-progress-height, var(--ui-space-half, #{t.$space-0}));
+      inline-size: 100%;
+
+      background: var(--ui-scroll-progress-bg, var(--ui-color-primary));
+      transform-origin: inline-start;
+      scale: 0 1;
+
+      animation: scroll-progress-fill auto linear;
+      animation-timeline: scroll();
+    }
+
+    @keyframes scroll-progress-fill {
+      to {
+        scale: 1 1;
+      }
+    }
+
+    // ========================================================================
+    // VIEW-DRIVEN FADE IN
+    // Fade in when element enters viewport
+    // ========================================================================
+    .view-fade {
+      animation: view-fade-in auto linear both;
+      animation-timeline: view();
+      animation-range: entry 0% entry 100%;
+    }
+
+    @keyframes view-fade-in {
+      from {
+        opacity: 0;
+      }
+
+      to {
+        opacity: 1;
+      }
+    }
+
+    // ========================================================================
+    // VIEW-DRIVEN SLIDE UP
+    // Slide up and fade in when element enters viewport
+    // ========================================================================
+    .view-slide-up {
+      animation: view-slide-up-in auto linear both;
+      animation-timeline: view();
+      animation-range: entry 0% entry 100%;
+    }
+
+    @keyframes view-slide-up-in {
+      from {
+        opacity: 0;
+        transform: translateY(var(--ui-space-4, #{t.$space-4}));
+      }
+
+      to {
+        opacity: 1;
+        transform: translateY(0);
+      }
+    }
+
+    // ========================================================================
+    // VIEW-DRIVEN SLIDE START (left in LTR)
+    // ========================================================================
+    .view-slide-start {
+      animation: view-slide-start-in auto linear both;
+      animation-timeline: view();
+      animation-range: entry 0% entry 100%;
+    }
+
+    @keyframes view-slide-start-in {
+      from {
+        opacity: 0;
+        transform: translateX(calc(var(--ui-space-4, #{t.$space-4}) * -1));
+      }
+
+      to {
+        opacity: 1;
+        transform: translateX(0);
+      }
+    }
+
+    // ========================================================================
+    // VIEW-DRIVEN SCALE
+    // Scale up and fade in on viewport entry
+    // ========================================================================
+    .view-scale {
+      animation: view-scale-in auto linear both;
+      animation-timeline: view();
+      animation-range: entry 0% entry 100%;
+    }
+
+    @keyframes view-scale-in {
+      from {
+        opacity: 0;
+        scale: 0.9;
+      }
+
+      to {
+        opacity: 1;
+        scale: 1;
+      }
+    }
+
+    // ========================================================================
+    // ACCESSIBILITY: disable all scroll-driven animations for reduced motion
+    // ========================================================================
+    @media (prefers-reduced-motion: reduce) {
+      .scroll-progress,
+      .view-fade,
+      .view-slide-up,
+      .view-slide-start,
+      .view-scale {
+        opacity: 1;
+        transform: none;
+        scale: 1 1;
+
+        animation: none;
+      }
+    }
+  }
+}

--- a/packages/css/src/utilities/scroll-animation/scroll-animation.api.json
+++ b/packages/css/src/utilities/scroll-animation/scroll-animation.api.json
@@ -1,0 +1,17 @@
+{
+  "name": "scroll-animation",
+  "type": "utility",
+  "utilities": ["scroll-progress", "view-fade", "view-slide-up", "view-slide-start", "view-scale"],
+  "cssVars": [
+    {
+      "name": "--ui-scroll-progress-height",
+      "default": "var(--ui-space-half)",
+      "description": "Scroll progress indicator height"
+    },
+    {
+      "name": "--ui-scroll-progress-bg",
+      "default": "var(--ui-color-primary)",
+      "description": "Scroll progress indicator color"
+    }
+  ]
+}

--- a/packages/css/src/utilities/scroll-animation/scroll-animation.docs.json
+++ b/packages/css/src/utilities/scroll-animation/scroll-animation.docs.json
@@ -1,0 +1,100 @@
+{
+  "id": "scroll-animation-utils",
+  "type": "utility",
+  "title": "Scroll Animation",
+  "description": "Scroll-driven animation utilities for progress indicators and viewport-triggered effects. Wrapped in @supports — no impact on unsupported browsers.",
+  "api": "scroll-animation.api.json",
+  "sections": [
+    {
+      "title": "Scroll Progress Indicator",
+      "description": "Fixed bar at the top of the viewport that fills as the user scrolls down.",
+      "examples": [
+        {
+          "items": [
+            {
+              "tag": "div",
+              "attrs": { "style": "position: relative; block-size: 12rem; overflow-y: auto;" },
+              "children": [
+                {
+                  "tag": "div",
+                  "class": "ui-scroll-progress",
+                  "attrs": { "style": "position: absolute;" }
+                },
+                {
+                  "tag": "div",
+                  "attrs": { "style": "block-size: 40rem; padding: var(--ui-space-2);" },
+                  "children": [{ "tag": "p", "text": "Scroll down to see the progress bar fill." }]
+                }
+              ]
+            }
+          ],
+          "code": "<div class=\"ui-scroll-progress\"></div>\n<!-- Fills as page scrolls -->"
+        }
+      ]
+    },
+    {
+      "title": "View Fade",
+      "description": "Elements fade in as they enter the viewport.",
+      "examples": [
+        {
+          "items": [
+            {
+              "tag": "div",
+              "class": "ui-view-fade ui-card ui-p-2",
+              "text": "I fade in on scroll"
+            }
+          ],
+          "code": "<div class=\"ui-view-fade\">I fade in on scroll</div>"
+        }
+      ]
+    },
+    {
+      "title": "View Slide Up",
+      "description": "Elements slide up and fade in on viewport entry.",
+      "examples": [
+        {
+          "items": [
+            {
+              "tag": "div",
+              "class": "ui-view-slide-up ui-card ui-p-2",
+              "text": "I slide up into view"
+            }
+          ],
+          "code": "<div class=\"ui-view-slide-up\">I slide up into view</div>"
+        }
+      ]
+    },
+    {
+      "title": "View Slide Start",
+      "description": "Elements slide in from the start edge (left in LTR) on viewport entry.",
+      "examples": [
+        {
+          "items": [
+            {
+              "tag": "div",
+              "class": "ui-view-slide-start ui-card ui-p-2",
+              "text": "I slide from the start"
+            }
+          ],
+          "code": "<div class=\"ui-view-slide-start\">I slide from the start</div>"
+        }
+      ]
+    },
+    {
+      "title": "View Scale",
+      "description": "Elements scale up and fade in on viewport entry.",
+      "examples": [
+        {
+          "items": [
+            {
+              "tag": "div",
+              "class": "ui-view-scale ui-card ui-p-2",
+              "text": "I scale into view"
+            }
+          ],
+          "code": "<div class=\"ui-view-scale\">I scale into view</div>"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- New `scroll-animation` utility with 5 classes: `scroll-progress`, `view-fade`, `view-slide-up`, `view-slide-start`, `view-scale`
- All wrapped in `@supports (animation-timeline: scroll())` for progressive enhancement
- Respects `prefers-reduced-motion: reduce` — disables all animations
- Includes scroll progress indicator (fixed bar at viewport top) and viewport-triggered animations

Closes #315

## Test plan
- [ ] Verify no visual changes in unsupported browsers (Safari)
- [ ] Verify scroll-progress indicator fills on page scroll in Chrome 115+
- [ ] Verify view-driven animations trigger on viewport entry
- [ ] Verify reduced-motion disables all effects


