### PR TITLE
Rename --ui-weight-* to --ui-font-weight-* tokens

### DIFF
--- a/.changeset/rename-weight-to-font-weight.md
+++ b/.changeset/rename-weight-to-font-weight.md
@@ -1,0 +1,5 @@
+---
+"@teseor/css": major
+---
+
+Rename --ui-weight-* tokens to --ui-font-weight-* for CSS property name consistency. Clean break — old names removed entirely. Add banned-token-names lint rule to prevent regression.

--- a/packages/css/src/base/typography/typography.scss
+++ b/packages/css/src/base/typography/typography.scss
@@ -62,7 +62,7 @@
   // Inline elements - line-height: 0 prevents affecting parent rhythm
   strong,
   b {
-    font-weight: var(--ui-weight-bold);
+    font-weight: var(--ui-font-weight-bold);
     line-height: 0;
   }
 

--- a/packages/css/src/components/actions/button/api.json
+++ b/packages/css/src/components/actions/button/api.json
@@ -57,7 +57,7 @@
     },
     {
       "name": "--ui-button-font-weight",
-      "default": "var(--ui-weight-medium)",
+      "default": "var(--ui-font-weight-medium)",
       "description": "Font weight"
     },
     {

--- a/packages/css/src/components/actions/button/index.scss
+++ b/packages/css/src/components/actions/button/index.scss
@@ -27,7 +27,7 @@
     // @desc Font size
     --_font-size: var(--ui-button-font-size, var(--ui-font-size-sm, #{t.$font-size-sm}));
     // @desc Font weight
-    --_font-weight: var(--ui-button-font-weight, var(--ui-weight-medium, #{t.$weight-medium}));
+    --_font-weight: var(--ui-button-font-weight, var(--ui-font-weight-medium, #{t.$font-weight-medium}));
     // @desc Corner radius
     --_radius: var(--ui-button-radius, var(--ui-radius-md, #{t.$radius-md}));
     --_bg: var(--_accent);

--- a/packages/css/src/components/data-display/avatar/index.scss
+++ b/packages/css/src/components/data-display/avatar/index.scss
@@ -6,7 +6,7 @@
 
 @layer components.tokens {
   .avatar {
-    --_weight-medium: var(--ui-weight-medium, #{t.$weight-medium});
+    --_weight-medium: var(--ui-font-weight-medium, #{t.$font-weight-medium});
     --_border-width-sm: var(--ui-border-width-sm, #{t.$border-width-sm});
     --_color-bg: var(--ui-color-bg, #{t.$color-bg});
     // @desc Overall size

--- a/packages/css/src/components/data-display/badge/api.json
+++ b/packages/css/src/components/data-display/badge/api.json
@@ -33,7 +33,7 @@
     },
     {
       "name": "--ui-badge-font-weight",
-      "default": "var(--ui-weight-medium)",
+      "default": "var(--ui-font-weight-medium)",
       "description": "Font weight"
     },
     {

--- a/packages/css/src/components/data-display/badge/index.scss
+++ b/packages/css/src/components/data-display/badge/index.scss
@@ -16,7 +16,7 @@
     // @desc Font size
     --_font-size: var(--ui-badge-font-size, var(--ui-font-size-xs, #{t.$font-size-xs}));
     // @desc Font weight
-    --_font-weight: var(--ui-badge-font-weight, var(--ui-weight-medium, #{t.$weight-medium}));
+    --_font-weight: var(--ui-badge-font-weight, var(--ui-font-weight-medium, #{t.$font-weight-medium}));
     // @desc Corner radius
     --_radius: var(--ui-badge-radius, var(--ui-radius-full, #{t.$radius-full}));
     --_bg: var(--_accent);

--- a/packages/css/src/components/data-display/data-list/index.scss
+++ b/packages/css/src/components/data-display/data-list/index.scss
@@ -9,7 +9,7 @@
   .data-list {
     --_row-1: var(--ui-row-1, #{t.$row});
     --_font-size-sm: var(--ui-font-size-sm, #{t.$font-size-sm});
-    --_weight-medium: var(--ui-weight-medium, #{t.$weight-medium});
+    --_weight-medium: var(--ui-font-weight-medium, #{t.$font-weight-medium});
     --_border-width-sm: var(--ui-border-width-sm, #{t.$border-width-sm});
     --_color-border: var(--ui-color-border, #{t.$color-border});
     --_color-bg-subtle: var(--ui-color-bg-subtle, #{t.$color-bg-subtle});

--- a/packages/css/src/components/data-display/stat/api.json
+++ b/packages/css/src/components/data-display/stat/api.json
@@ -24,7 +24,7 @@
     },
     {
       "name": "--ui-stat-value-font-weight",
-      "default": "var(--ui-weight-bold)",
+      "default": "var(--ui-font-weight-bold)",
       "description": "Value display font weight"
     },
     {

--- a/packages/css/src/components/data-display/stat/index.scss
+++ b/packages/css/src/components/data-display/stat/index.scss
@@ -13,7 +13,7 @@
     // @desc Value display font size
     --_font-size: var(--ui-stat-value-font-size, var(--ui-font-size-3xl, #{t.$font-size-3xl}));
     // @desc Value display font weight
-    --_font-weight: var(--ui-stat-value-font-weight, var(--ui-weight-bold, #{t.$weight-bold}));
+    --_font-weight: var(--ui-stat-value-font-weight, var(--ui-font-weight-bold, #{t.$font-weight-bold}));
     // @desc Value display line height
     --_line-height: var(--ui-stat-value-line-height, var(--ui-leading-3xl, #{t.$leading-3xl}));
     // @desc Value display text color

--- a/packages/css/src/components/data-display/table/index.scss
+++ b/packages/css/src/components/data-display/table/index.scss
@@ -7,7 +7,7 @@
   .table {
     --_border-width-sm: var(--ui-border-width-sm, #{t.$border-width-sm});
     --_unit: var(--ui-unit, #{t.$unit});
-    --_weight-medium: var(--ui-weight-medium, #{t.$weight-medium});
+    --_weight-medium: var(--ui-font-weight-medium, #{t.$font-weight-medium});
     --_color-bg-subtle: var(--ui-color-bg-subtle, #{t.$color-bg-subtle});
     --_color-bg-muted: var(--ui-color-bg-muted, #{t.$color-bg-muted});
     // @desc Font size

--- a/packages/css/src/components/data-display/tag/index.scss
+++ b/packages/css/src/components/data-display/tag/index.scss
@@ -6,7 +6,7 @@
 
 @layer components.tokens {
   .tag {
-    --_weight-medium: var(--ui-weight-medium, #{t.$weight-medium});
+    --_weight-medium: var(--ui-font-weight-medium, #{t.$font-weight-medium});
     --_opacity-disabled: var(--ui-opacity-disabled, #{t.$opacity-disabled});
     --_opacity-loading: var(--ui-opacity-loading, #{t.$opacity-loading});
     // @desc Overall height

--- a/packages/css/src/components/disclosure/disclosure/index.scss
+++ b/packages/css/src/components/disclosure/disclosure/index.scss
@@ -7,7 +7,7 @@
 
 @layer components.tokens {
   .disclosure {
-    --_weight-medium: var(--ui-weight-medium, #{t.$weight-medium});
+    --_weight-medium: var(--ui-font-weight-medium, #{t.$font-weight-medium});
     --_color-bg-subtle: var(--ui-color-bg-subtle, #{t.$color-bg-subtle});
     --_duration-fast: var(--ui-duration-fast, #{t.$duration-fast});
     --_ease-default: var(--ui-ease-default, ease);

--- a/packages/css/src/components/feedback/alert/index.scss
+++ b/packages/css/src/components/feedback/alert/index.scss
@@ -5,7 +5,7 @@
 
 @layer components.tokens {
   .alert {
-    --_weight-medium: var(--ui-weight-medium, #{t.$weight-medium});
+    --_weight-medium: var(--ui-font-weight-medium, #{t.$font-weight-medium});
     --_row-1: var(--ui-row-1, #{t.$row});
     --_font-size-sm: var(--ui-font-size-sm, #{t.$font-size-sm});
     --_color-text-muted: var(--ui-color-text-muted, #{t.$color-text-muted});

--- a/packages/css/src/components/feedback/toast/index.scss
+++ b/packages/css/src/components/feedback/toast/index.scss
@@ -19,7 +19,7 @@
 
   .toast {
     --_border-width-sm: var(--ui-border-width-sm, #{t.$border-width-sm});
-    --_weight-medium: var(--ui-weight-medium, #{t.$weight-medium});
+    --_weight-medium: var(--ui-font-weight-medium, #{t.$font-weight-medium});
     --_row-1: var(--ui-row-1, #{t.$row});
     --_font-size-sm: var(--ui-font-size-sm, #{t.$font-size-sm});
     --_color-text-muted: var(--ui-color-text-muted, #{t.$color-text-muted});

--- a/packages/css/src/components/forms/checkbox-group/api.json
+++ b/packages/css/src/components/forms/checkbox-group/api.json
@@ -31,7 +31,7 @@
     },
     {
       "name": "--ui-checkbox-group-legend-weight",
-      "default": "var(--ui-weight-medium)",
+      "default": "var(--ui-font-weight-medium)",
       "description": "Legend weight"
     },
     {

--- a/packages/css/src/components/forms/checkbox-group/index.scss
+++ b/packages/css/src/components/forms/checkbox-group/index.scss
@@ -14,7 +14,7 @@
     // @desc Legend size
     --_legend-size: var(--ui-checkbox-group-legend-size, var(--ui-font-size-sm, #{t.$font-size-sm}));
     // @desc Legend weight
-    --_legend-weight: var(--ui-checkbox-group-legend-weight, var(--ui-weight-medium, #{t.$weight-medium}));
+    --_legend-weight: var(--ui-checkbox-group-legend-weight, var(--ui-font-weight-medium, #{t.$font-weight-medium}));
     // @desc Legend color
     --_legend-color: var(--ui-checkbox-group-legend-color, var(--ui-color-text, #{t.$color-text}));
     // @desc Legend spacing

--- a/packages/css/src/components/forms/fieldset/api.json
+++ b/packages/css/src/components/forms/fieldset/api.json
@@ -46,7 +46,7 @@
     },
     {
       "name": "--ui-fieldset-legend-weight",
-      "default": "var(--ui-weight-medium)",
+      "default": "var(--ui-font-weight-medium)",
       "description": "Legend weight"
     },
     {

--- a/packages/css/src/components/forms/fieldset/index.scss
+++ b/packages/css/src/components/forms/fieldset/index.scss
@@ -23,7 +23,7 @@
     // @desc Legend size
     --_legend-size: var(--ui-fieldset-legend-size, var(--ui-font-size-sm, #{t.$font-size-sm}));
     // @desc Legend weight
-    --_legend-weight: var(--ui-fieldset-legend-weight, var(--ui-weight-medium, #{t.$weight-medium}));
+    --_legend-weight: var(--ui-fieldset-legend-weight, var(--ui-font-weight-medium, #{t.$font-weight-medium}));
     // @desc Legend color
     --_legend-color: var(--ui-fieldset-legend-color, var(--ui-color-text, #{t.$color-text}));
   }

--- a/packages/css/src/components/forms/label/index.scss
+++ b/packages/css/src/components/forms/label/index.scss
@@ -5,10 +5,10 @@
 
 @layer components.tokens {
   .label {
-    --_weight-medium: var(--ui-weight-medium, #{t.$weight-medium});
+    --_weight-medium: var(--ui-font-weight-medium, #{t.$font-weight-medium});
     --_leading-tight-sm: var(--ui-leading-tight-sm, var(--ui-row-1, #{t.$row-1}));
     --_opacity-disabled: var(--ui-opacity-disabled, #{t.$opacity-disabled});
-    --_weight-normal: var(--ui-weight-normal, #{t.$weight-normal});
+    --_weight-normal: var(--ui-font-weight-normal, #{t.$font-weight-normal});
     --_color-text-muted: var(--ui-color-text-muted, #{t.$color-text-muted});
     // @desc Font size
     --_font-size: var(--ui-label-font-size, var(--ui-font-size-sm, #{t.$font-size-sm}));

--- a/packages/css/src/components/forms/radio-group/api.json
+++ b/packages/css/src/components/forms/radio-group/api.json
@@ -31,7 +31,7 @@
     },
     {
       "name": "--ui-radio-group-legend-weight",
-      "default": "var(--ui-weight-medium)",
+      "default": "var(--ui-font-weight-medium)",
       "description": "Legend weight"
     },
     {

--- a/packages/css/src/components/forms/radio-group/index.scss
+++ b/packages/css/src/components/forms/radio-group/index.scss
@@ -14,7 +14,7 @@
     // @desc Legend size
     --_legend-size: var(--ui-radio-group-legend-size, var(--ui-font-size-sm, #{t.$font-size-sm}));
     // @desc Legend weight
-    --_legend-weight: var(--ui-radio-group-legend-weight, var(--ui-weight-medium, #{t.$weight-medium}));
+    --_legend-weight: var(--ui-radio-group-legend-weight, var(--ui-font-weight-medium, #{t.$font-weight-medium}));
     // @desc Legend color
     --_legend-color: var(--ui-radio-group-legend-color, var(--ui-color-text, #{t.$color-text}));
     // @desc Legend spacing

--- a/packages/css/src/components/navigation/menu/index.scss
+++ b/packages/css/src/components/navigation/menu/index.scss
@@ -9,7 +9,7 @@
   .menu {
     --_border-width-sm: var(--ui-border-width-sm, #{t.$border-width-sm});
     --_font-size-xs: var(--ui-font-size-xs, #{t.$font-size-xs});
-    --_weight-medium: var(--ui-weight-medium, #{t.$weight-medium});
+    --_weight-medium: var(--ui-font-weight-medium, #{t.$font-weight-medium});
     --_row-1: var(--ui-row-1, #{t.$row});
     --_color-text-muted: var(--ui-color-text-muted, #{t.$color-text-muted});
     --_font-size-sm: var(--ui-font-size-sm, #{t.$font-size-sm});

--- a/packages/css/src/components/navigation/nav/api.json
+++ b/packages/css/src/components/navigation/nav/api.json
@@ -46,7 +46,7 @@
     },
     {
       "name": "--ui-nav-item-font-weight",
-      "default": "var(--ui-weight-medium)",
+      "default": "var(--ui-font-weight-medium)",
       "description": "Item font weight"
     },
     {

--- a/packages/css/src/components/navigation/nav/index.scss
+++ b/packages/css/src/components/navigation/nav/index.scss
@@ -20,7 +20,7 @@
     // @desc Item font size
     --_item-font-size: var(--ui-nav-item-font-size, var(--ui-font-size-sm, #{t.$font-size-sm}));
     // @desc Item font weight
-    --_item-font-weight: var(--ui-nav-item-font-weight, var(--ui-weight-medium, #{t.$weight-medium}));
+    --_item-font-weight: var(--ui-nav-item-font-weight, var(--ui-font-weight-medium, #{t.$font-weight-medium}));
     // @desc Item text color
     --_item-color: var(--ui-nav-item-color, var(--ui-color-text-muted, #{t.$color-text-muted}));
     // @desc Item color hover

--- a/packages/css/src/components/navigation/tabs/index.scss
+++ b/packages/css/src/components/navigation/tabs/index.scss
@@ -8,7 +8,7 @@
     --_space-1: var(--ui-space-1, #{t.$space-1});
     --_border-width-sm: var(--ui-border-width-sm, #{t.$border-width-sm});
     --_font-sans: var(--ui-font-sans, #{t.$font-sans});
-    --_weight-medium: var(--ui-weight-medium, #{t.$weight-medium});
+    --_weight-medium: var(--ui-font-weight-medium, #{t.$font-weight-medium});
     --_color-text-muted: var(--ui-color-text-muted, #{t.$color-text-muted});
     --_border-width-md: var(--ui-border-width-md, #{t.$border-width-md});
     --_duration-base: var(--ui-duration-base, #{t.$duration-base});

--- a/packages/css/src/components/overlays/dialog/index.scss
+++ b/packages/css/src/components/overlays/dialog/index.scss
@@ -8,7 +8,7 @@
 @layer components.tokens {
   .dialog {
     --_font-size-lg: var(--ui-font-size-lg, #{t.$font-size-lg});
-    --_weight-semibold: var(--ui-weight-semibold, #{t.$weight-semibold});
+    --_weight-semibold: var(--ui-font-weight-semibold, #{t.$font-weight-semibold});
     // @desc Header padding on all sides
     --_header-padding: var(--ui-dialog-header-padding, calc(#{t.$unit} * 2) calc(#{t.$unit} * 3));
     // @desc Body area padding on all sides

--- a/packages/css/src/components/overlays/drawer/index.scss
+++ b/packages/css/src/components/overlays/drawer/index.scss
@@ -16,7 +16,7 @@
     --_ease-in: var(--ui-ease-in, ease-in);
     --_border-width-sm: var(--ui-border-width-sm, #{t.$border-width-sm});
     --_font-size-lg: var(--ui-font-size-lg, #{t.$font-size-lg});
-    --_weight-semibold: var(--ui-weight-semibold, #{t.$weight-semibold});
+    --_weight-semibold: var(--ui-font-weight-semibold, #{t.$font-weight-semibold});
     --_row-1: var(--ui-row-1, #{t.$row});
     --_font-size-sm: var(--ui-font-size-sm, #{t.$font-size-sm});
     --_color-text-muted: var(--ui-color-text-muted, #{t.$color-text-muted});

--- a/packages/css/src/components/overlays/popover/index.scss
+++ b/packages/css/src/components/overlays/popover/index.scss
@@ -10,7 +10,7 @@
     --_row-1: var(--ui-row-1, #{t.$row});
     --_border-width-sm: var(--ui-border-width-sm, #{t.$border-width-sm});
     --_font-size-md: var(--ui-font-size-md, #{t.$font-size-md});
-    --_weight-semibold: var(--ui-weight-semibold, #{t.$weight-semibold});
+    --_weight-semibold: var(--ui-font-weight-semibold, #{t.$font-weight-semibold});
     --_duration-fast: var(--ui-duration-fast, #{t.$duration-fast});
     --_ease-default: var(--ui-ease-default, ease);
     // @desc Background color

--- a/packages/css/src/components/typography/heading/api.json
+++ b/packages/css/src/components/typography/heading/api.json
@@ -20,7 +20,7 @@
     },
     {
       "name": "--ui-heading-weight",
-      "default": "var(--ui-weight-bold)",
+      "default": "var(--ui-font-weight-bold)",
       "description": "Weight"
     },
     {

--- a/packages/css/src/components/typography/heading/index.scss
+++ b/packages/css/src/components/typography/heading/index.scss
@@ -10,7 +10,7 @@
     // @desc Line height
     --_line-height: var(--ui-heading-line-height, var(--ui-leading-xl, #{t.$leading-xl}));
     // @desc Weight
-    --_weight: var(--ui-heading-weight, var(--ui-weight-bold, #{t.$weight-bold}));
+    --_weight: var(--ui-heading-weight, var(--ui-font-weight-bold, #{t.$font-weight-bold}));
     // @desc Text color
     --_color: var(--ui-heading-color, var(--ui-color-text, #{t.$color-text}));
   }

--- a/packages/css/src/config/tokens/_variables.scss
+++ b/packages/css/src/config/tokens/_variables.scss
@@ -128,10 +128,10 @@ $leading-3xl: $unit * 5;
 $leading-4xl: $unit * 6;
 
 // Font weights
-$weight-normal: 400;
-$weight-medium: 500;
-$weight-semibold: 600;
-$weight-bold: 700;
+$font-weight-normal: 400;
+$font-weight-medium: 500;
+$font-weight-semibold: 600;
+$font-weight-bold: 700;
 
 // Letter spacing
 $tracking-display: -0.02em;

--- a/packages/css/src/config/tokens/typography.scss
+++ b/packages/css/src/config/tokens/typography.scss
@@ -41,10 +41,10 @@
     // ==========================================================================
     // PRIMITIVE TOKENS - Font Weights
     // ==========================================================================
-    --ui-weight-normal: 400;
-    --ui-weight-medium: 500;
-    --ui-weight-semibold: 600;
-    --ui-weight-bold: 700;
+    --ui-font-weight-normal: 400;
+    --ui-font-weight-medium: 500;
+    --ui-font-weight-semibold: 600;
+    --ui-font-weight-bold: 700;
 
     // ==========================================================================
     // PRIMITIVE TOKENS - Letter Spacing
@@ -60,61 +60,61 @@
     // Heading 1
     --ui-heading-1-size: var(--ui-font-size-4xl);
     --ui-heading-1-line-height: var(--ui-leading-4xl);
-    --ui-heading-1-weight: var(--ui-weight-bold);
+    --ui-heading-1-weight: var(--ui-font-weight-bold);
     --ui-heading-1-tracking: var(--ui-tracking-display);
 
     // Heading 2
     --ui-heading-2-size: var(--ui-font-size-3xl);
     --ui-heading-2-line-height: var(--ui-leading-3xl);
-    --ui-heading-2-weight: var(--ui-weight-bold);
+    --ui-heading-2-weight: var(--ui-font-weight-bold);
     --ui-heading-2-tracking: -0.01em;
 
     // Heading 3
     --ui-heading-3-size: var(--ui-font-size-2xl);
     --ui-heading-3-line-height: var(--ui-leading-2xl);
-    --ui-heading-3-weight: var(--ui-weight-semibold);
+    --ui-heading-3-weight: var(--ui-font-weight-semibold);
     --ui-heading-3-tracking: var(--ui-tracking-body);
 
     // Heading 4
     --ui-heading-4-size: var(--ui-font-size-xl);
     --ui-heading-4-line-height: var(--ui-leading-xl);
-    --ui-heading-4-weight: var(--ui-weight-semibold);
+    --ui-heading-4-weight: var(--ui-font-weight-semibold);
     --ui-heading-4-tracking: var(--ui-tracking-body);
 
     // Heading 5
     --ui-heading-5-size: var(--ui-font-size-lg);
     --ui-heading-5-line-height: var(--ui-leading-sm);
-    --ui-heading-5-weight: var(--ui-weight-medium);
+    --ui-heading-5-weight: var(--ui-font-weight-medium);
     --ui-heading-5-tracking: var(--ui-tracking-body);
 
     // Body
     --ui-body-size: var(--ui-font-size-md);
     --ui-body-line-height: var(--ui-leading-md);
-    --ui-body-weight: var(--ui-weight-normal);
+    --ui-body-weight: var(--ui-font-weight-normal);
     --ui-body-tracking: var(--ui-tracking-body);
 
     // Body Small
     --ui-body-sm-size: var(--ui-font-size-sm);
     --ui-body-sm-line-height: var(--ui-leading-sm);
-    --ui-body-sm-weight: var(--ui-weight-normal);
+    --ui-body-sm-weight: var(--ui-font-weight-normal);
     --ui-body-sm-tracking: var(--ui-tracking-body);
 
     // Caption
     --ui-caption-size: var(--ui-font-size-xs);
     --ui-caption-line-height: var(--ui-leading-xs);
-    --ui-caption-weight: var(--ui-weight-normal);
+    --ui-caption-weight: var(--ui-font-weight-normal);
     --ui-caption-tracking: 0.01em;
 
     // Lead
     --ui-lead-size: var(--ui-font-size-lg);
     --ui-lead-line-height: var(--ui-leading-lg);
-    --ui-lead-weight: var(--ui-weight-normal);
+    --ui-lead-weight: var(--ui-font-weight-normal);
     --ui-lead-tracking: var(--ui-tracking-body);
 
     // Eyebrow
     --ui-eyebrow-size: var(--ui-font-size-xs);
     --ui-eyebrow-line-height: var(--ui-leading-xs);
-    --ui-eyebrow-weight: var(--ui-weight-semibold);
+    --ui-eyebrow-weight: var(--ui-font-weight-semibold);
     --ui-eyebrow-tracking: var(--ui-tracking-caps);
   }
 }

--- a/packages/css/src/layout/sidebar-nav/api.json
+++ b/packages/css/src/layout/sidebar-nav/api.json
@@ -76,7 +76,7 @@
     },
     {
       "name": "--ui-sidebar-nav-group-label-weight",
-      "default": "var(--ui-weight-bold)",
+      "default": "var(--ui-font-weight-bold)",
       "description": "Group label weight"
     },
     {
@@ -126,7 +126,7 @@
     },
     {
       "name": "--ui-sidebar-nav-item-active-weight",
-      "default": "var(--ui-weight-medium)",
+      "default": "var(--ui-font-weight-medium)",
       "description": "Item active weight"
     },
     {

--- a/packages/css/src/layout/sidebar-nav/index.scss
+++ b/packages/css/src/layout/sidebar-nav/index.scss
@@ -12,7 +12,7 @@
     --_space-1: var(--ui-space-1);
     --_space-half: var(--ui-space-half);
     --_size-xs: var(--ui-size-xs);
-    --_weight-medium: var(--ui-weight-medium);
+    --_weight-medium: var(--ui-font-weight-medium);
     --_color-text-muted: var(--ui-color-text-muted);
     --_duration-fast: var(--ui-duration-fast);
     --_easing-default: var(--ui-easing-default);
@@ -83,7 +83,7 @@
     // @desc Group label color
     --_color: var(--ui-sidebar-nav-group-label-color, var(--ui-color-text-muted));
     // @desc Group label weight
-    --_weight: var(--ui-sidebar-nav-group-label-weight, var(--ui-weight-bold));
+    --_weight: var(--ui-sidebar-nav-group-label-weight, var(--ui-font-weight-bold));
 
     display: block;
 
@@ -191,7 +191,7 @@
     // @desc Item active color
     --_color: var(--ui-sidebar-nav-item-active-color, var(--ui-color-primary-hover));
     // @desc Item active weight
-    --_weight: var(--ui-sidebar-nav-item-active-weight, var(--ui-weight-medium));
+    --_weight: var(--ui-sidebar-nav-item-active-weight, var(--ui-font-weight-medium));
   }
 
   // Nested item indent

--- a/packages/css/src/utilities/text/text.scss
+++ b/packages/css/src/utilities/text/text.scss
@@ -25,19 +25,19 @@
   // FONT WEIGHT
   // ==========================================================================
   .font-normal {
-    font-weight: var(--ui-weight-normal);
+    font-weight: var(--ui-font-weight-normal);
   }
 
   .font-medium {
-    font-weight: var(--ui-weight-medium);
+    font-weight: var(--ui-font-weight-medium);
   }
 
   .font-semibold {
-    font-weight: var(--ui-weight-semibold);
+    font-weight: var(--ui-font-weight-semibold);
   }
 
   .font-bold {
-    font-weight: var(--ui-weight-bold);
+    font-weight: var(--ui-font-weight-bold);
   }
 
   // ==========================================================================

--- a/scripts/lint-components.ts
+++ b/scripts/lint-components.ts
@@ -629,6 +629,51 @@ function lintI18nCoverage(): void {
   }
 }
 
+function lintBannedTokenNames(): void {
+  const srcDir = join(__dirname, '../packages/css/src');
+  const errors: string[] = [];
+
+  // Banned patterns: old token names that have been renamed
+  const bannedPatterns: { pattern: RegExp; message: string }[] = [
+    {
+      pattern: /--ui-weight-(?:normal|medium|semibold|bold)/g,
+      message: 'use --ui-font-weight-* instead of --ui-weight-*',
+    },
+    {
+      pattern: /\$weight-(?:normal|medium|semibold|bold)/g,
+      message: 'use $font-weight-* instead of $weight-*',
+    },
+  ];
+
+  const allFiles = [...findScssFiles(srcDir), ...findScssFiles(join(__dirname, '../apps'))];
+
+  for (const file of allFiles) {
+    const content = readFileSync(file, 'utf-8');
+    const relPath = file.replace(`${join(__dirname, '..')}/`, '');
+
+    for (const { pattern, message } of bannedPatterns) {
+      pattern.lastIndex = 0;
+      for (let match = pattern.exec(content); match !== null; match = pattern.exec(content)) {
+        const line = content.substring(0, match.index).split('\n').length;
+        errors.push(`${relPath}:${line}: "${match[0]}" is banned — ${message}`);
+      }
+    }
+  }
+
+  if (errors.length > 0) {
+    console.error('Banned token names check failed:\n');
+    for (const err of errors) {
+      console.error(`  - ${err}`);
+    }
+    console.error(
+      `\n${errors.length} banned token name(s) found. See naming dictionary for allowed names.`,
+    );
+    process.exit(1);
+  }
+
+  console.log(`Banned token names: ${allFiles.length} SCSS files passed.`);
+}
+
 lintComponents();
 lintSidenavCompleteness();
 lintDocsContent();
@@ -637,5 +682,6 @@ lintBareTokenVars();
 lintWrongLayerTokens();
 lintStyleLayerTokens();
 lintTokenNames();
+lintBannedTokenNames();
 lintApiSync();
 lintI18nCoverage();


### PR DESCRIPTION
## Summary
- Rename `--ui-weight-normal/medium/semibold/bold` to `--ui-font-weight-*` for CSS property name consistency
- Rename SCSS vars `$weight-*` to `$font-weight-*` across all 37 files
- Add `lintBannedTokenNames()` rule to `lint-components.ts` — rejects old `--ui-weight-*` and `$weight-*` patterns

Clean break — no deprecated aliases. Old names removed entirely.

Closes #383

## Test plan
- [x] `pnpm lint` passes (including new banned-names check)
- [x] `pnpm typecheck` passes
- [x] `pnpm test:unit` passes (96 tests)
- [ ] CI visual regression (no visual change expected — values identical)