### PR TITLE
chore(repo): enforce no-plan-markers rule via check-comments script + hooks

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "Stop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node scripts/check-comments.js --working"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -17,6 +17,9 @@ pre-commit:
     spec:
       glob: 'specs/*.yaml'
       run: pnpm lint:spec
+    no-plan-markers:
+      glob: '*.{ts,tsx,js,jsx,mjs,cjs,css,scss,yaml,yml,sh,md}'
+      run: node scripts/check-comments.js {staged_files}
 
 pre-push:
   commands:

--- a/scripts/check-comments.js
+++ b/scripts/check-comments.js
@@ -1,0 +1,195 @@
+#!/usr/bin/env node
+import { execFileSync } from "node:child_process";
+import { readFileSync, statSync } from "node:fs";
+import { extname, relative } from "node:path";
+
+const PATTERNS = [
+  {
+    label: "phase marker",
+    re: /\bv\d+\.\d+\b/i,
+    hint: "Roadmap phase reference rots; describe what the file IS, not when it ships.",
+  },
+  {
+    label: "decision id",
+    re: /\([MG]\d+\)/,
+    hint: "Decision IDs live in handover/session notes, not in committed artifacts.",
+  },
+  {
+    label: "TODO/FIXME",
+    re: /\b(TODO|FIXME)\b/,
+    hint: "Use `/issue-this <description>` to file an issue instead of an inline TODO.",
+  },
+  {
+    label: "doc-path pointer",
+    re: /(see docs\/|per ADR-\d+|audit [A-Z]\d+)/i,
+    hint: "Paths and ADR numbers rot during refactors; describe the file directly.",
+  },
+];
+
+const EXEMPT_PATH_RES = [
+  /^docs\//,
+  /^\.claude\//,
+  /^\.local\//,
+  /^scripts\/check-comments\.js$/,
+  /^README\.md$/i,
+  /^CONTRIBUTING\.md$/i,
+  /^CHANGELOG\.md$/i,
+  /(^|\/)\.changeset\//,
+];
+
+const SCANNABLE_EXTENSIONS = new Set([
+  ".ts",
+  ".tsx",
+  ".js",
+  ".jsx",
+  ".mjs",
+  ".cjs",
+  ".css",
+  ".scss",
+  ".yaml",
+  ".yml",
+  ".sh",
+  ".md",
+]);
+
+function isExempt(path) {
+  for (const re of EXEMPT_PATH_RES) if (re.test(path)) return true;
+  return false;
+}
+
+function isScannable(path) {
+  const ext = extname(path).toLowerCase();
+  return SCANNABLE_EXTENSIONS.has(ext);
+}
+
+function commentRangesForLine(line, ext) {
+  const ranges = [];
+  if (ext === ".yaml" || ext === ".yml" || ext === ".sh") {
+    const hashIdx = line.indexOf("#");
+    if (hashIdx !== -1) ranges.push([hashIdx, line.length]);
+  } else if (
+    ext === ".js" ||
+    ext === ".ts" ||
+    ext === ".tsx" ||
+    ext === ".jsx" ||
+    ext === ".mjs" ||
+    ext === ".cjs"
+  ) {
+    const lineComment = line.indexOf("//");
+    if (lineComment !== -1) ranges.push([lineComment, line.length]);
+    const blockOpen = line.indexOf("/*");
+    if (blockOpen !== -1) {
+      const blockClose = line.indexOf("*/", blockOpen + 2);
+      ranges.push([blockOpen, blockClose === -1 ? line.length : blockClose + 2]);
+    }
+    if (line.trimStart().startsWith("*") && !line.includes("//")) {
+      ranges.push([0, line.length]);
+    }
+  } else if (ext === ".css" || ext === ".scss") {
+    const blockOpen = line.indexOf("/*");
+    if (blockOpen !== -1) {
+      const blockClose = line.indexOf("*/", blockOpen + 2);
+      ranges.push([blockOpen, blockClose === -1 ? line.length : blockClose + 2]);
+    }
+  } else if (ext === ".md") {
+    return [[0, line.length]];
+  }
+  return ranges;
+}
+
+function scanFile(path) {
+  let raw;
+  try {
+    raw = readFileSync(path, "utf8");
+  } catch {
+    return [];
+  }
+  const ext = extname(path).toLowerCase();
+  const violations = [];
+  const lines = raw.split(/\r?\n/);
+  let inBlockComment = false;
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i] ?? "";
+    let ranges = commentRangesForLine(line, ext);
+    if (inBlockComment) {
+      ranges = [[0, line.length], ...ranges];
+      if (line.includes("*/")) inBlockComment = false;
+    } else if (
+      (line.includes("/*") && !line.includes("*/")) ||
+      (line.includes("/*") && line.indexOf("/*") > line.lastIndexOf("*/"))
+    ) {
+      inBlockComment = true;
+    }
+    if (ranges.length === 0) continue;
+    for (const [start, end] of ranges) {
+      const snippet = line.slice(start, end);
+      for (const { label, re, hint } of PATTERNS) {
+        const match = snippet.match(re);
+        if (match) {
+          violations.push({
+            path,
+            line: i + 1,
+            column: start + (match.index ?? 0) + 1,
+            label,
+            hint,
+            text: line.trim(),
+          });
+        }
+      }
+    }
+  }
+  return violations;
+}
+
+function collectArgs() {
+  const argv = process.argv.slice(2);
+  if (argv.length === 0 || argv.includes("--staged")) {
+    const out = execFileSync("git", ["diff", "--cached", "--name-only", "--diff-filter=ACMR"], {
+      encoding: "utf8",
+    });
+    return out.split("\n").filter(Boolean);
+  }
+  if (argv.includes("--working")) {
+    const out = execFileSync("git", ["ls-files", "--modified", "--others", "--exclude-standard"], {
+      encoding: "utf8",
+    });
+    return out.split("\n").filter(Boolean);
+  }
+  if (argv.includes("--all")) {
+    const out = execFileSync("git", ["ls-files"], { encoding: "utf8" });
+    return out.split("\n").filter(Boolean);
+  }
+  return argv.filter((arg) => !arg.startsWith("--"));
+}
+
+function main() {
+  const files = collectArgs()
+    .filter((p) => !isExempt(p))
+    .filter((p) => isScannable(p))
+    .filter((p) => {
+      try {
+        return statSync(p).isFile();
+      } catch {
+        return false;
+      }
+    });
+
+  let total = 0;
+  for (const file of files) {
+    const violations = scanFile(file);
+    for (const v of violations) {
+      const rel = relative(process.cwd(), v.path);
+      process.stdout.write(`${rel}:${v.line}:${v.column}: [${v.label}] ${v.hint}\n  ${v.text}\n`);
+      total += 1;
+    }
+  }
+  if (total > 0) {
+    process.stdout.write(
+      `\n${total} no-plan-marker violation${total === 1 ? "" : "s"}. Strip phase markers, decision IDs, doc pointers, and TODOs before committing.\n`,
+    );
+    process.exit(1);
+  }
+  process.exit(0);
+}
+
+main();


### PR DESCRIPTION
## What
Adds `scripts/check-comments.js` — scans comment regions of source files for forbidden patterns (phase markers, decision IDs, TODOs, doc-path pointers) — and wires it into both the lefthook `pre-commit` and the Claude Code `Stop` hook so violations are caught before code is committed and before any conversation turn ends.

## Why
Closes #533. Memory-only enforcement of `feedback-no-plan-markers-in-artifacts` keeps failing — the most recent violation (`(v0.2)` / `in v0.4` in `scripts/protect-main.sh`) made it through commit and PR review. A mechanical gate that scans staged files at commit time, plus a Stop hook that runs after every Claude turn, makes the rule cheap to enforce and impossible to forget.

## How it works
- `scripts/check-comments.js` plain Node ESM, no deps. Modes:
  - default (`--staged`): scans files staged for commit — used by lefthook
  - `--working`: scans modified + untracked files — used by the Claude Stop hook
  - `--all`: scans every tracked file — used for one-shot audits
  - bare file paths: scans those files directly — used for ad-hoc testing
- For each scannable file (`*.{ts,tsx,js,jsx,mjs,cjs,css,scss,yaml,yml,sh,md}`), only the comment regions are checked — line comments (`//`, `#`), block comments (`/* ... */`), and `.md` content. This avoids false positives on legitimate version pins (`v1.55.0-jammy`, `pnpm/action-setup@v6`).
- Patterns flagged: phase markers (`vN.N`), decision IDs (`(M\d+)`, `(G\d+)`), `TODO`/`FIXME`, doc-path pointers (`see docs/`, `per ADR-N`, `audit AN`).
- Exempt paths: `docs/`, `.claude/`, `.local/`, `.changeset/`, the script itself, `README.md`, `CONTRIBUTING.md`, `CHANGELOG.md`.

## Test plan
- [ ] Make a temp file like `/tmp/test.css` with `/* lands in v0.4 */` and run `node scripts/check-comments.js /tmp/test.css` — exit 1, message points at line/column
- [ ] Run `node scripts/check-comments.js --all` — exit 0 (current repo is clean)
- [ ] Stage a file with a forbidden pattern and try to commit — lefthook blocks the commit at the `no-plan-markers` step
- [ ] In a Claude Code session, paste a TODO into a tracked file then end the turn — the Stop hook surfaces the violation
- [ ] Version pins (`actions/labeler@v6`, `mcr.microsoft.com/playwright:v1.55.0-jammy`) in YAML keys do NOT trip the check

## Out of scope
- Retroactive cleanup of any pre-existing violations the linter now finds in source — separate PR per file (`tokens.css` cleanup is already tracked as #534)
- Configurable patterns (a JSON config in the repo root) — the patterns are hard-coded for now; a config can land once a second consumer needs different rules
- A failure-comment reporter that posts violations to PRs — pre-commit + Stop hook are the enforcement points; CI doesn't need a separate gate