### PR TITLE
chore(ci): add protect-main.sh to configure required status checks

### DIFF
--- a/scripts/protect-main.sh
+++ b/scripts/protect-main.sh
@@ -1,13 +1,10 @@
 #!/usr/bin/env bash
-# Configure the "Protect main" repository ruleset for the v0.1 required status checks.
+# Configure the "Protect main" repository ruleset on the target repo.
 # Idempotent: every run replaces the ruleset's rules with the canonical set defined below.
 #
 # Usage:
 #   scripts/protect-main.sh                # operates on teseor/teseor
 #   TESEOR_REPO=org/fork scripts/protect-main.sh
-#
-# Pre-v1.0 the maintainer self-merges; required_approving_review_count is 0.
-# Bump to 1 once the v1.0 review policy lands.
 
 set -euo pipefail
 
@@ -81,14 +78,8 @@ gh api -X PUT "repos/${REPO}/rulesets/${ruleset_id}" \
   --jq '"Updated ruleset \"" + .name + "\" with " + (.rules | length | tostring) + " rules."'
 
 echo "Required status checks configured for ${REPO}/main:"
-echo "  ci.yml          → lint, typecheck, test-unit, gen-drift, changeset"
-echo "  visual-tests    → visual"
-echo "  pr-discipline   → linked-issue, title-format, body-sections (labeler is a side effect, not gated)"
-echo "  size-data       → measure"
-echo "  CodeQL          → Analyze (javascript-typescript)"
-echo
-echo "Aspirational checks not yet gated (workflows scaffolded but trigger on workflow_run, not PR):"
-echo "  lighthouse / audit       — runs after deploy-docs succeeds (v0.2)"
-echo "  size-report / report     — runs after size-data uploads an artifact (v0.2)"
-echo "  showcase-purity          — workflow lands with the first apps/showcase-*/ in v0.4"
-echo "Add these contexts to the script and re-run when each one starts firing on PRs."
+echo "  ci.yml          lint, typecheck, test-unit, gen-drift, changeset"
+echo "  visual-tests    visual"
+echo "  pr-discipline   linked-issue, title-format, body-sections"
+echo "  size-data       measure"
+echo "  CodeQL          Analyze (javascript-typescript)"

--- a/scripts/protect-main.sh
+++ b/scripts/protect-main.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Configure the "Protect main" repository ruleset for the v0.1 required status checks.
+# Idempotent: every run replaces the ruleset's rules with the canonical set defined below.
+#
+# Usage:
+#   scripts/protect-main.sh                # operates on teseor/teseor
+#   TESEOR_REPO=org/fork scripts/protect-main.sh
+#
+# Pre-v1.0 the maintainer self-merges; required_approving_review_count is 0.
+# Bump to 1 once the v1.0 review policy lands.
+
+set -euo pipefail
+
+REPO="${TESEOR_REPO:-teseor/teseor}"
+RULESET_NAME="Protect main"
+
+ruleset_id="$(
+  gh api "repos/${REPO}/rulesets" \
+    --jq ".[] | select(.name == \"${RULESET_NAME}\") | .id"
+)"
+
+if [ -z "${ruleset_id}" ]; then
+  echo "Ruleset '${RULESET_NAME}' not found on ${REPO}." >&2
+  echo "Create it once via the GitHub UI, then re-run this script." >&2
+  exit 1
+fi
+
+payload="$(cat <<'JSON'
+{
+  "name": "Protect main",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "include": ["refs/heads/main"],
+      "exclude": []
+    }
+  },
+  "rules": [
+    { "type": "deletion" },
+    { "type": "non_fast_forward" },
+    { "type": "required_linear_history" },
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 0,
+        "dismiss_stale_reviews_on_push": false,
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "required_review_thread_resolution": false,
+        "allowed_merge_methods": ["squash"]
+      }
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": false,
+        "do_not_enforce_on_create": false,
+        "required_status_checks": [
+          { "context": "lint" },
+          { "context": "typecheck" },
+          { "context": "test-unit" },
+          { "context": "gen-drift" },
+          { "context": "changeset" },
+          { "context": "visual" },
+          { "context": "linked-issue" },
+          { "context": "title-format" },
+          { "context": "body-sections" },
+          { "context": "measure" },
+          { "context": "Analyze (javascript-typescript)" }
+        ]
+      }
+    }
+  ]
+}
+JSON
+)"
+
+gh api -X PUT "repos/${REPO}/rulesets/${ruleset_id}" \
+  --input - <<<"${payload}" \
+  --jq '"Updated ruleset \"" + .name + "\" with " + (.rules | length | tostring) + " rules."'
+
+echo "Required status checks configured for ${REPO}/main:"
+echo "  ci.yml          → lint, typecheck, test-unit, gen-drift, changeset"
+echo "  visual-tests    → visual"
+echo "  pr-discipline   → linked-issue, title-format, body-sections (labeler is a side effect, not gated)"
+echo "  size-data       → measure"
+echo "  CodeQL          → Analyze (javascript-typescript)"
+echo
+echo "Aspirational checks not yet gated (workflows scaffolded but trigger on workflow_run, not PR):"
+echo "  lighthouse / audit       — runs after deploy-docs succeeds (v0.2)"
+echo "  size-report / report     — runs after size-data uploads an artifact (v0.2)"
+echo "  showcase-purity          — workflow lands with the first apps/showcase-*/ in v0.4"
+echo "Add these contexts to the script and re-run when each one starts firing on PRs."


### PR DESCRIPTION
## What
Adds `scripts/protect-main.sh` — an idempotent script that PATCHes the "Protect main" ruleset on the repo to require the v0.1 status checks (in addition to the existing deletion / non-fast-forward / linear-history / squash-only PR rules).

## Why
Closes #528. The branch-protection ruleset has so far only enforced merge mechanics. Now that all v0.1 workflows have shipped (sub-PR A: pr-discipline; sub-PR B: ci + visual + deploy-docs + lighthouse; sub-PR C: release + stale + size), every PR check that currently fires can be made required. This script is the version-controlled source of truth for that configuration so it survives repo migration and is re-runnable when gate names change.

## Test plan
Maintainer runs (after merge):
- [ ] `bash scripts/protect-main.sh` against `teseor/teseor` — output ends with "Updated ruleset 'Protect main' with 5 rules."
- [ ] `gh api repos/teseor/teseor/rulesets/12815884 --jq '.rules[] | select(.type=="required_status_checks")'` shows all 11 contexts
- [ ] Open a trivial follow-up PR — every required check appears in the "Status checks" UI; merge is blocked until each is green
- [ ] Re-run the script — second run reports the same 5 rules; no error

## Out of scope
- Bumping `required_approving_review_count` from 0 to 1 — happens at v1.0 per `docs/process/agent-workflow.md`
- `lighthouse / audit`, `size-report / report`, `showcase-purity` — scaffolded but trigger on `workflow_run` (or don't exist yet); add them to the script when each starts firing per-PR
- Replicating the ruleset across forks — `TESEOR_REPO=org/fork scripts/protect-main.sh` lets forks reuse it

## Notes
- 11 status checks gated: `lint`, `typecheck`, `test-unit`, `gen-drift`, `changeset`, `visual`, `linked-issue`, `title-format`, `body-sections`, `measure`, `Analyze (javascript-typescript)`.
- `pr-discipline / labeler` is intentionally NOT gated — it is a side effect that applies labels, per `docs/process/agent-workflow.md`.
- Script uses the rulesets API (PUT a full payload) rather than the legacy `branches/{branch}/protection` endpoint mentioned in the issue; the repo already moved to rulesets and the legacy endpoint is read-only when a ruleset exists.
- Marked `executable` (`chmod +x`) in the commit so `scripts/protect-main.sh` works without an explicit `bash` prefix.