### PR TITLE
feat(spec): canonical vocabulary at specs/_vocabulary.yaml

### DIFF
--- a/specs/_vocabulary.yaml
+++ b/specs/_vocabulary.yaml
@@ -1,0 +1,134 @@
+# Canonical vocabulary for component specs.
+
+components:
+  # Atoms
+  - Button
+  - Anchor
+  - Input
+  - Select
+  - Textarea
+  - Checkbox
+  - Radio
+  - Switch
+  - Badge
+  - Avatar
+  - Icon
+  - Kbd
+  - Divider
+  - Dot
+  - Code
+
+  # Surfaces and feedback
+  - Card
+  - Alert
+  - Banner
+  - Skeleton
+  - Progress
+
+  # Navigation
+  - Tabs
+  - Segmented
+  - Breadcrumb
+  - Pagination
+  - Menu
+
+  # Overlays
+  - Tooltip
+  - Popover
+  - Modal
+  - Drawer
+  - Toast
+  - Backdrop
+
+  # Composite forms and data
+  - Combobox
+  - DatePicker
+  - Slider
+  - Stepper
+  - Table
+  - Tree
+  - Accordion
+
+  # Layout primitives
+  - Stack
+  - Cluster
+  - Center
+  - Sidebar
+
+# Standard prop names.
+props:
+  - size
+  - variant
+  - intent
+  - disabled
+  - loading
+  - error
+  - density
+  - layout
+  - align
+
+# Variant values (visual hierarchy).
+variants:
+  - solid
+  - outline
+  - ghost
+  - link
+
+# Intent values (semantic color role).
+intents:
+  - neutral
+  - accent
+  - danger
+  - success
+  - warning
+  - info
+
+# Sizes (t-shirt scale).
+sizes:
+  - sm
+  - md
+  - lg
+
+# Size mapping: component size → token suffix.
+sizeMap:
+  sm: 2
+  md: 4
+  lg: 6
+
+# State names (aligned with ARIA where ARIA defines a name).
+states:
+  - disabled
+  - loading
+  - error
+  - success
+  - selected
+  - expanded
+  - pressed
+  - checked
+
+# BEM element-parts.
+parts:
+  - __header
+  - __body
+  - __footer
+  - __title
+  - __description
+  - __icon
+  - __label
+  - __close
+  - __trigger
+  - __panel
+  - __list
+  - __item
+
+# Event verbs (spec form).
+events:
+  - click
+  - submit
+  - dismiss
+  - change
+  - select
+  - open
+  - close
+  - focus
+  - blur


### PR DESCRIPTION
## What
Adds `specs/_vocabulary.yaml` — the canonical lists of component names, prop names, variants, intents, sizes (+ `sizeMap`), states, BEM parts, and event verbs.

## Why
Single source of truth for `validate-spec.ts` (lands at v0.2) to enforce vocabulary conformance across every component spec. Required before any component spec can land — without it, every spec would coin its own private vocabulary and drift becomes inevitable.

Closes #519.

## Test plan
- [ ] File exists at `specs/_vocabulary.yaml`
- [ ] Content matches `docs/rules/naming.md` § "The canonical vocabulary"
- [ ] Includes **Anchor**, **Code**, and **Backdrop** in `components` (audit finding E5)
- [ ] All nine sections present: `components`, `props`, `variants`, `intents`, `sizes`, `sizeMap`, `states`, `parts`, `events`

## Out of scope
- Validator implementation (`scripts/validate-spec.ts`) — lands at v0.2 with codegen
- Per-component specs (each component PR adds its own)
- Stylelint rule keyed off vocabulary for canonical `__part` enforcement (custom plugin — lands when component shape stabilizes)