### PR TITLE
chore(css): strip process commentary from tokens.css and widen check-comments patterns

### DIFF
--- a/.changeset/strip-process-comments-tokens-css.md
+++ b/.changeset/strip-process-comments-tokens-css.md
@@ -1,0 +1,5 @@
+---
+"@teseor/css": patch
+---
+
+Strip process commentary, build-pipeline notes, and doc-path pointers from `tokens.css` comments. No runtime or value change; only the source comments shrink.

--- a/packages/css/src/tokens.css
+++ b/packages/css/src/tokens.css
@@ -1,7 +1,4 @@
-/* Teseor tokens — Tier 1 scale + Tier 2 semantic aliases.
- * Per docs/architecture/three-tier-tokens.md and layer-order.md.
- * Tier 3 (component-private --_x) lives in component files.
- */
+/* Teseor tokens — Tier 1 scale + Tier 2 semantic aliases. */
 
 @layer tokens.scale {
   :root {
@@ -210,8 +207,7 @@
     --t-row: var(--t-row-2);
   }
 
-  /* Forced-colors remap — postcss-teseor-floor double-walks this branch
-   * when inlining literal floors. See ADR-0003 § "Forced-colors resolution". */
+  /* Forced-colors remap to CSS system colors. */
   @media (forced-colors: active) {
     :root {
       --t-fg: CanvasText;
@@ -236,8 +232,7 @@
     }
   }
 
-  /* Breakpoints — defined here so components write @media (--md) { … }.
-   * postcss-custom-media inlines the actual min-width at build time. */
+  /* Breakpoint aliases. */
   @custom-media --md (min-width: 48rem);
   @custom-media --lg (min-width: 64rem);
   @custom-media --xl (min-width: 80rem);

--- a/scripts/check-comments.js
+++ b/scripts/check-comments.js
@@ -21,8 +21,18 @@ const PATTERNS = [
   },
   {
     label: "doc-path pointer",
-    re: /(see docs\/|per ADR-\d+|audit [A-Z]\d+)/i,
-    hint: "Paths and ADR numbers rot during refactors; describe the file directly.",
+    re: /\bdocs\/[a-z]/i,
+    hint: "Paths to docs/ rot during refactors; describe the file directly.",
+  },
+  {
+    label: "ADR reference",
+    re: /\bADR-\d+/,
+    hint: "ADR numbers re-number during merges; describe the constraint inline.",
+  },
+  {
+    label: "audit code",
+    re: /\baudit [A-Z]\d+\b/,
+    hint: "Audit codes only resolve with the handover open; strip from artifacts.",
   },
 ];
 


### PR DESCRIPTION
## What
Two tightly-coupled changes in one PR: (a) strip the four pre-existing process-commentary / doc-pointer / ADR-reference comments from `packages/css/src/tokens.css`, and (b) widen `scripts/check-comments.js` so the same shapes can't slip past the gate again.

## Why
Closes #534. The no-plan-markers guardrail (#533) just landed but its initial pattern list was too narrow — it only matched `see docs/` and `per ADR-\d+`. `tokens.css` carried `Per docs/architecture/...` and `See ADR-0003`, which fell through. Catching them required widening to `\bdocs\/[a-z]` and `\bADR-\d+`. The remaining "lives in component files" / "inlines at build time" lines are pure process commentary with no anchor regex can match, so this PR removes them by hand following #534's acceptance criteria.

This is the single cleanup PR we agreed to in lieu of per-file PRs — one regex-tightening + every existing artifact comment violation, in one merge.

## Test plan
- [ ] `node scripts/check-comments.js --all` exits 0 (whole repo clean under the new patterns)
- [ ] CI `lint` job stays green (stylelint untouched; biome ignores CSS)
- [ ] Bundle output (`packages/css/dist/teseor.css` once v0.2 builds) is byte-identical to the prior content modulo the comment lines — no token values or selectors changed
- [ ] Re-run `node scripts/check-comments.js /tmp/synthetic.css` with `Per docs/...` and `See ADR-0003` — both now flagged

## What got cleaned
- Header reduced to `/* Teseor tokens — Tier 1 scale + Tier 2 semantic aliases. */`
- Forced-colors block comment reduced to `/* Forced-colors remap to CSS system colors. */`
- Breakpoints block comment reduced to `/* Breakpoint aliases. */`
- New patterns in `check-comments.js`: `doc-path pointer` (broadened), `ADR reference` (new), `audit code` (new)
- Changeset added: `@teseor/css: patch` — internal cleanup, no runtime change

## Out of scope
- `tokens.css` token values or `@layer` structure — purely comment edits
- Any other source file — the repo-wide scan is otherwise clean under the new patterns; if more files leak this stuff later, the gate now catches them at commit time