### PR TITLE
Fix grid violations: card padding, bare button in docs

### DIFF
--- a/.changeset/fix-grid-violations-round2.md
+++ b/.changeset/fix-grid-violations-round2.md
@@ -1,0 +1,5 @@
+---
+"@teseor/css": patch
+---
+
+Fix grid violations: replace ui-p-2 with ui-card--sm on cards, add ui-button to bare button in docs

--- a/packages/css/src/utilities/scroll-animation/docs.html
+++ b/packages/css/src/utilities/scroll-animation/docs.html
@@ -14,16 +14,16 @@ description: Scroll-driven animation utilities for progress indicators and viewp
 
 <!-- @view_fade -->
 <!-- Elements fade in as they enter the viewport. -->
-<div class="ui-view-fade ui-card ui-p-2">{{ t('i_fade_in_on_scroll', 'I fade in on scroll') }}</div>
+<div class="ui-view-fade ui-card ui-card--sm">{{ t('i_fade_in_on_scroll', 'I fade in on scroll') }}</div>
 
 <!-- @view_slide_up -->
 <!-- Elements slide up and fade in on viewport entry. -->
-<div class="ui-view-slide-up ui-card ui-p-2">{{ t('i_slide_up_into_view', 'I slide up into view') }}</div>
+<div class="ui-view-slide-up ui-card ui-card--sm">{{ t('i_slide_up_into_view', 'I slide up into view') }}</div>
 
 <!-- @view_slide_start -->
 <!-- Elements slide in from the start edge (left in LTR) on viewport entry. -->
-<div class="ui-view-slide-start ui-card ui-p-2">{{ t('i_slide_from_the_start', 'I slide from the start') }}</div>
+<div class="ui-view-slide-start ui-card ui-card--sm">{{ t('i_slide_from_the_start', 'I slide from the start') }}</div>
 
 <!-- @view_scale -->
 <!-- Elements scale up and fade in on viewport entry. -->
-<div class="ui-view-scale ui-card ui-p-2">{{ t('i_scale_into_view', 'I scale into view') }}</div>
+<div class="ui-view-scale ui-card ui-card--sm">{{ t('i_scale_into_view', 'I scale into view') }}</div>

--- a/packages/css/src/utilities/scroll-snap/docs.html
+++ b/packages/css/src/utilities/scroll-snap/docs.html
@@ -6,72 +6,72 @@ description: Scroll-snap utilities for carousels, horizontal lists, and snap-to-
 <!-- @horizontal_snap -->
 <!-- Snap children to start position on horizontal scroll. -->
 <div class="ui-snap-x ui-flex ui-gap-2 ui-p-2 demo-narrow">
-  <div class="ui-snap-start ui-card ui-p-2 demo-snap-item">{{ t('item_1', 'Item 1') }}</div>
-  <div class="ui-snap-start ui-card ui-p-2 demo-snap-item">{{ t('item_2', 'Item 2') }}</div>
-  <div class="ui-snap-start ui-card ui-p-2 demo-snap-item">{{ t('item_3', 'Item 3') }}</div>
-  <div class="ui-snap-start ui-card ui-p-2 demo-snap-item">{{ t('item_4', 'Item 4') }}</div>
+  <div class="ui-snap-start ui-card ui-card--sm demo-snap-item">{{ t('item_1', 'Item 1') }}</div>
+  <div class="ui-snap-start ui-card ui-card--sm demo-snap-item">{{ t('item_2', 'Item 2') }}</div>
+  <div class="ui-snap-start ui-card ui-card--sm demo-snap-item">{{ t('item_3', 'Item 3') }}</div>
+  <div class="ui-snap-start ui-card ui-card--sm demo-snap-item">{{ t('item_4', 'Item 4') }}</div>
 </div>
 
 <!-- @center_snap -->
 <!-- Snap children to center position. -->
 <div class="ui-snap-x ui-flex ui-gap-2 ui-p-2 demo-narrow">
-  <div class="ui-snap-center ui-card ui-p-2 demo-snap-item">{{ t('center_1', 'Center 1') }}</div>
-  <div class="ui-snap-center ui-card ui-p-2 demo-snap-item">{{ t('center_2', 'Center 2') }}</div>
-  <div class="ui-snap-center ui-card ui-p-2 demo-snap-item">{{ t('center_3', 'Center 3') }}</div>
+  <div class="ui-snap-center ui-card ui-card--sm demo-snap-item">{{ t('center_1', 'Center 1') }}</div>
+  <div class="ui-snap-center ui-card ui-card--sm demo-snap-item">{{ t('center_2', 'Center 2') }}</div>
+  <div class="ui-snap-center ui-card ui-card--sm demo-snap-item">{{ t('center_3', 'Center 3') }}</div>
 </div>
 
 <!-- @vertical_snap -->
 <!-- Snap children on vertical scroll. -->
 <div class="ui-snap-y" style="max-block-size: 8rem">
-  <div class="ui-snap-start ui-card ui-p-2">{{ t('section_1', 'Section 1') }}</div>
-  <div class="ui-snap-start ui-card ui-p-2">{{ t('section_2', 'Section 2') }}</div>
-  <div class="ui-snap-start ui-card ui-p-2">{{ t('section_3', 'Section 3') }}</div>
+  <div class="ui-snap-start ui-card ui-card--sm">{{ t('section_1', 'Section 1') }}</div>
+  <div class="ui-snap-start ui-card ui-card--sm">{{ t('section_2', 'Section 2') }}</div>
+  <div class="ui-snap-start ui-card ui-card--sm">{{ t('section_3', 'Section 3') }}</div>
 </div>
 
 <!-- @proximity_snap -->
 <!-- Softer snap that only engages when close to a snap point. -->
 <div class="ui-snap-x-proximity ui-flex ui-gap-2 ui-p-2 demo-narrow">
-  <div class="ui-snap-start ui-card ui-p-2 demo-snap-item">{{ t('proximity_1', 'Proximity 1') }}</div>
-  <div class="ui-snap-start ui-card ui-p-2 demo-snap-item">{{ t('proximity_2', 'Proximity 2') }}</div>
-  <div class="ui-snap-start ui-card ui-p-2 demo-snap-item">{{ t('proximity_3', 'Proximity 3') }}</div>
+  <div class="ui-snap-start ui-card ui-card--sm demo-snap-item">{{ t('proximity_1', 'Proximity 1') }}</div>
+  <div class="ui-snap-start ui-card ui-card--sm demo-snap-item">{{ t('proximity_2', 'Proximity 2') }}</div>
+  <div class="ui-snap-start ui-card ui-card--sm demo-snap-item">{{ t('proximity_3', 'Proximity 3') }}</div>
 </div>
 <div class="ui-snap-y-proximity" style="max-block-size: 8rem">
-  <div class="ui-snap-start ui-card ui-p-2">{{ t('section_1', 'Section 1') }}</div>
-  <div class="ui-snap-start ui-card ui-p-2">{{ t('section_2', 'Section 2') }}</div>
-  <div class="ui-snap-start ui-card ui-p-2">{{ t('section_3', 'Section 3') }}</div>
+  <div class="ui-snap-start ui-card ui-card--sm">{{ t('section_1', 'Section 1') }}</div>
+  <div class="ui-snap-start ui-card ui-card--sm">{{ t('section_2', 'Section 2') }}</div>
+  <div class="ui-snap-start ui-card ui-card--sm">{{ t('section_3', 'Section 3') }}</div>
 </div>
 
 <!-- @end_alignment_and_stop -->
 <!-- Snap children to end position or force stop at every snap point. -->
 <div class="ui-snap-x ui-flex ui-gap-2 ui-p-2 demo-narrow">
-  <div class="ui-snap-end ui-card ui-p-2 demo-snap-item">{{ t('end_1', 'End 1') }}</div>
-  <div class="ui-snap-end ui-card ui-p-2 demo-snap-item">{{ t('end_2', 'End 2') }}</div>
-  <div class="ui-snap-end ui-card ui-p-2 demo-snap-item">{{ t('end_3', 'End 3') }}</div>
+  <div class="ui-snap-end ui-card ui-card--sm demo-snap-item">{{ t('end_1', 'End 1') }}</div>
+  <div class="ui-snap-end ui-card ui-card--sm demo-snap-item">{{ t('end_2', 'End 2') }}</div>
+  <div class="ui-snap-end ui-card ui-card--sm demo-snap-item">{{ t('end_3', 'End 3') }}</div>
 </div>
 <div class="ui-snap-x ui-flex ui-gap-2 ui-p-2 demo-narrow">
-  <div class="ui-snap-start ui-snap-always ui-card ui-p-2 demo-snap-item">{{ t('always_1', 'Always 1') }}</div>
-  <div class="ui-snap-start ui-snap-always ui-card ui-p-2 demo-snap-item">{{ t('always_2', 'Always 2') }}</div>
-  <div class="ui-snap-start ui-snap-always ui-card ui-p-2 demo-snap-item">{{ t('always_3', 'Always 3') }}</div>
+  <div class="ui-snap-start ui-snap-always ui-card ui-card--sm demo-snap-item">{{ t('always_1', 'Always 1') }}</div>
+  <div class="ui-snap-start ui-snap-always ui-card ui-card--sm demo-snap-item">{{ t('always_2', 'Always 2') }}</div>
+  <div class="ui-snap-start ui-snap-always ui-card ui-card--sm demo-snap-item">{{ t('always_3', 'Always 3') }}</div>
 </div>
 
 <!-- @disable_snap -->
 <!-- Remove snap behavior from a container. -->
 <div class="ui-snap-none ui-flex ui-gap-2 ui-p-2 demo-narrow ui-overflow-x-auto">
-  <div class="ui-card ui-p-2 demo-snap-item">{{ t('no_snap_1', 'No snap 1') }}</div>
-  <div class="ui-card ui-p-2 demo-snap-item">{{ t('no_snap_2', 'No snap 2') }}</div>
+  <div class="ui-card ui-card--sm demo-snap-item">{{ t('no_snap_1', 'No snap 1') }}</div>
+  <div class="ui-card ui-card--sm demo-snap-item">{{ t('no_snap_2', 'No snap 2') }}</div>
 </div>
 
 <!-- @scroll_padding -->
 <!-- Offset snap position for fixed headers or insets. -->
 <div class="ui-snap-x ui-snap-p-1 ui-flex ui-gap-2 ui-p-2 demo-narrow">
-  <div class="ui-snap-start ui-card ui-p-2 demo-snap-item">{{ t('p_1', 'p-1') }}</div>
-  <div class="ui-snap-start ui-card ui-p-2 demo-snap-item">{{ t('p_1', 'p-1') }}</div>
+  <div class="ui-snap-start ui-card ui-card--sm demo-snap-item">{{ t('p_1', 'p-1') }}</div>
+  <div class="ui-snap-start ui-card ui-card--sm demo-snap-item">{{ t('p_1', 'p-1') }}</div>
 </div>
 <div class="ui-snap-x ui-snap-p-2 ui-flex ui-gap-2 ui-p-2 demo-narrow">
-  <div class="ui-snap-start ui-card ui-p-2 demo-snap-item">{{ t('p_2', 'p-2') }}</div>
-  <div class="ui-snap-start ui-card ui-p-2 demo-snap-item">{{ t('p_2', 'p-2') }}</div>
+  <div class="ui-snap-start ui-card ui-card--sm demo-snap-item">{{ t('p_2', 'p-2') }}</div>
+  <div class="ui-snap-start ui-card ui-card--sm demo-snap-item">{{ t('p_2', 'p-2') }}</div>
 </div>
 <div class="ui-snap-x ui-snap-p-4 ui-flex ui-gap-2 ui-p-2 demo-narrow">
-  <div class="ui-snap-start ui-card ui-p-2 demo-snap-item">{{ t('p_4', 'p-4') }}</div>
-  <div class="ui-snap-start ui-card ui-p-2 demo-snap-item">{{ t('p_4', 'p-4') }}</div>
+  <div class="ui-snap-start ui-card ui-card--sm demo-snap-item">{{ t('p_4', 'p-4') }}</div>
+  <div class="ui-snap-start ui-card ui-card--sm demo-snap-item">{{ t('p_4', 'p-4') }}</div>
 </div>

--- a/packages/css/src/utilities/visually-hidden/docs.html
+++ b/packages/css/src/utilities/visually-hidden/docs.html
@@ -6,7 +6,7 @@ description: Hides content visually while keeping it accessible to screen reader
 
 <!-- @default -->
 <!-- Content is hidden visually but announced by screen readers -->
-<button>
+<button class="ui-button">
 {{ t('submit', 'Submit') }}
   <span class="ui-visually-hidden"> {{ t('form_to_contact_support', 'form to contact support') }}</span>
 </button>


### PR DESCRIPTION
## Summary

- Replace `ui-p-2` with `ui-card--sm` on cards in scroll-snap and scroll-animation docs — padding utilities bypass the card's border compensation (`calc(padding - border-width)`), causing 2px off-grid. Using card's own size modifier keeps the border math correct.
- Add `.ui-button` class to bare `<button>` in visually-hidden docs — browser defaults (13px font, 1px padding, 2px border) were off-grid.

## Results

| Metric | Before (PR #432) | After |
|--------|------------------|-------|
| Total violations | 121 | 65 |
| Pages with violations | 20 | 18 |
| scroll-snap page | 46 violations | 0 |
| scroll-animation page | 8 violations | 1 |
| visually-hidden page | 3 violations | 0 |

## Remaining 65 violations (follow-up)

Root cause: `inline-flex`/`inline-block` components (status, badge, link::after) in tabs panels push line boxes 2px past `line-height: 16px` due to CSS baseline alignment + font descender space. Affects ~15 pages. Needs a tabs-panel-level fix, not per-component.

## Test plan

- [x] `pnpm lint` passes
- [x] `pnpm test:unit` passes (111 tests)
- [x] Visual snapshots unchanged (card--sm visually equivalent to p-2)
- [x] `pnpm audit:grid` drops from 121 to 65 violations

Closes #433