### PR TITLE
Introduce --ui-radius-base derivation token

### DIFF
--- a/.changeset/radius-base-token.md
+++ b/.changeset/radius-base-token.md
@@ -1,0 +1,5 @@
+---
+"@teseor/css": minor
+---
+
+Add --ui-radius-base theme knob token. Override it once to control all border radii (sm, md, lg derive from it). Simplifies theming — e.g. `--ui-radius-base: 2px` for sharp corners.

--- a/apps/docs-css/src/styles.css
+++ b/apps/docs-css/src/styles.css
@@ -159,9 +159,7 @@
 
   .demo-theme--corporate {
     --ui-color-primary: oklch(55% 0.15 180);
-    --ui-radius-sm: 2px;
-    --ui-radius-md: 4px;
-    --ui-radius-lg: 6px;
+    --ui-radius-base: 2px;
   }
 
   /* Component override demos */

--- a/packages/css/src/config/tokens/_variables.scss
+++ b/packages/css/src/config/tokens/_variables.scss
@@ -144,11 +144,12 @@ $font-size-relative-xs: 0.6em;
 $font-size-relative-sm: 0.75em;
 
 // ==========================================================================
-// 5. Radius — derived from $unit
+// 5. Radius — derived from $radius-base (which defaults to $unit)
 // ==========================================================================
-$radius-sm: $unit * 0.5; // 4px
-$radius-md: $unit; // 8px
-$radius-lg: $unit * 2; // 16px
+$radius-base: $unit; // 8px — theme knob
+$radius-sm: $radius-base * 0.5; // 4px
+$radius-md: $radius-base; // 8px
+$radius-lg: $radius-base * 2; // 16px
 $radius-full: 9999px;
 
 // ==========================================================================

--- a/packages/css/src/config/tokens/radius.scss
+++ b/packages/css/src/config/tokens/radius.scss
@@ -1,9 +1,10 @@
 @layer tokens {
   :root {
-    // Radius - derived from --unit (8px)
-    --ui-radius-sm: calc(var(--ui-unit) * 0.5); // 4px
-    --ui-radius-md: var(--ui-unit); // 8px
-    --ui-radius-lg: calc(var(--ui-unit) * 2); // 16px
+    // Override --ui-radius-base to control all border radii at once
+    --ui-radius-base: var(--ui-unit); // 8px — the single theme knob
+    --ui-radius-sm: calc(var(--ui-radius-base) * 0.5); // 4px
+    --ui-radius-md: var(--ui-radius-base); // 8px
+    --ui-radius-lg: calc(var(--ui-radius-base) * 2); // 16px
     --ui-radius-full: 9999px;
   }
 }


### PR DESCRIPTION
## Summary
- Add `--ui-radius-base` as the single theme knob for border radius control
- `--ui-radius-sm/md/lg` now derive from `--ui-radius-base` via calc()
- SCSS `$radius-base` added to `_variables.scss`
- `.demo-theme--corporate` simplified from 3 overrides to 1

## Test plan
- [x] `pnpm lint` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm test:unit` — 96 tests pass
- [x] No visual change (identical computed values)

Closes #381