### PR TITLE
Rename --ui-leading-* to --ui-line-height-* tokens

### DIFF
--- a/.changeset/rename-leading-to-line-height.md
+++ b/.changeset/rename-leading-to-line-height.md
@@ -1,0 +1,5 @@
+---
+"@teseor/css": major
+---
+
+Rename --ui-leading-* tokens to --ui-line-height-* for CSS property name consistency. Clean break — old names removed entirely. Add banned-token-names lint rule to prevent regression.

--- a/packages/css/src/base/docs.html
+++ b/packages/css/src/base/docs.html
@@ -13,7 +13,7 @@ skipValidation: true
 .ui-root {
   font-family: var(--ui-font-sans);
   font-size: var(--ui-font-size-md);
-  line-height: var(--ui-leading-md);
+  line-height: var(--ui-line-height-md);
   color: var(--ui-color-text);
   background: var(--ui-color-bg);
 }

--- a/packages/css/src/base/root.scss
+++ b/packages/css/src/base/root.scss
@@ -4,7 +4,7 @@
   .root {
     font-family: var(--ui-font-sans, #{t.$font-sans});
     font-size: var(--ui-font-size-md, #{t.$font-size-md});
-    line-height: var(--ui-leading-md, calc(#{t.$unit} * 3));
+    line-height: var(--ui-line-height-md, calc(#{t.$unit} * 3));
     color: var(--ui-color-text, #{t.$color-text});
 
     background: var(--ui-color-bg, #{t.$color-bg});

--- a/packages/css/src/base/typography/typography.scss
+++ b/packages/css/src/base/typography/typography.scss
@@ -127,22 +127,22 @@
   @media (width < 45.625rem) {
     h1 {
       font-size: var(--ui-font-size-2xl); // 28px
-      line-height: var(--ui-leading-2xl); // 32px
+      line-height: var(--ui-line-height-2xl); // 32px
     }
 
     h2 {
       font-size: var(--ui-font-size-xl); // 24px
-      line-height: var(--ui-leading-xl); // 32px
+      line-height: var(--ui-line-height-xl); // 32px
     }
 
     h3 {
       font-size: var(--ui-font-size-lg); // 20px
-      line-height: var(--ui-leading-sm); // 24px
+      line-height: var(--ui-line-height-sm); // 24px
     }
 
     h4 {
       font-size: 1.125rem; // 18px
-      line-height: var(--ui-leading-sm); // 24px
+      line-height: var(--ui-line-height-sm); // 24px
     }
   }
 
@@ -155,7 +155,7 @@
 
     h2 {
       font-size: var(--ui-font-size-4xl); // 40px
-      line-height: var(--ui-leading-4xl); // 48px
+      line-height: var(--ui-line-height-4xl); // 48px
     }
   }
 }

--- a/packages/css/src/components/data-display/stat/api.json
+++ b/packages/css/src/components/data-display/stat/api.json
@@ -29,7 +29,7 @@
     },
     {
       "name": "--ui-stat-value-line-height",
-      "default": "var(--ui-leading-3xl)",
+      "default": "var(--ui-line-height-3xl)",
       "description": "Value display line height"
     },
     {
@@ -49,7 +49,7 @@
     },
     {
       "name": "--ui-stat-label-line-height",
-      "default": "var(--ui-leading-sm)",
+      "default": "var(--ui-line-height-sm)",
       "description": "Label line height"
     }
   ]

--- a/packages/css/src/components/data-display/stat/index.scss
+++ b/packages/css/src/components/data-display/stat/index.scss
@@ -15,7 +15,7 @@
     // @desc Value display font weight
     --_font-weight: var(--ui-stat-value-font-weight, var(--ui-font-weight-bold, #{t.$font-weight-bold}));
     // @desc Value display line height
-    --_line-height: var(--ui-stat-value-line-height, var(--ui-leading-3xl, #{t.$leading-3xl}));
+    --_line-height: var(--ui-stat-value-line-height, var(--ui-line-height-3xl, #{t.$line-height-3xl}));
     // @desc Value display text color
     --_color: var(--ui-stat-value-color, var(--ui-color-text, #{t.$color-text}));
   }
@@ -26,13 +26,13 @@
     // @desc Label text color
     --_color: var(--ui-stat-label-color, var(--ui-color-text-muted, #{t.$color-text-muted}));
     // @desc Label line height
-    --_line-height: var(--ui-stat-label-line-height, var(--ui-leading-sm, #{t.$leading-sm}));
+    --_line-height: var(--ui-stat-label-line-height, var(--ui-line-height-sm, #{t.$line-height-sm}));
   }
 
   // @modifier size
   .stat--sm .stat__value {
     --_font-size: var(--ui-font-size-xl, #{t.$font-size-xl});
-    --_line-height: var(--ui-leading-xl, #{t.$leading-xl});
+    --_line-height: var(--ui-line-height-xl, #{t.$line-height-xl});
   }
 }
 

--- a/packages/css/src/components/forms/checkbox-group/index.scss
+++ b/packages/css/src/components/forms/checkbox-group/index.scss
@@ -5,7 +5,7 @@
 
 @layer components.tokens {
   .checkbox-group {
-    --_leading-tight-sm: var(--ui-leading-tight-sm, var(--ui-row-1, #{t.$leading-tight-sm}));
+    --_leading-tight-sm: var(--ui-line-height-tight-sm, var(--ui-row-1, #{t.$line-height-tight-sm}));
     --_row-1: var(--ui-row-1, #{t.$row-1});
     --_opacity-disabled: var(--ui-opacity-disabled, #{t.$opacity-disabled});
     --_space-2: var(--ui-space-2, #{t.$space-2});

--- a/packages/css/src/components/forms/fieldset/index.scss
+++ b/packages/css/src/components/forms/fieldset/index.scss
@@ -7,7 +7,7 @@
 
 @layer components.tokens {
   .fieldset {
-    --_leading-tight-sm: var(--ui-leading-tight-sm, var(--ui-row-1, #{t.$leading-tight-sm}));
+    --_leading-tight-sm: var(--ui-line-height-tight-sm, var(--ui-row-1, #{t.$line-height-tight-sm}));
     --_space-half: var(--ui-space-half, #{t.$space-0});
     --_opacity-disabled: var(--ui-opacity-disabled, #{t.$opacity-disabled});
     // @desc Spacing

--- a/packages/css/src/components/forms/form-error/index.scss
+++ b/packages/css/src/components/forms/form-error/index.scss
@@ -7,7 +7,7 @@
 
 @layer components.tokens {
   .form-error {
-    --_leading-tight-sm: var(--ui-leading-tight-sm, var(--ui-row-1, #{t.$row-1}));
+    --_leading-tight-sm: var(--ui-line-height-tight-sm, var(--ui-row-1, #{t.$row-1}));
     // @desc Text color
     --_color: var(--ui-form-error-color, var(--ui-color-danger, #{t.$color-danger}));
     // @desc Overall size

--- a/packages/css/src/components/forms/form-helper/index.scss
+++ b/packages/css/src/components/forms/form-helper/index.scss
@@ -7,7 +7,7 @@
 
 @layer components.tokens {
   .form-helper {
-    --_leading-tight-sm: var(--ui-leading-tight-sm, var(--ui-row-1, #{t.$row-1}));
+    --_leading-tight-sm: var(--ui-line-height-tight-sm, var(--ui-row-1, #{t.$row-1}));
     // @desc Text color
     --_color: var(--ui-form-helper-color, var(--ui-color-text-muted, #{t.$color-text-muted}));
     // @desc Overall size

--- a/packages/css/src/components/forms/label/index.scss
+++ b/packages/css/src/components/forms/label/index.scss
@@ -6,7 +6,7 @@
 @layer components.tokens {
   .label {
     --_weight-medium: var(--ui-font-weight-medium, #{t.$font-weight-medium});
-    --_leading-tight-sm: var(--ui-leading-tight-sm, var(--ui-row-1, #{t.$row-1}));
+    --_leading-tight-sm: var(--ui-line-height-tight-sm, var(--ui-row-1, #{t.$row-1}));
     --_opacity-disabled: var(--ui-opacity-disabled, #{t.$opacity-disabled});
     --_weight-normal: var(--ui-font-weight-normal, #{t.$font-weight-normal});
     --_color-text-muted: var(--ui-color-text-muted, #{t.$color-text-muted});

--- a/packages/css/src/components/forms/radio-group/index.scss
+++ b/packages/css/src/components/forms/radio-group/index.scss
@@ -5,7 +5,7 @@
 
 @layer components.tokens {
   .radio-group {
-    --_leading-tight-sm: var(--ui-leading-tight-sm, var(--ui-row-1, #{t.$leading-tight-sm}));
+    --_leading-tight-sm: var(--ui-line-height-tight-sm, var(--ui-row-1, #{t.$line-height-tight-sm}));
     --_row-1: var(--ui-row-1, #{t.$row-1});
     --_opacity-disabled: var(--ui-opacity-disabled, #{t.$opacity-disabled});
     --_space-2: var(--ui-space-2, #{t.$space-2});

--- a/packages/css/src/components/typography/blockquote/api.json
+++ b/packages/css/src/components/typography/blockquote/api.json
@@ -38,7 +38,7 @@
     },
     {
       "name": "--ui-blockquote-line-height",
-      "default": "var(--ui-leading-lg)",
+      "default": "var(--ui-line-height-lg)",
       "description": "Line height"
     }
   ]

--- a/packages/css/src/components/typography/blockquote/index.scss
+++ b/packages/css/src/components/typography/blockquote/index.scss
@@ -6,7 +6,7 @@
   .blockquote {
     --_space-1: var(--ui-space-1, #{t.$space-1});
     --_font-size-sm: var(--ui-font-size-sm, #{t.$font-size-sm});
-    --_leading-sm: var(--ui-leading-sm, #{t.$leading-sm});
+    --_leading-sm: var(--ui-line-height-sm, #{t.$line-height-sm});
     --_color-text-muted: var(--ui-color-text-muted, #{t.$color-text-muted});
     // @desc Border color
     --_border-color: var(--ui-blockquote-border-color, var(--ui-color-border-strong, #{t.$color-border-strong}));
@@ -19,7 +19,7 @@
     // @desc Font size
     --_font-size: var(--ui-blockquote-font-size, var(--ui-font-size-lg, #{t.$font-size-lg}));
     // @desc Line height
-    --_line-height: var(--ui-blockquote-line-height, var(--ui-leading-lg, #{t.$leading-lg}));
+    --_line-height: var(--ui-blockquote-line-height, var(--ui-line-height-lg, #{t.$line-height-lg}));
   }
 
   // @modifier variant

--- a/packages/css/src/components/typography/code-block/api.json
+++ b/packages/css/src/components/typography/code-block/api.json
@@ -48,7 +48,7 @@
     },
     {
       "name": "--ui-code-block-line-height",
-      "default": "var(--ui-leading-tight-sm)",
+      "default": "var(--ui-line-height-tight-sm)",
       "description": "Line height"
     },
     {

--- a/packages/css/src/components/typography/code-block/index.scss
+++ b/packages/css/src/components/typography/code-block/index.scss
@@ -21,7 +21,7 @@
     // @desc Font size
     --_font-size: var(--ui-code-block-font-size, var(--ui-font-size-sm, #{t.$font-size-sm}));
     // @desc Line height
-    --_line-height: var(--ui-code-block-line-height, var(--ui-leading-tight-sm, #{t.$leading-tight-sm}));
+    --_line-height: var(--ui-code-block-line-height, var(--ui-line-height-tight-sm, #{t.$line-height-tight-sm}));
     // @desc Corner radius
     --_radius: var(--ui-code-block-radius, var(--ui-radius-md, #{t.$radius-md}));
   }

--- a/packages/css/src/components/typography/code/index.scss
+++ b/packages/css/src/components/typography/code/index.scss
@@ -8,7 +8,7 @@
   // Inline code
   .code {
     --_font-mono: var(--ui-font-mono, #{t.$font-mono});
-    --_leading-tight-sm: var(--ui-leading-tight-sm, #{t.$leading-tight-sm});
+    --_leading-tight-sm: var(--ui-line-height-tight-sm, #{t.$line-height-tight-sm});
     --_border-width-sm: var(--ui-border-width-sm, #{t.$border-width-sm});
     // @desc Font size
     --_font-size: var(--ui-code-font-size, var(--ui-font-size-sm, #{t.$font-size-sm}));

--- a/packages/css/src/components/typography/heading/api.json
+++ b/packages/css/src/components/typography/heading/api.json
@@ -15,7 +15,7 @@
     },
     {
       "name": "--ui-heading-line-height",
-      "default": "var(--ui-leading-xl)",
+      "default": "var(--ui-line-height-xl)",
       "description": "Line height"
     },
     {
@@ -35,7 +35,7 @@
     },
     {
       "name": "--ui-heading-line-height-4xl",
-      "default": "var(--ui-leading-4xl)",
+      "default": "var(--ui-line-height-4xl)",
       "description": "Line height 4xl"
     },
     {
@@ -45,7 +45,7 @@
     },
     {
       "name": "--ui-heading-line-height-3xl",
-      "default": "var(--ui-leading-3xl)",
+      "default": "var(--ui-line-height-3xl)",
       "description": "Line height 3xl"
     },
     {
@@ -55,7 +55,7 @@
     },
     {
       "name": "--ui-heading-line-height-2xl",
-      "default": "var(--ui-leading-2xl)",
+      "default": "var(--ui-line-height-2xl)",
       "description": "Line height 2xl"
     },
     {
@@ -65,7 +65,7 @@
     },
     {
       "name": "--ui-heading-line-height-xl",
-      "default": "var(--ui-leading-xl)",
+      "default": "var(--ui-line-height-xl)",
       "description": "Line height at extra-large size"
     },
     {
@@ -75,7 +75,7 @@
     },
     {
       "name": "--ui-heading-line-height-lg",
-      "default": "var(--ui-leading-lg)",
+      "default": "var(--ui-line-height-lg)",
       "description": "Line height at large size"
     },
     {
@@ -85,7 +85,7 @@
     },
     {
       "name": "--ui-heading-line-height-md",
-      "default": "var(--ui-leading-tight-md)",
+      "default": "var(--ui-line-height-tight-md)",
       "description": "Line height at medium size"
     },
     {
@@ -95,7 +95,7 @@
     },
     {
       "name": "--ui-heading-line-height-sm",
-      "default": "var(--ui-leading-tight-sm)",
+      "default": "var(--ui-line-height-tight-sm)",
       "description": "Line height at small size"
     }
   ]

--- a/packages/css/src/components/typography/heading/index.scss
+++ b/packages/css/src/components/typography/heading/index.scss
@@ -8,7 +8,7 @@
     // @desc Font size
     --_font-size: var(--ui-heading-font-size, var(--ui-font-size-xl, #{t.$font-size-xl}));
     // @desc Line height
-    --_line-height: var(--ui-heading-line-height, var(--ui-leading-xl, #{t.$leading-xl}));
+    --_line-height: var(--ui-heading-line-height, var(--ui-line-height-xl, #{t.$line-height-xl}));
     // @desc Weight
     --_weight: var(--ui-heading-weight, var(--ui-font-weight-bold, #{t.$font-weight-bold}));
     // @desc Text color
@@ -20,49 +20,49 @@
     // @desc Font size 4xl
     --_font-size: var(--ui-heading-font-size-4xl, var(--ui-font-size-4xl, #{t.$font-size-4xl}));
     // @desc Line height 4xl
-    --_line-height: var(--ui-heading-line-height-4xl, var(--ui-leading-4xl, #{t.$leading-4xl}));
+    --_line-height: var(--ui-heading-line-height-4xl, var(--ui-line-height-4xl, #{t.$line-height-4xl}));
   }
 
   .heading--3xl {
     // @desc Font size 3xl
     --_font-size: var(--ui-heading-font-size-3xl, var(--ui-font-size-3xl, #{t.$font-size-3xl}));
     // @desc Line height 3xl
-    --_line-height: var(--ui-heading-line-height-3xl, var(--ui-leading-3xl, #{t.$leading-3xl}));
+    --_line-height: var(--ui-heading-line-height-3xl, var(--ui-line-height-3xl, #{t.$line-height-3xl}));
   }
 
   .heading--2xl {
     // @desc Font size 2xl
     --_font-size: var(--ui-heading-font-size-2xl, var(--ui-font-size-2xl, #{t.$font-size-2xl}));
     // @desc Line height 2xl
-    --_line-height: var(--ui-heading-line-height-2xl, var(--ui-leading-2xl, #{t.$leading-2xl}));
+    --_line-height: var(--ui-heading-line-height-2xl, var(--ui-line-height-2xl, #{t.$line-height-2xl}));
   }
 
   .heading--xl {
     // @desc Font size at extra-large size
     --_font-size: var(--ui-heading-font-size-xl, var(--ui-font-size-xl, #{t.$font-size-xl}));
     // @desc Line height at extra-large size
-    --_line-height: var(--ui-heading-line-height-xl, var(--ui-leading-xl, #{t.$leading-xl}));
+    --_line-height: var(--ui-heading-line-height-xl, var(--ui-line-height-xl, #{t.$line-height-xl}));
   }
 
   .heading--lg {
     // @desc Font size at large size
     --_font-size: var(--ui-heading-font-size-lg, var(--ui-font-size-lg, #{t.$font-size-lg}));
     // @desc Line height at large size
-    --_line-height: var(--ui-heading-line-height-lg, var(--ui-leading-lg, #{t.$leading-lg}));
+    --_line-height: var(--ui-heading-line-height-lg, var(--ui-line-height-lg, #{t.$line-height-lg}));
   }
 
   .heading--md {
     // @desc Font size at medium size
     --_font-size: var(--ui-heading-font-size-md, var(--ui-font-size-md, #{t.$font-size-md}));
     // @desc Line height at medium size
-    --_line-height: var(--ui-heading-line-height-md, var(--ui-leading-tight-md, #{t.$leading-tight-md}));
+    --_line-height: var(--ui-heading-line-height-md, var(--ui-line-height-tight-md, #{t.$line-height-tight-md}));
   }
 
   .heading--sm {
     // @desc Font size at small size
     --_font-size: var(--ui-heading-font-size-sm, var(--ui-font-size-sm, #{t.$font-size-sm}));
     // @desc Line height at small size
-    --_line-height: var(--ui-heading-line-height-sm, var(--ui-leading-tight-sm, #{t.$leading-tight-sm}));
+    --_line-height: var(--ui-heading-line-height-sm, var(--ui-line-height-tight-sm, #{t.$line-height-tight-sm}));
   }
 
 }

--- a/packages/css/src/components/typography/list/api.json
+++ b/packages/css/src/components/typography/list/api.json
@@ -31,7 +31,7 @@
     },
     {
       "name": "--ui-list-line-height",
-      "default": "var(--ui-leading-md)",
+      "default": "var(--ui-line-height-md)",
       "description": "Line height"
     }
   ]

--- a/packages/css/src/components/typography/list/index.scss
+++ b/packages/css/src/components/typography/list/index.scss
@@ -13,7 +13,7 @@
     // @desc Indent
     --_indent: var(--ui-list-indent, var(--ui-space-3, #{t.$space-3}));
     // @desc Line height
-    --_line-height: var(--ui-list-line-height, var(--ui-leading-md, #{t.$leading-md}));
+    --_line-height: var(--ui-list-line-height, var(--ui-line-height-md, #{t.$line-height-md}));
   }
 
   // @modifier spacing

--- a/packages/css/src/config/tokens/_variables.scss
+++ b/packages/css/src/config/tokens/_variables.scss
@@ -112,20 +112,20 @@ $font-size-3xl: 2rem; // 32px
 $font-size-4xl: 2.5rem; // 40px
 
 // Tight line heights (compact UI elements)
-$leading-tight-xs: $row;
-$leading-tight-sm: $row;
-$leading-tight-md: $unit * 3;
-$leading-tight-lg: $unit * 3;
+$line-height-tight-xs: $row;
+$line-height-tight-sm: $row;
+$line-height-tight-md: $unit * 3;
+$line-height-tight-lg: $unit * 3;
 
 // Normal line heights (body text)
-$leading-xs: $row;
-$leading-sm: $unit * 3;
-$leading-md: $unit * 3;
-$leading-lg: $row-2;
-$leading-xl: $row-2;
-$leading-2xl: $row-2;
-$leading-3xl: $unit * 5;
-$leading-4xl: $unit * 6;
+$line-height-xs: $row;
+$line-height-sm: $unit * 3;
+$line-height-md: $unit * 3;
+$line-height-lg: $row-2;
+$line-height-xl: $row-2;
+$line-height-2xl: $row-2;
+$line-height-3xl: $unit * 5;
+$line-height-4xl: $unit * 6;
 
 // Font weights
 $font-weight-normal: 400;

--- a/packages/css/src/config/tokens/typography.scss
+++ b/packages/css/src/config/tokens/typography.scss
@@ -23,20 +23,20 @@
     // ==========================================================================
 
     // Tight line-heights for compact UI elements
-    --ui-leading-tight-xs: var(--ui-row-1);
-    --ui-leading-tight-sm: var(--ui-row-1);
-    --ui-leading-tight-md: calc(var(--ui-unit) * 3);
-    --ui-leading-tight-lg: calc(var(--ui-unit) * 3);
+    --ui-line-height-tight-xs: var(--ui-row-1);
+    --ui-line-height-tight-sm: var(--ui-row-1);
+    --ui-line-height-tight-md: calc(var(--ui-unit) * 3);
+    --ui-line-height-tight-lg: calc(var(--ui-unit) * 3);
 
     // Normal line-heights for readable body text
-    --ui-leading-xs: var(--ui-row-1);
-    --ui-leading-sm: calc(var(--ui-unit) * 3);
-    --ui-leading-md: calc(var(--ui-unit) * 3);
-    --ui-leading-lg: var(--ui-row-2);
-    --ui-leading-xl: var(--ui-row-2);
-    --ui-leading-2xl: var(--ui-row-2);
-    --ui-leading-3xl: calc(var(--ui-unit) * 5);
-    --ui-leading-4xl: calc(var(--ui-unit) * 6);
+    --ui-line-height-xs: var(--ui-row-1);
+    --ui-line-height-sm: calc(var(--ui-unit) * 3);
+    --ui-line-height-md: calc(var(--ui-unit) * 3);
+    --ui-line-height-lg: var(--ui-row-2);
+    --ui-line-height-xl: var(--ui-row-2);
+    --ui-line-height-2xl: var(--ui-row-2);
+    --ui-line-height-3xl: calc(var(--ui-unit) * 5);
+    --ui-line-height-4xl: calc(var(--ui-unit) * 6);
 
     // ==========================================================================
     // PRIMITIVE TOKENS - Font Weights
@@ -59,61 +59,61 @@
 
     // Heading 1
     --ui-heading-1-size: var(--ui-font-size-4xl);
-    --ui-heading-1-line-height: var(--ui-leading-4xl);
+    --ui-heading-1-line-height: var(--ui-line-height-4xl);
     --ui-heading-1-weight: var(--ui-font-weight-bold);
     --ui-heading-1-tracking: var(--ui-tracking-display);
 
     // Heading 2
     --ui-heading-2-size: var(--ui-font-size-3xl);
-    --ui-heading-2-line-height: var(--ui-leading-3xl);
+    --ui-heading-2-line-height: var(--ui-line-height-3xl);
     --ui-heading-2-weight: var(--ui-font-weight-bold);
     --ui-heading-2-tracking: -0.01em;
 
     // Heading 3
     --ui-heading-3-size: var(--ui-font-size-2xl);
-    --ui-heading-3-line-height: var(--ui-leading-2xl);
+    --ui-heading-3-line-height: var(--ui-line-height-2xl);
     --ui-heading-3-weight: var(--ui-font-weight-semibold);
     --ui-heading-3-tracking: var(--ui-tracking-body);
 
     // Heading 4
     --ui-heading-4-size: var(--ui-font-size-xl);
-    --ui-heading-4-line-height: var(--ui-leading-xl);
+    --ui-heading-4-line-height: var(--ui-line-height-xl);
     --ui-heading-4-weight: var(--ui-font-weight-semibold);
     --ui-heading-4-tracking: var(--ui-tracking-body);
 
     // Heading 5
     --ui-heading-5-size: var(--ui-font-size-lg);
-    --ui-heading-5-line-height: var(--ui-leading-sm);
+    --ui-heading-5-line-height: var(--ui-line-height-sm);
     --ui-heading-5-weight: var(--ui-font-weight-medium);
     --ui-heading-5-tracking: var(--ui-tracking-body);
 
     // Body
     --ui-body-size: var(--ui-font-size-md);
-    --ui-body-line-height: var(--ui-leading-md);
+    --ui-body-line-height: var(--ui-line-height-md);
     --ui-body-weight: var(--ui-font-weight-normal);
     --ui-body-tracking: var(--ui-tracking-body);
 
     // Body Small
     --ui-body-sm-size: var(--ui-font-size-sm);
-    --ui-body-sm-line-height: var(--ui-leading-sm);
+    --ui-body-sm-line-height: var(--ui-line-height-sm);
     --ui-body-sm-weight: var(--ui-font-weight-normal);
     --ui-body-sm-tracking: var(--ui-tracking-body);
 
     // Caption
     --ui-caption-size: var(--ui-font-size-xs);
-    --ui-caption-line-height: var(--ui-leading-xs);
+    --ui-caption-line-height: var(--ui-line-height-xs);
     --ui-caption-weight: var(--ui-font-weight-normal);
     --ui-caption-tracking: 0.01em;
 
     // Lead
     --ui-lead-size: var(--ui-font-size-lg);
-    --ui-lead-line-height: var(--ui-leading-lg);
+    --ui-lead-line-height: var(--ui-line-height-lg);
     --ui-lead-weight: var(--ui-font-weight-normal);
     --ui-lead-tracking: var(--ui-tracking-body);
 
     // Eyebrow
     --ui-eyebrow-size: var(--ui-font-size-xs);
-    --ui-eyebrow-line-height: var(--ui-leading-xs);
+    --ui-eyebrow-line-height: var(--ui-line-height-xs);
     --ui-eyebrow-weight: var(--ui-font-weight-semibold);
     --ui-eyebrow-tracking: var(--ui-tracking-caps);
   }

--- a/packages/css/src/utilities/text/text.scss
+++ b/packages/css/src/utilities/text/text.scss
@@ -45,42 +45,42 @@
   // ==========================================================================
   .text-xs {
     font-size: var(--ui-font-size-xs);
-    line-height: var(--ui-leading-xs);
+    line-height: var(--ui-line-height-xs);
   }
 
   .text-sm {
     font-size: var(--ui-font-size-sm);
-    line-height: var(--ui-leading-sm);
+    line-height: var(--ui-line-height-sm);
   }
 
   .text-md {
     font-size: var(--ui-font-size-md);
-    line-height: var(--ui-leading-md);
+    line-height: var(--ui-line-height-md);
   }
 
   .text-lg {
     font-size: var(--ui-font-size-lg);
-    line-height: var(--ui-leading-lg);
+    line-height: var(--ui-line-height-lg);
   }
 
   .text-xl {
     font-size: var(--ui-font-size-xl);
-    line-height: var(--ui-leading-xl);
+    line-height: var(--ui-line-height-xl);
   }
 
   .text-2xl {
     font-size: var(--ui-font-size-2xl);
-    line-height: var(--ui-leading-2xl);
+    line-height: var(--ui-line-height-2xl);
   }
 
   .text-3xl {
     font-size: var(--ui-font-size-3xl);
-    line-height: var(--ui-leading-3xl);
+    line-height: var(--ui-line-height-3xl);
   }
 
   .text-4xl {
     font-size: var(--ui-font-size-4xl);
-    line-height: var(--ui-leading-4xl);
+    line-height: var(--ui-line-height-4xl);
   }
 
   // ==========================================================================

--- a/scripts/lint-components.ts
+++ b/scripts/lint-components.ts
@@ -643,6 +643,14 @@ function lintBannedTokenNames(): void {
       pattern: /\$weight-(?:normal|medium|semibold|bold)/g,
       message: 'use $font-weight-* instead of $weight-*',
     },
+    {
+      pattern: /--ui-leading-(?:tight-)?(?:xs|sm|md|lg|xl|2xl|3xl|4xl)/g,
+      message: 'use --ui-line-height-* instead of --ui-leading-*',
+    },
+    {
+      pattern: /\$leading-(?:tight-)?(?:xs|sm|md|lg|xl|2xl|3xl|4xl)/g,
+      message: 'use $line-height-* instead of $leading-*',
+    },
   ];
 
   const allFiles = [...findScssFiles(srcDir), ...findScssFiles(join(__dirname, '../apps'))];


### PR DESCRIPTION
## Summary
- Rename `--ui-leading-*` (14 tokens) to `--ui-line-height-*` for CSS property name consistency
- Rename SCSS vars `$leading-*` to `$line-height-*` across 25 files
- Add `--ui-leading-*` and `$leading-*` to banned-token-names lint rule

Clean break — no deprecated aliases. Old names removed entirely.

Closes #384

## Test plan
- [x] `pnpm lint` passes (including banned-names check)
- [x] `pnpm typecheck` passes
- [x] `pnpm test:unit` passes (96 tests)
- [ ] CI visual regression (no visual change expected — values identical)