### PR TITLE
fix(css): revert @teseor/css version to 3.0.0 (ADR-0001 launch floor)

### DIFF
--- a/packages/css/package.json
+++ b/packages/css/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teseor/css",
-  "version": "0.0.0",
+  "version": "3.0.0",
   "description": "Teseor design system — CSS source of truth",
   "type": "module",
   "sideEffects": false,


### PR DESCRIPTION
## What
Revert `packages/css/package.json` `version` from `0.0.0` back to `3.0.0`.

## Why
PR #536 (now merged) flipped `3.0.0` to `0.0.0` against ADR-0001's settled decision. The prior published `@teseor/css@2.5.2` on the legacy GitHub Packages registry forces our launch at `3.0.0`. The original `3.0.0` was correct.

Closes #538.

## Test plan
- [ ] `grep version packages/css/package.json` → `"version": "3.0.0"`
- [ ] Diff vs main shows only that single-line revert
- [ ] `.claude/handover.md` "Settled" section updated separately so this doesn't recur

## Out of scope
- Changesets config and release flow — separate work
- The handover.md update — happening now in this session, not part of this PR