### PR TITLE
chore(ci): add release, stale, and size workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,35 @@
+name: release
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+  pull-requests: write
+  id-token: write
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: ./.github/actions/setup
+      - run: pnpm build
+      - id: changesets
+        uses: changesets/action@v1.8.0
+        with:
+          publish: pnpm release
+          version: pnpm changeset version
+          commit: 'chore(release): version packages'
+          title: 'chore(release): version packages'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_PROVENANCE: 'true'

--- a/.github/workflows/size-data.yml
+++ b/.github/workflows/size-data.yml
@@ -1,0 +1,39 @@
+name: size-data
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  measure:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup
+      - run: pnpm build:css
+      - id: dist
+        name: Look for built artifacts
+        run: |
+          if [ -d packages/css/dist ] && [ -n "$(ls -A packages/css/dist 2>/dev/null)" ]; then
+            echo "have_dist=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "have_dist=false" >> "$GITHUB_OUTPUT"
+            echo "No built artifacts yet; size measurement skipped."
+          fi
+      - if: steps.dist.outputs.have_dist == 'true'
+        run: pnpm exec size-limit --json > size-current.json
+      - if: steps.dist.outputs.have_dist == 'true'
+        name: Record PR number for the report job
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: echo "$PR_NUMBER" > pr-number.txt
+      - if: steps.dist.outputs.have_dist == 'true'
+        uses: actions/upload-artifact@v7
+        with:
+          name: size-data
+          path: |
+            size-current.json
+            pr-number.txt
+          if-no-files-found: error

--- a/.github/workflows/size-report.yml
+++ b/.github/workflows/size-report.yml
@@ -1,0 +1,55 @@
+name: size-report
+
+on:
+  workflow_run:
+    workflows: [size-data]
+    types: [completed]
+
+permissions:
+  pull-requests: write
+  actions: read
+
+jobs:
+  report:
+    if: github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - id: artifact
+        name: Download size-data artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: size-data
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+        continue-on-error: true
+      - if: steps.artifact.outcome == 'success'
+        id: render
+        name: Render size table
+        run: |
+          set -e
+          pr_number=$(cat pr-number.txt)
+          echo "pr_number=$pr_number" >> "$GITHUB_OUTPUT"
+          {
+            echo 'body<<EOT'
+            echo '### Bundle size'
+            echo ''
+            echo '| Artifact | Size | Gzip | Limit |'
+            echo '| --- | --- | --- | --- |'
+            node -e '
+              const data = JSON.parse(require("fs").readFileSync("size-current.json", "utf8"));
+              for (const entry of data) {
+                const size = entry.size != null ? (entry.size / 1024).toFixed(2) + " KB" : "—";
+                const gz = entry.passed != null ? (entry.size != null && entry.gzipSize != null ? (entry.gzipSize / 1024).toFixed(2) + " KB" : "—") : "—";
+                const limit = entry.limit || "—";
+                process.stdout.write(`| ${entry.name} | ${size} | ${gz} | ${limit} |\n`);
+              }
+            '
+            echo 'EOT'
+          } >> "$GITHUB_OUTPUT"
+      - if: steps.artifact.outcome == 'success'
+        uses: marocchino/sticky-pull-request-comment@v3
+        with:
+          number: ${{ steps.render.outputs.pr_number }}
+          header: size-report
+          message: ${{ steps.render.outputs.body }}

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,30 @@
+name: stale
+
+on:
+  schedule:
+    - cron: '0 1 * * *'
+  workflow_dispatch:
+
+permissions:
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v10
+        with:
+          stale-pr-message: >-
+            This PR has been inactive for 10 days. Comment, push, or remove
+            the staleness with the `do-not-stale` label — otherwise it will
+            close in 4 days.
+          close-pr-message: >-
+            Closed after 14 days of inactivity. Reopen with a comment if the
+            work is still relevant.
+          days-before-pr-stale: 10
+          days-before-pr-close: 4
+          days-before-issue-stale: -1
+          days-before-issue-close: -1
+          exempt-pr-labels: do-not-stale
+          delete-branch: true
+          operations-per-run: 100

--- a/.size-limit.json
+++ b/.size-limit.json
@@ -1,0 +1,14 @@
+[
+  {
+    "name": "teseor.css (full bundle)",
+    "path": "packages/css/dist/teseor.css",
+    "limit": "12 KB",
+    "gzip": true
+  },
+  {
+    "name": "tokens.css",
+    "path": "packages/css/dist/tokens.css",
+    "limit": "2.5 KB",
+    "gzip": true
+  }
+]

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "lint:spec": "echo 'lint:spec: lands when specs/ has content' && exit 0",
     "gen": "echo 'gen: codegen lands at v0.2' && exit 0",
     "typecheck": "tsc --noEmit",
+    "size": "size-limit",
     "changeset": "changeset",
     "release": "changeset publish",
     "prepare": "lefthook install"
@@ -30,8 +31,10 @@
     "@biomejs/biome": "^2.4.15",
     "@changesets/changelog-git": "^0.2.1",
     "@changesets/cli": "^2.31.0",
+    "@size-limit/file": "^12.1.0",
     "@types/node": "^24.12.4",
     "lefthook": "^2.1.8",
+    "size-limit": "^12.1.0",
     "stylelint": "^17.12.0",
     "stylelint-config-standard": "^40.0.0",
     "typescript": "^6.0.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,12 +17,18 @@ importers:
       '@changesets/cli':
         specifier: ^2.31.0
         version: 2.31.0(@types/node@24.12.4)
+      '@size-limit/file':
+        specifier: ^12.1.0
+        version: 12.1.0(size-limit@12.1.0)
       '@types/node':
         specifier: ^24.12.4
         version: 24.12.4
       lefthook:
         specifier: ^2.1.8
         version: 2.1.8
+      size-limit:
+        specifier: ^12.1.0
+        version: 12.1.0
       stylelint:
         specifier: ^17.12.0
         version: 17.12.0(typescript@6.0.3)
@@ -251,6 +257,12 @@ packages:
     resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
     engines: {node: '>=18'}
 
+  '@size-limit/file@12.1.0':
+    resolution: {integrity: sha512-eGwDcIufnNnvJRzv3liDOn6MAOGgmOTUdpeGQ2KuRTlgIgO54AJH1ilvktlJc6PIjNfwpYY0dOGyap1QgM1swQ==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    peerDependencies:
+      size-limit: 12.1.0
+
   '@types/node@12.20.55':
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
 
@@ -297,6 +309,10 @@ packages:
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
+
+  bytes-iec@3.1.1:
+    resolution: {integrity: sha512-fey6+4jDK7TFtFg/klGSvNKJctyU7n2aQdnM+CO0ruLPbqqMOM8Tio0Pc+deqUeVKX1tL5DQep1zQ7+37aTAsA==}
+    engines: {node: '>= 0.8'}
 
   cacheable@2.3.5:
     resolution: {integrity: sha512-EQfaKe09tl615iNvq/TBRWTFf1AKJNXYQSsMx0Z3EI0nA+pVsVPS8wJhnRlkbdacKPh1d0qVIhwTc2zsQNFEEg==}
@@ -399,6 +415,15 @@ packages:
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
 
   file-entry-cache@11.1.3:
     resolution: {integrity: sha512-oMbq0PD6VIiIwMF6LIa7MEwd/l9huKwmqRKXqmrkqIZv8CvRbfowL+L0ryAl8h//HfAS0zS+4SbYoRyAoA6BJA==}
@@ -614,6 +639,10 @@ packages:
     resolution: {integrity: sha512-tJIoVpFF52PuU8YPJI9bRprGwzI6FR2GNeBbpMnXdRjjfJHyOR4VRLXilzoQ6lbhKVHfTohXhrQgLpU41bKITg==}
     hasBin: true
 
+  lilconfig@3.1.3:
+    resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
+    engines: {node: '>=14'}
+
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
@@ -656,6 +685,9 @@ packages:
     resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
+
+  nanospinner@1.2.2:
+    resolution: {integrity: sha512-Zt/AmG6qRU3e+WnzGGLuMCEAO/dAu45stNbHY223tUxldaDAeE+FxSPsd9Q+j+paejmm0ZbrNVs5Sraqy3dRxA==}
 
   normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
@@ -713,6 +745,10 @@ packages:
   picomatch@2.3.2:
     resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
     engines: {node: '>=8.6'}
+
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
 
   pify@4.0.1:
     resolution: {integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==}
@@ -793,6 +829,16 @@ packages:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
 
+  size-limit@12.1.0:
+    resolution: {integrity: sha512-VnDS2fycANrJFVPQwjaD+h+hkISY7EB3LsPsYWje4lBCjQwwsZLxjwwRwVJKHrcj2ZqyG+DdXykWm9mbZklZrw==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      jiti: ^2.0.0
+    peerDependenciesMeta:
+      jiti:
+        optional: true
+
   slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
@@ -870,6 +916,10 @@ packages:
   term-size@2.2.1:
     resolution: {integrity: sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==}
     engines: {node: '>=8'}
+
+  tinyglobby@0.2.16:
+    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
+    engines: {node: '>=12.0.0'}
 
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
@@ -1182,6 +1232,10 @@ snapshots:
 
   '@sindresorhus/merge-streams@4.0.0': {}
 
+  '@size-limit/file@12.1.0(size-limit@12.1.0)':
+    dependencies:
+      size-limit: 12.1.0
+
   '@types/node@12.20.55': {}
 
   '@types/node@24.12.4':
@@ -1222,6 +1276,8 @@ snapshots:
   braces@3.0.3:
     dependencies:
       fill-range: 7.1.1
+
+  bytes-iec@3.1.1: {}
 
   cacheable@2.3.5:
     dependencies:
@@ -1311,6 +1367,10 @@ snapshots:
   fastq@1.20.1:
     dependencies:
       reusify: 1.1.0
+
+  fdir@6.5.0(picomatch@4.0.4):
+    optionalDependencies:
+      picomatch: 4.0.4
 
   file-entry-cache@11.1.3:
     dependencies:
@@ -1504,6 +1564,8 @@ snapshots:
       lefthook-windows-arm64: 2.1.8
       lefthook-windows-x64: 2.1.8
 
+  lilconfig@3.1.3: {}
+
   lines-and-columns@1.2.4: {}
 
   locate-path@5.0.0:
@@ -1532,6 +1594,10 @@ snapshots:
   ms@2.1.3: {}
 
   nanoid@3.3.12: {}
+
+  nanospinner@1.2.2:
+    dependencies:
+      picocolors: 1.1.1
 
   normalize-path@3.0.0: {}
 
@@ -1577,6 +1643,8 @@ snapshots:
   picocolors@1.1.1: {}
 
   picomatch@2.3.2: {}
+
+  picomatch@4.0.4: {}
 
   pify@4.0.1: {}
 
@@ -1637,6 +1705,14 @@ snapshots:
   shebang-regex@3.0.0: {}
 
   signal-exit@4.1.0: {}
+
+  size-limit@12.1.0:
+    dependencies:
+      bytes-iec: 3.1.1
+      lilconfig: 3.1.3
+      nanospinner: 1.2.2
+      picocolors: 1.1.1
+      tinyglobby: 0.2.16
 
   slash@3.0.0: {}
 
@@ -1746,6 +1822,11 @@ snapshots:
       strip-ansi: 6.0.1
 
   term-size@2.2.1: {}
+
+  tinyglobby@0.2.16:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
 
   to-regex-range@5.0.1:
     dependencies:


### PR DESCRIPTION
## What
Adds the last four v0.1 workflows: changesets-driven release, stale-PR housekeeping, and the split size-data / size-report pair. Brings in `size-limit` + `@size-limit/file` tooling and the per-component / bundle budgets.

## Why
Closes #522 — `release.yml` runs `changesets/action` on push to `main`: maintains the rolling "version packages" PR while changesets exist, then publishes to npm with `--provenance` (Sigstore) once that PR is merged. Permissions scoped to `contents: write` + `pull-requests: write` + `id-token: write`.
Closes #524 — `stale.yml` runs daily, applies the 10-day warn / 14-day close policy to PRs only (issues kept as backlog signal). `size-data.yml` + `size-report.yml` split the measure/report responsibilities so only the report job needs `pull-requests: write`. Both gracefully skip when no built artifacts exist yet — they activate as v0.2 produces `packages/css/dist/`.

## Test plan
- [ ] `size-data` job on this PR logs "No built artifacts yet; size measurement skipped." (no `packages/css/dist/` until v0.2)
- [ ] `size-report` workflow does not trigger (no artifact uploaded by `size-data`)
- [ ] After merge, push to `main` triggers `release.yml`; no changesets exist, so it opens nothing
- [ ] `stale.yml` is reachable via `gh workflow run stale.yml`
- [ ] CI gate (lint + typecheck + test-unit + gen-drift + changeset) still green from sub-PR B

## Out of scope
- Project `CLAUDE.md` + `.claude/commands/*` — separate v0.1 issues tracked under #511–#518
- `protect-main.sh` step 13 — adds the 12 required status checks once all v0.1 workflows have shipped (this PR completes them); follow-up issue
- Setting `NPM_TOKEN` repo secret — required only when the first release actually publishes
- Real bundle baseline diff in `size-report` — current implementation reports the single PR snapshot; baseline comparison can land alongside the first real build in v0.2

## Notes
- Action versions verified against latest releases (May 2026): `changesets/action@v1.8.0`, `actions/stale@v10`, `actions/upload-artifact@v7`, `actions/download-artifact@v8`, `marocchino/sticky-pull-request-comment@v3.0.4`.
- `actions-cool/maintain-one-comment` from issue #524 is now repo-blocked on GitHub; substituted with the equivalent `marocchino/sticky-pull-request-comment@v3` (same single-comment-edited-in-place semantics).
- `actions/stale@v10` instead of the `v9` mentioned in issue #524 — v10 was released April 2026 and is the current stable.