### PR TITLE
Color shade generation + remove --ui-hue-primary

### DIFF
--- a/.changeset/color-shades-hue-removal.md
+++ b/.changeset/color-shades-hue-removal.md
@@ -1,0 +1,5 @@
+---
+"@teseor/css": minor
+---
+
+Add color-mix() shade tokens for success, warning, and danger (light, dark, subtle, hover variants). Remove disconnected --ui-hue-primary token — shadows now derive from --ui-color-neutral via color-mix(). Theme demos updated to override --ui-color-primary directly.

--- a/apps/docs-css/src/styles.css
+++ b/apps/docs-css/src/styles.css
@@ -144,21 +144,21 @@
     align-items: flex-start;
   }
 
-  /* Theme hue variants */
+  /* Theme color variants — override --ui-color-primary for real theming */
   .demo-theme--purple {
-    --ui-hue-primary: 270;
+    --ui-color-primary: oklch(55% 0.22 290);
   }
 
   .demo-theme--teal {
-    --ui-hue-primary: 180;
+    --ui-color-primary: oklch(55% 0.15 180);
   }
 
   .demo-theme--orange {
-    --ui-hue-primary: 25;
+    --ui-color-primary: oklch(65% 0.18 55);
   }
 
   .demo-theme--corporate {
-    --ui-hue-primary: 180;
+    --ui-color-primary: oklch(55% 0.15 180);
     --ui-radius-sm: 2px;
     --ui-radius-md: 4px;
     --ui-radius-lg: 6px;

--- a/packages/css/src/config/guides/getting-started.docs.html
+++ b/packages/css/src/config/guides/getting-started.docs.html
@@ -40,6 +40,6 @@ import '@teseor/css/dist/index.css';
 
 <!-- @customize -->
 <!-- Override design tokens with CSS custom properties. No build step required. -->
-<div class="demo-theme" style="--ui-hue-primary: 270">
+<div class="demo-theme" style="--ui-color-primary: oklch(55% 0.22 290)">
   <button class="ui-button">{{ t('purple_brand', 'Purple brand') }}</button>
 </div>

--- a/packages/css/src/config/guides/theming.docs.html
+++ b/packages/css/src/config/guides/theming.docs.html
@@ -6,7 +6,7 @@ weight: 2
 ---
 
 <!-- @brand_colors -->
-<!-- Change the entire color palette by adjusting hue values -->
+<!-- Override --ui-color-primary to change the entire color palette. All shades (light, dark, subtle, hover) derive automatically via color-mix(). -->
 <div class="demo-theme">
   <button class="ui-button">{{ t('primary', 'Primary') }}</button>
   <button class="ui-button ui-button--secondary">{{ t('secondary', 'Secondary') }}</button>

--- a/packages/css/src/config/tokens/_variables.scss
+++ b/packages/css/src/config/tokens/_variables.scss
@@ -21,15 +21,36 @@ $row-6: $row * 6;
 // 2. Colors — OKLCH for perceptual uniformity
 // ==========================================================================
 
-// Theming hue — used in HSL fallbacks for shadows, debug overlays
-$hue-primary: 220;
-
 // Base palette
 $color-primary: oklch(55% 0.22 250);
 $color-success: oklch(60% 0.18 145);
 $color-warning: oklch(75% 0.18 70);
 $color-danger: oklch(60% 0.22 25);
 $color-neutral: oklch(50% 0.02 250);
+
+// Primary shades (CSS uses color-mix)
+$color-primary-light: oklch(75% 0.15 250);
+$color-primary-dark: oklch(40% 0.18 250);
+$color-primary-subtle: oklch(95% 0.03 250);
+$color-primary-hover: oklch(48% 0.20 250);
+
+// Success shades (CSS uses color-mix)
+$color-success-light: oklch(80% 0.12 145);
+$color-success-dark: oklch(45% 0.15 145);
+$color-success-subtle: oklch(95% 0.03 145);
+$color-success-hover: oklch(52% 0.16 145);
+
+// Warning shades (CSS uses color-mix)
+$color-warning-light: oklch(88% 0.12 70);
+$color-warning-dark: oklch(58% 0.15 70);
+$color-warning-subtle: oklch(96% 0.03 70);
+$color-warning-hover: oklch(66% 0.16 70);
+
+// Danger shades (CSS uses color-mix)
+$color-danger-light: oklch(80% 0.14 25);
+$color-danger-dark: oklch(45% 0.18 25);
+$color-danger-subtle: oklch(95% 0.03 25);
+$color-danger-hover: oklch(52% 0.20 25);
 
 // Neutral scale — HSL approximation of color-mix(in oklch, ...) results.
 // CSS tokens use oklch color-mix(); these HSL values are static SCSS
@@ -44,10 +65,6 @@ $color-neutral-600: hsl(220 10% 35%);
 $color-neutral-700: hsl(220 10% 25%);
 $color-neutral-800: hsl(220 10% 15%);
 $color-neutral-900: hsl(220 10% 10%);
-
-// Primary shades (CSS uses color-mix)
-$color-primary-light: oklch(75% 0.15 250);
-$color-primary-dark: oklch(40% 0.18 250);
 
 // ==========================================================================
 // 3. Spacing — derived from $unit
@@ -143,7 +160,7 @@ $border-width-lg: $unit * 0.5; // 4px
 $focus-ring-offset: -$border-width-md;
 
 // ==========================================================================
-// 7. Shadows — static hue fallback
+// 7. Shadows — neutral-tinted
 // ==========================================================================
 $shadow-sm: 0 1px 2px hsl(220 10% 20% / 0.05);
 $shadow-md: 0 4px 6px hsl(220 10% 20% / 0.1);

--- a/packages/css/src/config/tokens/colors/index.scss
+++ b/packages/css/src/config/tokens/colors/index.scss
@@ -13,6 +13,24 @@
     --ui-color-primary-subtle: color-mix(in oklch, var(--ui-color-primary) 12%, white);
     --ui-color-primary-hover: color-mix(in oklch, var(--ui-color-primary) 85%, black);
 
+    // Success shades - auto-generated via color-mix
+    --ui-color-success-light: color-mix(in oklch, var(--ui-color-success) 50%, white);
+    --ui-color-success-dark: color-mix(in oklch, var(--ui-color-success) 75%, black);
+    --ui-color-success-subtle: color-mix(in oklch, var(--ui-color-success) 12%, white);
+    --ui-color-success-hover: color-mix(in oklch, var(--ui-color-success) 85%, black);
+
+    // Warning shades - auto-generated via color-mix
+    --ui-color-warning-light: color-mix(in oklch, var(--ui-color-warning) 50%, white);
+    --ui-color-warning-dark: color-mix(in oklch, var(--ui-color-warning) 75%, black);
+    --ui-color-warning-subtle: color-mix(in oklch, var(--ui-color-warning) 12%, white);
+    --ui-color-warning-hover: color-mix(in oklch, var(--ui-color-warning) 85%, black);
+
+    // Danger shades - auto-generated via color-mix
+    --ui-color-danger-light: color-mix(in oklch, var(--ui-color-danger) 50%, white);
+    --ui-color-danger-dark: color-mix(in oklch, var(--ui-color-danger) 75%, black);
+    --ui-color-danger-subtle: color-mix(in oklch, var(--ui-color-danger) 12%, white);
+    --ui-color-danger-hover: color-mix(in oklch, var(--ui-color-danger) 85%, black);
+
     // Neutral scale - auto-generated via color-mix
     --ui-color-neutral-50: color-mix(in oklch, var(--ui-color-neutral) 3%, white);
     --ui-color-neutral-100: color-mix(in oklch, var(--ui-color-neutral) 6%, white);

--- a/packages/css/src/config/tokens/shadows.scss
+++ b/packages/css/src/config/tokens/shadows.scss
@@ -1,7 +1,8 @@
 @layer tokens {
   :root {
-    --ui-shadow-sm: 0 1px 2px hsl(var(--ui-hue-primary, 220) 10% 20% / 0.05);
-    --ui-shadow-md: 0 4px 6px hsl(var(--ui-hue-primary, 220) 10% 20% / 0.1);
-    --ui-shadow-lg: 0 10px 15px hsl(var(--ui-hue-primary, 220) 10% 20% / 0.15);
+    // Shadows tinted by neutral color — changing --ui-color-neutral shifts shadow tone
+    --ui-shadow-sm: 0 1px 2px color-mix(in oklch, var(--ui-color-neutral) 20%, transparent);
+    --ui-shadow-md: 0 4px 6px color-mix(in oklch, var(--ui-color-neutral) 15%, transparent);
+    --ui-shadow-lg: 0 10px 15px color-mix(in oklch, var(--ui-color-neutral) 12%, transparent);
   }
 }

--- a/packages/css/src/debug/index.scss
+++ b/packages/css/src/debug/index.scss
@@ -7,8 +7,7 @@
 }
 
 .debug-grid {
-  // Fallback hue 220 (blue) when --ui-hue-primary not set
-  --debug-color: hsl(var(--ui-hue-primary, #{t.$hue-primary}) 80% 50% / 0.15);
+  --debug-color: color-mix(in oklch, var(--ui-color-primary, #{t.$color-primary}) 15%, transparent);
 }
 
 .debug-grid::after {
@@ -31,8 +30,8 @@
 
 // Stronger grid at row intervals
 .debug-grid-rows {
-  --debug-color: hsl(var(--ui-hue-primary, #{t.$hue-primary}) 80% 50% / 0.1);
-  --debug-color-strong: hsl(var(--ui-hue-primary, #{t.$hue-primary}) 80% 50% / 0.25);
+  --debug-color: color-mix(in oklch, var(--ui-color-primary, #{t.$color-primary}) 10%, transparent);
+  --debug-color-strong: color-mix(in oklch, var(--ui-color-primary, #{t.$color-primary}) 25%, transparent);
 }
 
 .debug-grid-rows::after {
@@ -56,7 +55,7 @@
 
 // Baseline grid only (horizontal lines)
 .debug-baseline {
-  --debug-color: hsl(var(--ui-hue-danger, 0) 80% 50% / 0.2);
+  --debug-color: color-mix(in oklch, var(--ui-color-danger, #{t.$color-danger}) 20%, transparent);
 }
 
 .debug-baseline::after {

--- a/packages/css/src/layout/footer/index.scss
+++ b/packages/css/src/layout/footer/index.scss
@@ -6,7 +6,7 @@
   .footer {
     --_space-2: var(--ui-space-2);
     --_border-width-sm: var(--ui-border-width-sm);
-    --_hue-primary: var(--ui-hue-primary, #{t.$hue-primary});
+    --_shadow-color: color-mix(in oklch, var(--ui-color-neutral, #{t.$color-neutral}) 8%, transparent);
     // @desc Overall height
     --_height: var(--ui-footer-height, var(--ui-row-3));
     // @desc Background color
@@ -73,6 +73,6 @@
 
   // @modifier boolean raised
   .footer--raised {
-    box-shadow: 0 calc(var(--_border-width-sm) * -1) 6px hsl(var(--_hue-primary) 10% 20% / 0.08);
+    box-shadow: 0 calc(var(--_border-width-sm) * -1) 6px var(--_shadow-color);
   }
 }


### PR DESCRIPTION
## Summary
- Add 12 `color-mix()` shade tokens for success, warning, and danger (light, dark, subtle, hover)
- Remove disconnected `--ui-hue-primary` — shadows now derive from `--ui-color-neutral`
- Debug overlays now use `color-mix()` with `--ui-color-primary` / `--ui-color-danger`
- Theme demos updated to override `--ui-color-primary` directly (OKLCH values)

## Test plan
- [x] `pnpm lint` passes (all checks)
- [x] `pnpm typecheck` passes
- [x] `pnpm test:unit` — 96 tests pass
- [x] Visual tests — 137 pass, 3 skipped (no snapshot changes)
- [x] Docs build succeeds

Closes #380