### PR TITLE
Tokenize hardcoded properties, refine defaults, extend position utilities

### DIFF
--- a/.changeset/theme-tokens-position.md
+++ b/.changeset/theme-tokens-position.md
@@ -1,0 +1,5 @@
+---
+"@teseor/css": minor
+---
+
+Tokenize sidebar-nav text-transform/letter-spacing and tabs line-height as CSS custom properties. Refine core token defaults (primary, neutral, radius, shadow, font stacks). Extend position utilities with inset scale, z-index, and overflow variants.

--- a/apps/docs-css/src/_includes/layouts/base.njk
+++ b/apps/docs-css/src/_includes/layouts/base.njk
@@ -38,7 +38,6 @@
             <option value="dracula">Dracula</option>
             <option value="github">GitHub</option>
             <option value="amazon">Amazon</option>
-            <option value="linear">Linear</option>
           </select>
           <select class="ui-select" id="density-select" onchange="setDensity(this.value)" aria-label="{{ t('density', 'Density') }}">
             <option value="compact">{{ t('compact', 'Compact') }}</option>

--- a/apps/docs-css/src/styles.css
+++ b/apps/docs-css/src/styles.css
@@ -350,14 +350,4 @@
     --ui-shadow-strength: 15%;
     --ui-border-width-base: 1px;
   }
-
-  /* Linear — indigo accent, minimal, modern */
-  [data-brand="linear"] {
-    --ui-color-primary: oklch(52% 0.2 280);
-    --ui-color-neutral: oklch(40% 0.015 265);
-    --ui-font-sans: "Inter", system-ui, -apple-system, sans-serif;
-    --ui-radius-base: 6px;
-    --ui-shadow-strength: 8%;
-    --ui-border-width-base: 1px;
-  }
 }

--- a/packages/css/src/components/navigation/tabs/api.json
+++ b/packages/css/src/components/navigation/tabs/api.json
@@ -64,6 +64,11 @@
       "description": "Tab bg active"
     },
     {
+      "name": "--ui-tabs-tab-line-height",
+      "default": "var(--ui-line-height-none)",
+      "description": "Tab line height"
+    },
+    {
       "name": "--ui-tabs-panel-padding",
       "default": "var(--ui-space-3)",
       "description": "Panel padding on all sides"

--- a/packages/css/src/components/navigation/tabs/index.scss
+++ b/packages/css/src/components/navigation/tabs/index.scss
@@ -30,6 +30,8 @@
     --_tab-bg: var(--ui-tabs-tab-bg, transparent);
     // @desc Tab bg active
     --_tab-bg-active: var(--ui-tabs-tab-bg-active, var(--ui-color-bg, #{t.$color-bg}));
+    // @desc Tab line height
+    --_tab-line-height: var(--ui-tabs-tab-line-height, var(--ui-line-height-none, #{t.$line-height-none}));
     // @desc Panel padding on all sides
     --_panel-padding: var(--ui-tabs-panel-padding, var(--ui-space-3, #{t.$space-3}));
   }
@@ -80,7 +82,7 @@
     font-family: var(--_font-sans);
     font-size: var(--_tab-font-size);
     font-weight: var(--_weight-medium);
-    line-height: 1;
+    line-height: var(--_tab-line-height);
     color: var(--_color-text-muted);
 
     background: var(--_tab-bg);

--- a/packages/css/src/config/tokens/_variables.scss
+++ b/packages/css/src/config/tokens/_variables.scss
@@ -103,8 +103,8 @@ $sizes: (
 // ==========================================================================
 
 // Font families (system stack, consumers override via CSS tokens)
-$font-sans: system-ui, -apple-system, blinkmacsystemfont, "Segoe UI", roboto, "Helvetica Neue", arial, sans-serif;
-$font-mono: ui-monospace, sfmono-regular, "SF Mono", menlo, consolas, "Liberation Mono", monospace;
+$font-sans: system-ui, -apple-system, blinkmacsystemfont, "Segoe UI", roboto, oxygen, ubuntu, cantarell, "Helvetica Neue", arial, sans-serif;
+$font-mono: ui-monospace, "SFMono-Regular", "SF Mono", menlo, consolas, "Liberation Mono", "Courier New", monospace;
 
 // Font sizes (derived from base, 1.2 modular scale)
 $font-size-base: 1rem; // 16px — core knob
@@ -116,6 +116,9 @@ $font-size-xl: 1.5rem; // 24px
 $font-size-2xl: 1.75rem; // 28px
 $font-size-3xl: 2rem; // 32px
 $font-size-4xl: 2.5rem; // 40px
+
+// Unitless line height (no extra leading)
+$line-height-none: 1;
 
 // Tight line heights (compact UI elements)
 $line-height-tight-xs: $row;

--- a/packages/css/src/config/tokens/core.scss
+++ b/packages/css/src/config/tokens/core.scss
@@ -8,26 +8,26 @@
     --ui-unit: calc(8px * var(--ui-scale));
 
     // Base colors — shades auto-generated via color-mix in tokens.scale
-    --ui-color-primary: oklch(55% 0.22 250);
+    --ui-color-primary: oklch(54% 0.20 260);
     --ui-color-success: oklch(60% 0.18 145);
     --ui-color-warning: oklch(75% 0.18 70);
     --ui-color-danger: oklch(60% 0.22 25);
-    --ui-color-neutral: oklch(50% 0.02 250);
+    --ui-color-neutral: oklch(45% 0.015 260);
 
     // Font families — system stacks, override for brand fonts
-    --ui-font-sans: system-ui, -apple-system, blinkmacsystemfont, "Segoe UI", roboto, "Helvetica Neue", arial, sans-serif;
-    --ui-font-mono: ui-monospace, sfmono-regular, "SF Mono", menlo, consolas, "Liberation Mono", monospace;
+    --ui-font-sans: system-ui, -apple-system, blinkmacsystemfont, "Segoe UI", roboto, oxygen, ubuntu, cantarell, "Helvetica Neue", arial, sans-serif;
+    --ui-font-mono: ui-monospace, "SFMono-Regular", "SF Mono", menlo, consolas, "Liberation Mono", "Courier New", monospace;
 
     // Base font size — all font-size-* tokens derive from this via calc()
     --ui-font-size-base: calc(1rem * var(--ui-scale));
 
     // Base radius — sm/md/lg derive from this
-    --ui-radius-base: var(--ui-unit);
+    --ui-radius-base: 6px;
 
     // Base border width — sm/md/lg derive from this
     --ui-border-width-base: calc(var(--ui-unit) * 0.125);
 
     // Shadow strength — controls opacity of all shadow levels
-    --ui-shadow-strength: 20%;
+    --ui-shadow-strength: 12%;
   }
 }

--- a/packages/css/src/config/tokens/typography.scss
+++ b/packages/css/src/config/tokens/typography.scss
@@ -17,6 +17,9 @@
     // Two modes: normal (for body text) and tight (for UI/forms)
     // ==========================================================================
 
+    // Unitless line height (no extra leading)
+    --ui-line-height-none: 1;
+
     // Tight line-heights for compact UI elements
     --ui-line-height-tight-xs: var(--ui-row-1);
     --ui-line-height-tight-sm: var(--ui-row-1);

--- a/packages/css/src/layout/sidebar-nav/api.json
+++ b/packages/css/src/layout/sidebar-nav/api.json
@@ -76,8 +76,18 @@
     },
     {
       "name": "--ui-sidebar-nav-group-label-weight",
-      "default": "var(--ui-font-weight-bold)",
+      "default": "var(--ui-font-weight-semibold)",
       "description": "Group label weight"
+    },
+    {
+      "name": "--ui-sidebar-nav-group-label-transform",
+      "default": "none",
+      "description": "Group label text-transform"
+    },
+    {
+      "name": "--ui-sidebar-nav-group-label-letter-spacing",
+      "default": "normal",
+      "description": "Group label letter-spacing"
     },
     {
       "name": "--ui-sidebar-nav-item-height",
@@ -116,17 +126,17 @@
     },
     {
       "name": "--ui-sidebar-nav-item-active-bg",
-      "default": "var(--ui-color-primary-subtle)",
+      "default": "var(--ui-color-bg-muted)",
       "description": "Item active bg"
     },
     {
       "name": "--ui-sidebar-nav-item-active-color",
-      "default": "var(--ui-color-primary-hover)",
+      "default": "var(--ui-color-primary)",
       "description": "Item active color"
     },
     {
       "name": "--ui-sidebar-nav-item-active-weight",
-      "default": "var(--ui-font-weight-medium)",
+      "default": "normal",
       "description": "Item active weight"
     },
     {

--- a/packages/css/src/layout/sidebar-nav/index.scss
+++ b/packages/css/src/layout/sidebar-nav/index.scss
@@ -83,7 +83,11 @@
     // @desc Group label color
     --_color: var(--ui-sidebar-nav-group-label-color, var(--ui-color-text-muted));
     // @desc Group label weight
-    --_weight: var(--ui-sidebar-nav-group-label-weight, var(--ui-font-weight-bold));
+    --_weight: var(--ui-sidebar-nav-group-label-weight, var(--ui-font-weight-semibold));
+    // @desc Group label text-transform
+    --_transform: var(--ui-sidebar-nav-group-label-transform, none);
+    // @desc Group label letter-spacing
+    --_letter-spacing: var(--ui-sidebar-nav-group-label-letter-spacing, normal);
 
     display: block;
 
@@ -92,8 +96,8 @@
 
     font-size: var(--_font-size);
     font-weight: var(--_weight);
-    letter-spacing: #{t.$letter-spacing-wide};
-    text-transform: uppercase;
+    letter-spacing: var(--_letter-spacing);
+    text-transform: var(--_transform);
     color: var(--_color);
   }
 
@@ -156,12 +160,14 @@
     min-block-size: var(--_height);
     padding-inline: var(--_padding-inline);
 
+    font-family: inherit;
     font-size: var(--_font-size);
     font-weight: var(--_weight, normal);
     text-decoration: none;
     color: var(--_color);
 
     background: var(--_bg);
+    border: none;
     border-radius: var(--_radius);
     cursor: pointer;
 
@@ -187,11 +193,11 @@
   // Active state
   .sidebar-nav__item--active {
     // @desc Item active bg
-    --_bg: var(--ui-sidebar-nav-item-active-bg, var(--ui-color-primary-subtle));
+    --_bg: var(--ui-sidebar-nav-item-active-bg, var(--ui-color-bg-muted));
     // @desc Item active color
-    --_color: var(--ui-sidebar-nav-item-active-color, var(--ui-color-primary-hover));
+    --_color: var(--ui-sidebar-nav-item-active-color, var(--ui-color-primary));
     // @desc Item active weight
-    --_weight: var(--ui-sidebar-nav-item-active-weight, var(--ui-font-weight-medium));
+    --_weight: var(--ui-sidebar-nav-item-active-weight, normal);
   }
 
   // Nested item indent

--- a/packages/css/src/utilities/position/api.json
+++ b/packages/css/src/utilities/position/api.json
@@ -1,6 +1,25 @@
 {
   "name": "position",
   "type": "utility",
-  "utilities": ["relative", "absolute", "overflow-hidden", "inset-0"],
+  "utilities": [
+    "relative",
+    "absolute",
+    "fixed",
+    "sticky",
+    "inset-0",
+    "top-0",
+    "bottom-0",
+    "start-0",
+    "end-0",
+    "top-2",
+    "bottom-2",
+    "start-2",
+    "end-2",
+    "z-10",
+    "z-20",
+    "z-50",
+    "overflow-hidden",
+    "overflow-auto"
+  ],
   "cssVars": []
 }

--- a/packages/css/src/utilities/position/docs.html
+++ b/packages/css/src/utilities/position/docs.html
@@ -9,6 +9,13 @@ description: Position, overflow, and inset utilities for controlling element pla
   <div class="ui-absolute ui-top-0 ui-end-0 ui-bg-subtle ui-p-1">{{ t('absolute_top_end', 'Absolute top-end') }}</div>
   <div class="ui-absolute ui-bottom-0 ui-start-0 ui-bg-subtle ui-p-1">{{ t('absolute_bottom_start', 'Absolute bottom-start') }}</div>
 </div>
+<div class="ui-sticky ui-top-0 ui-bg-muted ui-p-2">
+  <span class="ui-text-sm">{{ t('sticky_element', 'Sticky element (sticks to top on scroll)') }}</span>
+</div>
+<div class="ui-relative ui-overflow-hidden ui-bg-muted" style="block-size: var(--ui-row-4); transform: translate(0)">
+  <div class="ui-fixed ui-top-0 ui-start-0 ui-bg-subtle ui-p-1">{{ t('fixed_in_container', 'Fixed (contained by transform parent)') }}</div>
+</div>
+<p class="ui-text-sm ui-text-muted">{{ t('position_classes', 'Also available: ui-static') }}</p>
 
 <!-- @inset | row -->
 <!-- Pin element to all edges or specific sides. -->
@@ -17,6 +24,24 @@ description: Position, overflow, and inset utilities for controlling element pla
 </div>
 <div class="ui-relative ui-bg-muted" style="block-size: var(--ui-row-4)">
   <div class="ui-absolute ui-inset-block-0 ui-start-0 ui-bg-subtle ui-p-2">{{ t('inset_block_0_start_0', 'inset-block-0 + start-0') }}</div>
+</div>
+
+<!-- @inset-scale | row -->
+<!-- Offset from edges using space tokens (1-4). -->
+<div class="ui-relative ui-bg-muted" style="block-size: var(--ui-row-4)">
+  <div class="ui-absolute ui-top-1 ui-end-1 ui-bg-subtle ui-p-1">{{ t('top_1_end_1', 'top-1 end-1') }}</div>
+  <div class="ui-absolute ui-bottom-2 ui-start-2 ui-bg-subtle ui-p-1">{{ t('bottom_2_start_2', 'bottom-2 start-2') }}</div>
+</div>
+<div class="ui-relative ui-bg-muted" style="block-size: var(--ui-row-4)">
+  <div class="ui-absolute ui-top-0 ui-end-2 ui-bg-subtle ui-p-1">{{ t('top_0_end_2', 'top-0 end-2') }}</div>
+</div>
+
+<!-- @z-index | row -->
+<!-- Control stacking order. Scale: 0, 10, 20, 30, 40, 50. -->
+<div class="ui-relative ui-bg-muted" style="block-size: var(--ui-row-4)">
+  <div class="ui-absolute ui-top-1 ui-start-1 ui-z-10 ui-bg-subtle ui-p-1">{{ t('z_10', 'z-10') }}</div>
+  <div class="ui-absolute ui-top-2 ui-start-2 ui-z-20 ui-bg ui-p-1 ui-rounded">{{ t('z_20_on_top', 'z-20 on top') }}</div>
+  <div class="ui-absolute ui-top-3 ui-start-3 ui-z-50 ui-bg-subtle ui-p-1 ui-rounded">{{ t('z_50_highest', 'z-50 highest') }}</div>
 </div>
 
 <!-- @overflow | row -->

--- a/packages/css/src/utilities/position/position.scss
+++ b/packages/css/src/utilities/position/position.scss
@@ -35,20 +35,51 @@
     inset-inline: 0;
   }
 
-  .top-0 {
-    inset-block-start: 0;
+  @each $n in (0, 1, 2, 3, 4) {
+    .top-#{$n} {
+      inset-block-start: if($n == 0, 0, var(--ui-space-#{$n}));
+    }
+
+    .bottom-#{$n} {
+      inset-block-end: if($n == 0, 0, var(--ui-space-#{$n}));
+    }
+
+    .start-#{$n} {
+      inset-inline-start: if($n == 0, 0, var(--ui-space-#{$n}));
+    }
+
+    .end-#{$n} {
+      inset-inline-end: if($n == 0, 0, var(--ui-space-#{$n}));
+    }
   }
 
-  .bottom-0 {
-    inset-block-end: 0;
+  // Z-index
+  .z-0 {
+    z-index: 0;
   }
 
-  .start-0 {
-    inset-inline-start: 0;
+  .z-10 {
+    z-index: 10;
   }
 
-  .end-0 {
-    inset-inline-end: 0;
+  .z-20 {
+    z-index: 20;
+  }
+
+  .z-30 {
+    z-index: 30;
+  }
+
+  .z-40 {
+    z-index: 40;
+  }
+
+  .z-50 {
+    z-index: 50;
+  }
+
+  .z-auto {
+    z-index: auto;
   }
 
   // Overflow


### PR DESCRIPTION
## Summary

- Tokenize sidebar-nav `text-transform`/`letter-spacing` and tabs `line-height` as CSS custom properties
- Refine core token defaults: less saturated primary, cooler neutral, 6px radius, 12% shadow strength
- Improve default font stacks with broader cross-platform coverage (oxygen, ubuntu, cantarell, Courier New)
- Extend position utilities: inset scale (0-4), z-index (0-50), overflow variants
- Remove Linear theme preset (defaults now cover the intent)

Closes #437

## Test plan

- [x] `pnpm lint` passes
- [x] `pnpm test:unit` passes (111 tests)
- [x] Visual snapshots verified via Docker (137 passed, no changes needed)
- [ ] CI passes