### PR TITLE
chore(css): baseline @teseor/css version at 0.0.0 (unreleased)

### DIFF
--- a/packages/css/package.json
+++ b/packages/css/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teseor/css",
-  "version": "3.0.0",
+  "version": "0.0.0",
   "description": "Teseor design system — CSS source of truth",
   "type": "module",
   "sideEffects": false,


### PR DESCRIPTION
## What
Changes `packages/css/package.json` version from `3.0.0` to `0.0.0`. The committed version reflects "unreleased"; changesets manages every subsequent bump via the Release PR flow.

## Why
The previous `3.0.0` was aspirational — that release hasn't shipped yet. Hardcoding a target version in the file ahead of the actual release means the value lies until the release lands, and creates two sources of truth (the file vs the npm registry). The right pattern is: file reflects current published state, changesets drives the bump on every release.

Per ADR-0001 ("starting npm versions"), the first published release must clear the pre-existing `@teseor/css@2.5.2` on the old GitHub Packages registry. A single `major` changeset on the first release lifts `0.0.0` to the synchronized launch floor (currently planned as `3.0.0` per the ADR, but the changeset is what decides at release time).

## Test plan
- [ ] `cat packages/css/package.json | jq .version` → `"0.0.0"`
- [ ] `pnpm install` still resolves the workspace without complaint
- [ ] No changeset entry exists yet (Release PR stays unopened until a real bump is requested)

## Out of scope
- Changesets config (`.changeset/config.json`) — lands with the release workflow
- The actual first release (separate PR with the major changeset)