### PR TITLE
Rename --ui-tracking-* and --ui-z-* tokens

### DIFF
--- a/.changeset/rename-tracking-zindex.md
+++ b/.changeset/rename-tracking-zindex.md
@@ -1,0 +1,5 @@
+---
+"@teseor/css": major
+---
+
+Rename --ui-tracking-* to --ui-letter-spacing-* and --ui-z-* to --ui-z-index-* for CSS property name consistency. Clean break — old names removed entirely. Add banned-token-names lint rule to prevent regression.

--- a/packages/css/src/components/data-display/stat/index.scss
+++ b/packages/css/src/components/data-display/stat/index.scss
@@ -4,7 +4,7 @@
 
 @layer components.tokens {
   .stat {
-    --_tracking-display: var(--ui-tracking-display, #{t.$tracking-display});
+    --_tracking-display: var(--ui-letter-spacing-display, #{t.$letter-spacing-display});
     // @desc Gap between children
     --_gap: var(--ui-stat-gap, var(--ui-space-1, #{t.$space-1}));
   }

--- a/packages/css/src/components/feedback/toast/index.scss
+++ b/packages/css/src/components/feedback/toast/index.scss
@@ -8,7 +8,7 @@
 
 @layer components.tokens {
   .toast-viewport {
-    --_z-toast: var(--ui-z-toast, #{t.$z-toast});
+    --_z-toast: var(--ui-z-index-toast, #{t.$z-index-toast});
     // @desc Viewport gap
     --_gap: var(--ui-toast-viewport-gap, calc(#{t.$unit} * 1));
     // @desc Viewport padding

--- a/packages/css/src/components/navigation/dropdown-menu/api.json
+++ b/packages/css/src/components/navigation/dropdown-menu/api.json
@@ -24,7 +24,7 @@
   "cssVars": [
     {
       "name": "--ui-dropdown-menu-z",
-      "default": "var(--ui-z-dropdown)",
+      "default": "var(--ui-z-index-dropdown)",
       "description": "Z-index stacking order"
     },
     {

--- a/packages/css/src/components/navigation/dropdown-menu/index.scss
+++ b/packages/css/src/components/navigation/dropdown-menu/index.scss
@@ -10,7 +10,7 @@
     --_duration-fast: var(--ui-duration-fast, #{t.$duration-fast});
     --_ease-default: var(--ui-ease-default, #{t.$ease-default});
     // @desc Z-index stacking order
-    --_z: var(--ui-dropdown-menu-z, #{t.$z-dropdown});
+    --_z: var(--ui-dropdown-menu-z, #{t.$z-index-dropdown});
     // @desc Panel offset from anchor
     --_panel-offset: var(--ui-dropdown-menu-panel-offset, var(--ui-space-1, #{t.$space-1}));
     // @desc Panel minimum width

--- a/packages/css/src/components/navigation/menu/index.scss
+++ b/packages/css/src/components/navigation/menu/index.scss
@@ -69,7 +69,7 @@
     font-size: var(--_font-size-xs);
     font-weight: var(--_weight-medium);
     line-height: var(--_row-1);
-    letter-spacing: #{t.$tracking-wide};
+    letter-spacing: #{t.$letter-spacing-wide};
     text-transform: uppercase;
     color: var(--_color-text-muted);
   }

--- a/packages/css/src/components/overlays/drawer/index.scss
+++ b/packages/css/src/components/overlays/drawer/index.scss
@@ -8,7 +8,7 @@
 
 @layer components.tokens {
   .drawer {
-    --_z-drawer: var(--ui-z-drawer, #{t.$z-drawer});
+    --_z-drawer: var(--ui-z-index-drawer, #{t.$z-index-drawer});
     --_overlay-bg: var(--ui-overlay-bg, #{t.$overlay-bg});
     --_duration-normal: var(--ui-duration-normal, #{t.$duration-normal});
     --_ease-out: var(--ui-ease-out, ease-out);

--- a/packages/css/src/components/overlays/modal/api.json
+++ b/packages/css/src/components/overlays/modal/api.json
@@ -47,7 +47,7 @@
     },
     {
       "name": "--ui-modal-z",
-      "default": "var(--ui-z-modal)",
+      "default": "var(--ui-z-index-modal)",
       "description": "Z-index stacking order"
     },
     {

--- a/packages/css/src/components/overlays/modal/index.scss
+++ b/packages/css/src/components/overlays/modal/index.scss
@@ -22,7 +22,7 @@
     // @desc Maximum height
     --_max-height: var(--ui-modal-max-height, calc(100vh - #{t.$unit} * 8));
     // @desc Z-index stacking order
-    --_z: var(--ui-modal-z, var(--ui-z-modal, #{t.$z-modal}));
+    --_z: var(--ui-modal-z, var(--ui-z-index-modal, #{t.$z-index-modal}));
   }
 
   // @modifier size

--- a/packages/css/src/components/overlays/overlay/api.json
+++ b/packages/css/src/components/overlays/overlay/api.json
@@ -24,7 +24,7 @@
     },
     {
       "name": "--ui-overlay-z",
-      "default": "var(--ui-z-overlay)",
+      "default": "var(--ui-z-index-overlay)",
       "description": "Z-index stacking order"
     },
     {

--- a/packages/css/src/components/overlays/overlay/index.scss
+++ b/packages/css/src/components/overlays/overlay/index.scss
@@ -12,7 +12,7 @@
     // @desc Background color
     --_bg: var(--ui-overlay-bg, #{t.$overlay-bg});
     // @desc Z-index stacking order
-    --_z: var(--ui-overlay-z, var(--ui-z-overlay, #{t.$z-overlay}));
+    --_z: var(--ui-overlay-z, var(--ui-z-index-overlay, #{t.$z-index-overlay}));
   }
 
   // @modifier boolean light

--- a/packages/css/src/components/overlays/popover/api.json
+++ b/packages/css/src/components/overlays/popover/api.json
@@ -44,7 +44,7 @@
     },
     {
       "name": "--ui-popover-z",
-      "default": "var(--ui-z-popover)",
+      "default": "var(--ui-z-index-popover)",
       "description": "Z-index stacking order"
     },
     {

--- a/packages/css/src/components/overlays/popover/index.scss
+++ b/packages/css/src/components/overlays/popover/index.scss
@@ -26,7 +26,7 @@
     // @desc Maximum width
     --_max-width: var(--ui-popover-max-width, calc(#{t.$unit} * 40));
     // @desc Z-index stacking order
-    --_z: var(--ui-popover-z, var(--ui-z-popover, #{t.$z-popover}));
+    --_z: var(--ui-popover-z, var(--ui-z-index-popover, #{t.$z-index-popover}));
     // @desc Arrow size
     --_arrow-size: var(--ui-popover-arrow-size, calc(#{t.$unit}));
   }

--- a/packages/css/src/components/overlays/tooltip/api.json
+++ b/packages/css/src/components/overlays/tooltip/api.json
@@ -49,7 +49,7 @@
     },
     {
       "name": "--ui-tooltip-z",
-      "default": "var(--ui-z-tooltip)",
+      "default": "var(--ui-z-index-tooltip)",
       "description": "Z-index stacking order"
     },
     {

--- a/packages/css/src/components/overlays/tooltip/index.scss
+++ b/packages/css/src/components/overlays/tooltip/index.scss
@@ -22,7 +22,7 @@
     // @desc Font size
     --_font-size: var(--ui-tooltip-font-size, var(--ui-font-size-sm, #{t.$font-size-sm}));
     // @desc Z-index stacking order
-    --_z: var(--ui-tooltip-z, var(--ui-z-tooltip, #{t.$z-tooltip}));
+    --_z: var(--ui-tooltip-z, var(--ui-z-index-tooltip, #{t.$z-index-tooltip}));
     // @desc Arrow size
     --_arrow-size: var(--ui-tooltip-arrow-size, calc(#{t.$unit} / 2));
   }

--- a/packages/css/src/config/tokens/_variables.scss
+++ b/packages/css/src/config/tokens/_variables.scss
@@ -134,10 +134,10 @@ $font-weight-semibold: 600;
 $font-weight-bold: 700;
 
 // Letter spacing
-$tracking-display: -0.02em;
-$tracking-body: 0;
-$tracking-wide: 0.05em;
-$tracking-caps: 0.08em;
+$letter-spacing-display: -0.02em;
+$letter-spacing-body: 0;
+$letter-spacing-wide: 0.05em;
+$letter-spacing-caps: 0.08em;
 
 // Relative font sizes (for sub-elements sized relative to parent)
 $font-size-relative-xs: 0.6em;
@@ -170,16 +170,16 @@ $shadow-lg: 0 10px 15px hsl(220 10% 20% / 0.15);
 // ==========================================================================
 // 8. Z-index scale
 // ==========================================================================
-$z-base: 0;
-$z-sticky: 100;
-$z-dropdown: 200;
-$z-overlay: 300;
-$z-modal: 400;
-$z-popover: 500;
-$z-tooltip: 600;
-$z-toast: 700;
-$z-drawer: 800;
-$z-debug: 9999;
+$z-index-base: 0;
+$z-index-sticky: 100;
+$z-index-dropdown: 200;
+$z-index-overlay: 300;
+$z-index-modal: 400;
+$z-index-popover: 500;
+$z-index-tooltip: 600;
+$z-index-toast: 700;
+$z-index-drawer: 800;
+$z-index-debug: 9999;
 
 // ==========================================================================
 // 9. Motion

--- a/packages/css/src/config/tokens/docs.html
+++ b/packages/css/src/config/tokens/docs.html
@@ -73,16 +73,16 @@ skipValidation: true
 <!-- @z_index -->
 <!-- Layering scale with gaps to allow insertion without renumbering. -->
 :root {
-  --ui-z-base: 0;
-  --ui-z-sticky: 100;
-  --ui-z-dropdown: 200;
-  --ui-z-overlay: 300;
-  --ui-z-modal: 400;
-  --ui-z-popover: 500;
-  --ui-z-tooltip: 600;
-  --ui-z-toast: 700;
-  --ui-z-drawer: 800;
-  --ui-z-debug: 9999;
+  --ui-z-index-base: 0;
+  --ui-z-index-sticky: 100;
+  --ui-z-index-dropdown: 200;
+  --ui-z-index-overlay: 300;
+  --ui-z-index-modal: 400;
+  --ui-z-index-popover: 500;
+  --ui-z-index-tooltip: 600;
+  --ui-z-index-toast: 700;
+  --ui-z-index-drawer: 800;
+  --ui-z-index-debug: 9999;
 }
 
 <!-- @semantic_colors -->

--- a/packages/css/src/config/tokens/typography.scss
+++ b/packages/css/src/config/tokens/typography.scss
@@ -49,9 +49,9 @@
     // ==========================================================================
     // PRIMITIVE TOKENS - Letter Spacing
     // ==========================================================================
-    --ui-tracking-display: -0.02em;
-    --ui-tracking-body: 0;
-    --ui-tracking-caps: 0.08em;
+    --ui-letter-spacing-display: -0.02em;
+    --ui-letter-spacing-body: 0;
+    --ui-letter-spacing-caps: 0.08em;
 
     // ==========================================================================
     // SEMANTIC TOKENS - Text Roles
@@ -61,7 +61,7 @@
     --ui-heading-1-size: var(--ui-font-size-4xl);
     --ui-heading-1-line-height: var(--ui-line-height-4xl);
     --ui-heading-1-weight: var(--ui-font-weight-bold);
-    --ui-heading-1-tracking: var(--ui-tracking-display);
+    --ui-heading-1-tracking: var(--ui-letter-spacing-display);
 
     // Heading 2
     --ui-heading-2-size: var(--ui-font-size-3xl);
@@ -73,31 +73,31 @@
     --ui-heading-3-size: var(--ui-font-size-2xl);
     --ui-heading-3-line-height: var(--ui-line-height-2xl);
     --ui-heading-3-weight: var(--ui-font-weight-semibold);
-    --ui-heading-3-tracking: var(--ui-tracking-body);
+    --ui-heading-3-tracking: var(--ui-letter-spacing-body);
 
     // Heading 4
     --ui-heading-4-size: var(--ui-font-size-xl);
     --ui-heading-4-line-height: var(--ui-line-height-xl);
     --ui-heading-4-weight: var(--ui-font-weight-semibold);
-    --ui-heading-4-tracking: var(--ui-tracking-body);
+    --ui-heading-4-tracking: var(--ui-letter-spacing-body);
 
     // Heading 5
     --ui-heading-5-size: var(--ui-font-size-lg);
     --ui-heading-5-line-height: var(--ui-line-height-sm);
     --ui-heading-5-weight: var(--ui-font-weight-medium);
-    --ui-heading-5-tracking: var(--ui-tracking-body);
+    --ui-heading-5-tracking: var(--ui-letter-spacing-body);
 
     // Body
     --ui-body-size: var(--ui-font-size-md);
     --ui-body-line-height: var(--ui-line-height-md);
     --ui-body-weight: var(--ui-font-weight-normal);
-    --ui-body-tracking: var(--ui-tracking-body);
+    --ui-body-tracking: var(--ui-letter-spacing-body);
 
     // Body Small
     --ui-body-sm-size: var(--ui-font-size-sm);
     --ui-body-sm-line-height: var(--ui-line-height-sm);
     --ui-body-sm-weight: var(--ui-font-weight-normal);
-    --ui-body-sm-tracking: var(--ui-tracking-body);
+    --ui-body-sm-tracking: var(--ui-letter-spacing-body);
 
     // Caption
     --ui-caption-size: var(--ui-font-size-xs);
@@ -109,12 +109,12 @@
     --ui-lead-size: var(--ui-font-size-lg);
     --ui-lead-line-height: var(--ui-line-height-lg);
     --ui-lead-weight: var(--ui-font-weight-normal);
-    --ui-lead-tracking: var(--ui-tracking-body);
+    --ui-lead-tracking: var(--ui-letter-spacing-body);
 
     // Eyebrow
     --ui-eyebrow-size: var(--ui-font-size-xs);
     --ui-eyebrow-line-height: var(--ui-line-height-xs);
     --ui-eyebrow-weight: var(--ui-font-weight-semibold);
-    --ui-eyebrow-tracking: var(--ui-tracking-caps);
+    --ui-eyebrow-tracking: var(--ui-letter-spacing-caps);
   }
 }

--- a/packages/css/src/config/tokens/zindex.scss
+++ b/packages/css/src/config/tokens/zindex.scss
@@ -1,15 +1,15 @@
 @layer tokens {
   :root {
     // Z-index scale (gaps allow insertion)
-    --ui-z-base: 0;
-    --ui-z-sticky: 100;
-    --ui-z-dropdown: 200;
-    --ui-z-overlay: 300;
-    --ui-z-modal: 400;
-    --ui-z-popover: 500;
-    --ui-z-tooltip: 600;
-    --ui-z-toast: 700;
-    --ui-z-drawer: 800;
-    --ui-z-debug: 9999;
+    --ui-z-index-base: 0;
+    --ui-z-index-sticky: 100;
+    --ui-z-index-dropdown: 200;
+    --ui-z-index-overlay: 300;
+    --ui-z-index-modal: 400;
+    --ui-z-index-popover: 500;
+    --ui-z-index-tooltip: 600;
+    --ui-z-index-toast: 700;
+    --ui-z-index-drawer: 800;
+    --ui-z-index-debug: 9999;
   }
 }

--- a/packages/css/src/debug/index.scss
+++ b/packages/css/src/debug/index.scss
@@ -15,7 +15,7 @@
   position: absolute;
   inset-block-start: 0;
   inset-inline-start: 0;
-  z-index: var(--ui-z-debug);
+  z-index: var(--ui-z-index-debug);
 
   block-size: 100%;
   inline-size: 100%;
@@ -39,7 +39,7 @@
   position: absolute;
   inset-block-start: 0;
   inset-inline-start: 0;
-  z-index: var(--ui-z-debug);
+  z-index: var(--ui-z-index-debug);
 
   block-size: 100%;
   inline-size: 100%;
@@ -63,7 +63,7 @@
   position: absolute;
   inset-block-start: 0;
   inset-inline-start: 0;
-  z-index: var(--ui-z-debug);
+  z-index: var(--ui-z-index-debug);
 
   block-size: 100%;
   inline-size: 100%;

--- a/packages/css/src/layout/footer/api.json
+++ b/packages/css/src/layout/footer/api.json
@@ -44,7 +44,7 @@
     },
     {
       "name": "--ui-footer-z",
-      "default": "var(--ui-z-sticky)",
+      "default": "var(--ui-z-index-sticky)",
       "description": "Z-index stacking order"
     }
   ]

--- a/packages/css/src/layout/footer/index.scss
+++ b/packages/css/src/layout/footer/index.scss
@@ -16,7 +16,7 @@
     // @desc Border color
     --_border-color: var(--ui-footer-border-color, var(--ui-color-border));
     // @desc Z-index stacking order
-    --_z: var(--ui-footer-z, var(--ui-z-sticky));
+    --_z: var(--ui-footer-z, var(--ui-z-index-sticky));
 
     display: flex;
     align-items: center;

--- a/packages/css/src/layout/nav-rail/api.json
+++ b/packages/css/src/layout/nav-rail/api.json
@@ -34,7 +34,7 @@
     },
     {
       "name": "--ui-nav-rail-z",
-      "default": "var(--ui-z-sticky)",
+      "default": "var(--ui-z-index-sticky)",
       "description": "Z-index stacking order"
     }
   ]

--- a/packages/css/src/layout/nav-rail/index.scss
+++ b/packages/css/src/layout/nav-rail/index.scss
@@ -14,7 +14,7 @@
     // @desc Gap between children
     --_gap: var(--ui-nav-rail-gap, var(--ui-space-1));
     // @desc Z-index stacking order
-    --_z: var(--ui-nav-rail-z, var(--ui-z-sticky));
+    --_z: var(--ui-nav-rail-z, var(--ui-z-index-sticky));
 
     display: flex;
     flex-direction: column;

--- a/packages/css/src/layout/page-header/index.scss
+++ b/packages/css/src/layout/page-header/index.scss
@@ -7,7 +7,7 @@
     --_space-1: var(--ui-space-1);
     --_space-2: var(--ui-space-2);
     --_border-width-sm: var(--ui-border-width-sm);
-    --_z-sticky: var(--ui-z-sticky);
+    --_z-sticky: var(--ui-z-index-sticky);
     --_color-bg: var(--ui-color-bg);
     // @desc Vertical padding
     --_padding-block: var(--ui-page-header-padding-block, var(--ui-space-3));

--- a/packages/css/src/layout/sidebar-nav/index.scss
+++ b/packages/css/src/layout/sidebar-nav/index.scss
@@ -92,7 +92,7 @@
 
     font-size: var(--_font-size);
     font-weight: var(--_weight);
-    letter-spacing: #{t.$tracking-wide};
+    letter-spacing: #{t.$letter-spacing-wide};
     text-transform: uppercase;
     color: var(--_color);
   }

--- a/packages/css/src/layout/sidebar/index.scss
+++ b/packages/css/src/layout/sidebar/index.scss
@@ -3,7 +3,7 @@
 
 @layer primitives {
   .sidebar {
-    --_z-sticky: var(--ui-z-sticky);
+    --_z-sticky: var(--ui-z-index-sticky);
     --_unit: var(--ui-unit);
     --_color-bg-subtle: var(--ui-color-bg-subtle);
     --_border-width-sm: var(--ui-border-width-sm);

--- a/packages/css/src/layout/topbar/api.json
+++ b/packages/css/src/layout/topbar/api.json
@@ -44,7 +44,7 @@
     },
     {
       "name": "--ui-topbar-z",
-      "default": "var(--ui-z-sticky)",
+      "default": "var(--ui-z-index-sticky)",
       "description": "Z-index stacking order"
     }
   ]

--- a/packages/css/src/layout/topbar/index.scss
+++ b/packages/css/src/layout/topbar/index.scss
@@ -15,7 +15,7 @@
     // @desc Border color
     --_border-color: var(--ui-topbar-border-color, var(--ui-color-border));
     // @desc Z-index stacking order
-    --_z: var(--ui-topbar-z, var(--ui-z-sticky));
+    --_z: var(--ui-topbar-z, var(--ui-z-index-sticky));
 
     display: flex;
     align-items: center;

--- a/packages/css/src/utilities/scroll-animation/index.scss
+++ b/packages/css/src/utilities/scroll-animation/index.scss
@@ -12,7 +12,7 @@
       position: fixed;
       inset-block-start: 0;
       inset-inline-start: 0;
-      z-index: var(--ui-z-toast, #{t.$z-toast});
+      z-index: var(--ui-z-index-toast, #{t.$z-index-toast});
 
       block-size: var(--ui-scroll-progress-height, var(--ui-space-half, #{t.$space-0}));
       inline-size: 100%;

--- a/packages/css/src/utilities/text/text.scss
+++ b/packages/css/src/utilities/text/text.scss
@@ -275,14 +275,14 @@
   // LETTER SPACING
   // ==========================================================================
   .tracking-display {
-    letter-spacing: var(--ui-tracking-display);
+    letter-spacing: var(--ui-letter-spacing-display);
   }
 
   .tracking-body {
-    letter-spacing: var(--ui-tracking-body);
+    letter-spacing: var(--ui-letter-spacing-body);
   }
 
   .tracking-caps {
-    letter-spacing: var(--ui-tracking-caps);
+    letter-spacing: var(--ui-letter-spacing-caps);
   }
 }

--- a/scripts/lint-components.ts
+++ b/scripts/lint-components.ts
@@ -651,6 +651,24 @@ function lintBannedTokenNames(): void {
       pattern: /\$leading-(?:tight-)?(?:xs|sm|md|lg|xl|2xl|3xl|4xl)/g,
       message: 'use $line-height-* instead of $leading-*',
     },
+    {
+      pattern: /--ui-tracking-(?:display|body|caps|wide)/g,
+      message: 'use --ui-letter-spacing-* instead of --ui-tracking-*',
+    },
+    {
+      pattern: /\$tracking-(?:display|body|caps|wide)/g,
+      message: 'use $letter-spacing-* instead of $tracking-*',
+    },
+    {
+      pattern:
+        /--ui-z-(?!index-)(?:base|sticky|dropdown|overlay|modal|popover|tooltip|toast|drawer|debug)/g,
+      message: 'use --ui-z-index-* instead of --ui-z-*',
+    },
+    {
+      pattern:
+        /\$z-(?!index-)(?:base|sticky|dropdown|overlay|modal|popover|tooltip|toast|drawer|debug)/g,
+      message: 'use $z-index-* instead of $z-*',
+    },
   ];
 
   const allFiles = [...findScssFiles(srcDir), ...findScssFiles(join(__dirname, '../apps'))];


### PR DESCRIPTION
## Summary
- Rename `--ui-tracking-*` (3 tokens) to `--ui-letter-spacing-*` for CSS property name consistency
- Rename `--ui-z-*` (10 tokens) to `--ui-z-index-*` for CSS property name consistency
- Rename SCSS vars `$tracking-*` to `$letter-spacing-*` and `$z-*` to `$z-index-*` across 32 files
- Add all four patterns to banned-token-names lint rule

Clean break — no deprecated aliases. Old names removed entirely.

Closes #385

## Test plan
- [x] `pnpm lint` passes (including banned-names check)
- [x] `pnpm typecheck` passes
- [x] `pnpm test:unit` passes (96 tests)
- [ ] CI visual regression (no visual change expected — values identical)