### PR TITLE
Move guides to config/guides/, reorder sidenav, add Getting Started

### DIFF
--- a/.changeset/sidenav-reorder.md
+++ b/.changeset/sidenav-reorder.md
@@ -1,0 +1,5 @@
+---
+"@teseor/css": patch
+---
+
+Move guides to config/guides/, add Getting Started guide, reorder sidenav

--- a/apps/docs-css/eleventy.config.js
+++ b/apps/docs-css/eleventy.config.js
@@ -119,6 +119,7 @@ function resolveDoc(doc, docsFilePath) {
     groupLabel: group?.label || null,
     title: doc.title || (api ? capitalize(api.name) : id),
     description: doc.description || api?.description || '',
+    weight: doc.weight || null,
     sections: doc.sections || [],
     customization,
     api: mergedApi,
@@ -225,6 +226,14 @@ export default function (eleventyConfig) {
 
   eleventyConfig.addFilter('sortByTitle', (docs) =>
     [...docs].sort((a, b) => (a.title || '').localeCompare(b.title || '')),
+  );
+
+  eleventyConfig.addFilter('sortByWeight', (docs) =>
+    [...docs].sort((a, b) => {
+      const wa = a.weight ?? Number.MAX_SAFE_INTEGER;
+      const wb = b.weight ?? Number.MAX_SAFE_INTEGER;
+      return wa !== wb ? wa - wb : (a.title || '').localeCompare(b.title || '');
+    }),
   );
 
   eleventyConfig.addFilter('processTemplate', (template, data) => processTemplate(template, data));

--- a/apps/docs-css/src/_includes/partials/nav.njk
+++ b/apps/docs-css/src/_includes/partials/nav.njk
@@ -5,7 +5,20 @@
   </ul>
 </div>
 
-{# Foundation (was Tokens) #}
+{# Guides (moved before Foundation) #}
+{% set guides = docs | byType('guide') | sortByWeight %}
+{% if guides.length > 0 %}
+<div class="ui-sidebar-nav__group">
+  <span class="ui-sidebar-nav__group-label">Guides</span>
+  <ul class="ui-sidebar-nav__group-items">
+    {% for doc in guides %}
+    <li><a class="ui-sidebar-nav__item{% if page.url == doc.permalink %} ui-sidebar-nav__item--active{% endif %}" href="{{ doc.permalink | url }}"{% if page.url == doc.permalink %} aria-current="page"{% endif %}><span class="ui-sidebar-nav__label">{{ doc.title }}</span></a></li>
+    {% endfor %}
+  </ul>
+</div>
+{% endif %}
+
+{# Foundation #}
 {% set tokens = docs | byType('token') | sortByTitle %}
 {% if tokens.length > 0 %}
 <div class="ui-sidebar-nav__group">
@@ -18,7 +31,7 @@
 </div>
 {% endif %}
 
-{# Layout (was Primitives) #}
+{# Layout #}
 {% set primitives = docs | byType('primitive') | sortByTitle %}
 {% if primitives.length > 0 %}
 <div class="ui-sidebar-nav__group">
@@ -79,19 +92,6 @@
   <span class="ui-sidebar-nav__group-label">Utilities</span>
   <ul class="ui-sidebar-nav__group-items">
     {% for doc in utilities %}
-    <li><a class="ui-sidebar-nav__item{% if page.url == doc.permalink %} ui-sidebar-nav__item--active{% endif %}" href="{{ doc.permalink | url }}"{% if page.url == doc.permalink %} aria-current="page"{% endif %}><span class="ui-sidebar-nav__label">{{ doc.title }}</span></a></li>
-    {% endfor %}
-  </ul>
-</div>
-{% endif %}
-
-{# Guides #}
-{% set guides = docs | byType('guide') | sortByTitle %}
-{% if guides.length > 0 %}
-<div class="ui-sidebar-nav__group">
-  <span class="ui-sidebar-nav__group-label">Guides</span>
-  <ul class="ui-sidebar-nav__group-items">
-    {% for doc in guides %}
     <li><a class="ui-sidebar-nav__item{% if page.url == doc.permalink %} ui-sidebar-nav__item--active{% endif %}" href="{{ doc.permalink | url }}"{% if page.url == doc.permalink %} aria-current="page"{% endif %}><span class="ui-sidebar-nav__label">{{ doc.title }}</span></a></li>
     {% endfor %}
   </ul>

--- a/packages/css/src/config/guides/accessibility.docs.json
+++ b/packages/css/src/config/guides/accessibility.docs.json
@@ -3,6 +3,7 @@
   "type": "guide",
   "title": "Accessibility",
   "description": "Built-in accessibility features: reduced motion, system theme detection, high contrast, and keyboard focus indicators",
+  "weight": 3,
   "skipValidation": true,
   "sections": [
     {

--- a/packages/css/src/config/guides/getting-started.docs.json
+++ b/packages/css/src/config/guides/getting-started.docs.json
@@ -1,0 +1,106 @@
+{
+  "id": "getting-started",
+  "type": "guide",
+  "title": "Getting Started",
+  "description": "Install, import, and start using the CSS library in your project",
+  "weight": 1,
+  "skipValidation": true,
+  "sections": [
+    {
+      "title": "Installation",
+      "description": "Install the package from npm.",
+      "examples": [
+        {
+          "title": "npm / pnpm / yarn",
+          "code": "npm install @teseor/css\n# or\npnpm add @teseor/css\n# or\nyarn add @teseor/css"
+        }
+      ]
+    },
+    {
+      "title": "Import",
+      "description": "Import the compiled CSS in your app entry point.",
+      "examples": [
+        {
+          "title": "JS / TS entry",
+          "code": "import '@teseor/css';\n// or\nimport '@teseor/css/dist/index.css';"
+        },
+        {
+          "title": "HTML link",
+          "code": "<link rel=\"stylesheet\" href=\"node_modules/@teseor/css/dist/index.css\">"
+        }
+      ]
+    },
+    {
+      "title": "Root Class",
+      "description": "Add the .ui-root class to set baseline typography and colors.",
+      "examples": [
+        {
+          "items": [
+            {
+              "tag": "div",
+              "class": "ui-root",
+              "children": [{ "tag": "p", "text": "Text inherits font, size, color from .ui-root" }]
+            }
+          ],
+          "code": "<html class=\"ui-root\">\n  <body>\n    <!-- All children inherit base styles -->\n  </body>\n</html>"
+        }
+      ]
+    },
+    {
+      "title": "First Component",
+      "description": "Use any component by adding its class. No JS required.",
+      "examples": [
+        {
+          "title": "Button",
+          "items": [
+            {
+              "tag": "div",
+              "class": "ui-row ui-row--sm",
+              "children": [
+                { "tag": "button", "class": "ui-button", "text": "Primary" },
+                { "tag": "button", "class": "ui-button ui-button--secondary", "text": "Secondary" },
+                { "tag": "button", "class": "ui-button ui-button--danger", "text": "Danger" }
+              ]
+            }
+          ],
+          "code": "<button class=\"ui-button\">Primary</button>\n<button class=\"ui-button ui-button--secondary\">Secondary</button>\n<button class=\"ui-button ui-button--danger\">Danger</button>"
+        },
+        {
+          "title": "Card",
+          "items": [
+            {
+              "tag": "div",
+              "class": "ui-card",
+              "children": [
+                { "tag": "h3", "class": "ui-heading ui-heading--4", "text": "Card Title" },
+                {
+                  "tag": "p",
+                  "text": "Cards use semantic tokens for padding, border, and background."
+                }
+              ]
+            }
+          ],
+          "code": "<div class=\"ui-card\">\n  <h3 class=\"ui-heading ui-heading--4\">Card Title</h3>\n  <p>Content goes here.</p>\n</div>"
+        }
+      ]
+    },
+    {
+      "title": "Customize",
+      "description": "Override design tokens with CSS custom properties. No build step required.",
+      "examples": [
+        {
+          "title": "Change brand color",
+          "items": [
+            {
+              "tag": "div",
+              "class": "theme-demo",
+              "style": { "--ui-hue-primary": "270" },
+              "children": [{ "tag": "button", "class": "ui-button", "text": "Purple brand" }]
+            }
+          ],
+          "code": ":root {\n  --ui-hue-primary: 270; /* purple */\n}"
+        }
+      ]
+    }
+  ]
+}

--- a/packages/css/src/config/guides/theming.docs.json
+++ b/packages/css/src/config/guides/theming.docs.json
@@ -3,6 +3,7 @@
   "type": "guide",
   "title": "Theming",
   "description": "Customize the design system with CSS custom properties",
+  "weight": 2,
   "skipValidation": true,
   "sections": [
     {


### PR DESCRIPTION
## Summary
- Move theming.docs.json and accessibility.docs.json to config/guides/
- Create getting-started.docs.json with install, import, root class, first component, and customize sections
- Add weight field to guide docs for ordering (1=Getting Started, 2=Theming, 3=Accessibility)
- Add sortByWeight filter to eleventy.config.js
- Move Guides section before Foundation in sidenav

New sidenav order: Home > Guides > Foundation > Layout > Components > Typography > Utilities

Closes #343

## Test plan
- [x] `pnpm --filter docs-css build` succeeds (91 pages)
- [x] Sidenav order: Guides first with correct weight ordering
- [x] `pnpm lint` passes
- [ ] CI passes