### PR TITLE
chore(claude): add 5 slash commands and project permission allow-list

### DIFF
--- a/.claude/commands/done.md
+++ b/.claude/commands/done.md
@@ -1,0 +1,33 @@
+Wrap up the current branch and open a PR.
+
+## Workflow
+
+1. Verify the working tree is clean (`git status`) and we are on a feature
+   branch, not `main`.
+2. Run `pnpm lint && pnpm typecheck && pnpm test:unit`. If anything fails,
+   stop and surface the error — do not push a red branch.
+3. If `packages/**` was touched, run `pnpm changeset` and write a one-paragraph
+   entry. Skip if only tooling/docs changed (the `ci / changeset` gate enforces
+   this anyway).
+4. `git push -u origin HEAD` if the branch hasn't been pushed yet, else
+   `git push`.
+5. Open the PR with `gh pr create`. Extract the issue number from the branch
+   name (`<type>/<n>-<slug>`) and pre-fill the body using the template:
+   - `## What`: one-sentence summary
+   - `## Why`: the why, ending with `Closes #<n>`
+   - `## Test plan`: checkboxes for verifications a reviewer should do
+   - `## Out of scope`: what intentionally got pushed to a follow-up issue
+6. Wait until all required CI checks turn green before declaring done.
+
+## Failure modes
+
+- **CI fails after push**: drop into systematic debugging. Don't `--no-verify`
+  or `--allow-empty` your way around hook failures.
+- **Branch has commits closing more than three issues**: the PR is too wide.
+  Pause, propose a split to the user.
+- **No issue number in branch name**: ask the user which issue this PR closes,
+  or file one with `/issue-this` first. The `pr-discipline / linked-issue`
+  gate will block otherwise.
+- **`packages/**` changed but no changeset**: stop and ask the user whether
+  this is genuinely user-visible. If yes, write a changeset. If no, the
+  changeset gate will reject the PR.

--- a/.claude/commands/issue-this.md
+++ b/.claude/commands/issue-this.md
@@ -1,0 +1,28 @@
+File a GitHub issue for a mid-session TODO. Argument: a one-line description.
+
+## Workflow
+
+1. Draft a title and body from the description:
+   - Title: `<type>: <subject>` matching the same prefixes the project uses
+     (`feat`, `fix`, `chore`, `docs`, `test`).
+   - Body sections: `## What` (1 sentence), `## Why` (1 paragraph),
+     `## Acceptance` (checkbox list), `## Out of scope` (optional).
+2. Show the draft to the user and ask for confirmation. Adjust on feedback.
+3. Pick the appropriate `type:*` and `area:*` labels — read
+   `.github/labels.yml` for the canonical set.
+4. `gh issue create --title "..." --body "..." --label "type:..." --label "area:..."`.
+5. If invoked from a working branch, add a comment on the new issue linking
+   to the current branch so the connection is discoverable.
+6. Surface the issue URL to the user.
+
+## Failure modes
+
+- **Description is too vague to draft a sensible title**: ask the user one
+  clarifying question before drafting. Never file empty placeholder issues.
+- **Existing issue covers the same scope**: search first with
+  `gh issue list --search "<keywords>"`. If a match exists, comment on it
+  instead of filing a duplicate.
+- **No matching milestone or label exists**: file the issue without one and
+  surface that gap to the user — do not silently create new labels.
+- **User declines the draft**: discard the draft. Do not file a partial
+  version "to revise later".

--- a/.claude/commands/new-component.md
+++ b/.claude/commands/new-component.md
@@ -1,0 +1,36 @@
+Scaffold a new component spec + CSS file + placeholder tests. Argument: the component name (PascalCase).
+
+## Workflow
+
+1. Read `docs/rules/component-shape.md` and `specs/_vocabulary.yaml` live —
+   never rely on a remembered template.
+2. Ask the user: `kind: atomic | composite`, plus any other contextual
+   choices the component requires (initial variants, intents, etc.).
+3. Confirm the slugged name (kebab-case) is in the canonical vocabulary
+   (`specs/_vocabulary.yaml` `components:` list). If not, ask the user
+   whether to add it to vocabulary first — do not silently mint a new name.
+4. Create files:
+   - `specs/<name>.yaml` — required fields per `component-shape.md`,
+     canonical vocabulary applied
+   - `packages/css/src/components/<name>/<name>.css` — skeleton with both
+     `@layer components.tokens` and `@layer components.styles` sublayers,
+     scoped reset for child elements, third-tier fallback chain on every
+     `var(--t-*)` reference
+   - Placeholder Vitest unit test + Playwright visual test under
+     `tests/<name>/` so the test runners pick the component up later
+5. Do NOT run codegen — that is a separate maintainer action (`pnpm gen`)
+   once the spec + CSS are reviewed.
+6. Surface the created files to the user.
+
+## Failure modes
+
+- **Name not in `specs/_vocabulary.yaml`**: stop and confirm with the user
+  whether to extend vocabulary first.
+- **`packages/css/src/components/<name>/` already exists**: stop. Surface
+  the existing files; do not overwrite. The user can rename or pick a
+  different name.
+- **`component-shape.md` references a field the spec validator doesn't
+  recognise yet**: surface the gap; do not invent fields.
+- **CSS skeleton references a token that does not exist in `tokens.css`**:
+  the `build:css` gate will reject. Either reuse an existing token or
+  propose adding one in a separate PR.

--- a/.claude/commands/ship.md
+++ b/.claude/commands/ship.md
@@ -1,0 +1,28 @@
+Squash-merge the current PR and clean up.
+
+## Workflow
+
+1. `gh pr view --json state,mergeable,statusCheckRollup` — confirm the PR is
+   `OPEN`, `MERGEABLE`, and every required status check is `SUCCESS`.
+2. Surface the result to the user. Wait for explicit confirmation before
+   merging — the maintainer self-merges pre-v1.0, but the action is still
+   visible-and-shared, so confirm.
+3. `gh pr merge <n> --squash --delete-branch`.
+4. `git checkout main && git pull origin main`.
+5. Delete the local branch if it still exists.
+6. Verify any linked issues auto-closed; if any are still open, comment with
+   the merge commit to make the link explicit.
+
+## Failure modes
+
+- **Required checks not yet green**: stop. Do not merge with red or pending
+  gates. If a gate is flaky, surface that to the user — do not retry the
+  merge.
+- **PR has merge conflicts**: rebase the branch onto current `main`
+  (`git fetch origin && git rebase origin/main`), resolve conflicts, push,
+  wait for CI again, and re-invoke `/ship`.
+- **`gh pr merge --admin` is being requested**: this bypasses gates. Confirm
+  with the user explicitly that they understand which gates are being
+  bypassed and why. Never default to `--admin`.
+- **Wrong PR number resolved**: when ambiguous, default to the PR opened from
+  the current branch (`gh pr view`), not the most recent PR globally.

--- a/.claude/commands/work-on.md
+++ b/.claude/commands/work-on.md
@@ -1,0 +1,27 @@
+Start work on a GitHub issue. Argument: the issue number.
+
+## Workflow
+
+1. `gh issue view $ARGUMENTS --json title,body,labels,milestone` — load the issue.
+2. Summarise the scope in one sentence and confirm with the user before touching anything.
+3. Pick a branch prefix based on the issue's `type:*` label:
+   - `type:feature` → `feat/`
+   - `type:fix` → `fix/`
+   - `type:chore` → `chore/`
+   - `type:docs` → `docs/`
+4. Slug the issue title (lowercase, dashes, no punctuation, ≤ 50 chars). Branch
+   name: `<prefix>/v0.1-<slug>` or `<prefix>/<n>-<slug>` if no milestone scope
+   makes sense.
+5. `git checkout main && git pull origin main && git checkout -b <branch>`.
+6. Begin the work, posting incremental updates to the user.
+
+## Failure modes
+
+- **Issue is closed or has no milestone**: confirm with the user whether to
+  proceed; closed issues should not silently spawn new branches.
+- **Branch already exists locally or remote**: stop, ask the user whether to
+  resume that branch or pick a new name. Never force-overwrite.
+- **`main` is behind origin and has uncommitted changes**: stash or stop. Do
+  not force a fast-forward over user state.
+- **Working tree dirty on `main`**: stop and surface the diff to the user
+  before switching branches.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,33 @@
 {
+  "permissions": {
+    "allow": [
+      "Bash(pnpm lint)",
+      "Bash(pnpm lint:*)",
+      "Bash(pnpm typecheck)",
+      "Bash(pnpm test)",
+      "Bash(pnpm test:*)",
+      "Bash(pnpm gen)",
+      "Bash(pnpm build)",
+      "Bash(pnpm build:*)",
+      "Bash(pnpm size)",
+      "Bash(node scripts/check-comments.js:*)",
+      "Bash(git status:*)",
+      "Bash(git diff:*)",
+      "Bash(git log:*)",
+      "Bash(git show:*)",
+      "Bash(git branch:*)",
+      "Bash(git fetch:*)",
+      "Bash(gh issue view:*)",
+      "Bash(gh issue list:*)",
+      "Bash(gh pr view:*)",
+      "Bash(gh pr list:*)",
+      "Bash(gh pr checks:*)",
+      "Bash(gh run view:*)",
+      "Bash(gh run list:*)",
+      "Bash(gh api:*)",
+      "Bash(gh label list:*)"
+    ]
+  },
   "hooks": {
     "Stop": [
       {


### PR DESCRIPTION
## What
Adds `.claude/commands/{work-on,done,ship,issue-this,new-component}.md` — the five slash commands described in `docs/process/agent-workflow.md` — and expands `.claude/settings.json` with a project-shared permission allow-list of read-only commands (`pnpm lint/typecheck/test/build/size/gen`, common `git` reads, common `gh` reads).

## Why
Closes #526. Without slash commands, the workflow rules from `agent-workflow.md` only exist as prose — every session has to re-discover them. Wiring them as one-line shortcuts (`/work-on 540`, `/done`, `/ship`, `/issue-this <description>`, `/new-component Button`) means the steps stay consistent across sessions and contributors. Each command file ends with a `## Failure modes` section so partial-state recovery isn't improvised under pressure (e.g., red CI on `/done`, merge conflicts on `/ship`, ambiguous scope on `/work-on`).

The permission allow-list shaves the obvious read-only commands so contributors aren't prompted to approve `pnpm test` 50 times per session. Destructive operations (`git push`, `gh pr merge`, `gh pr create`, `rm`) are intentionally excluded — those still require explicit approval every time.

## Test plan
- [ ] `python3 -c "import json; json.load(open('.claude/settings.json'))"` exits 0
- [ ] In a Claude Code session, type `/work-on 540` — the contents of `work-on.md` load and Claude follows the workflow
- [ ] Same for `/done`, `/ship`, `/issue-this`, `/new-component`
- [ ] Permission prompts no longer fire for `pnpm test`, `git status`, `gh issue view <n>`; still fire for `git push`, `gh pr merge`, etc.
- [ ] `node scripts/check-comments.js --all` still exits 0 (.claude/ is exempt anyway)

## Out of scope
- Project-level `model` setting — left unset so the user / global config decides
- `permissions.deny` block — relying on default-deny instead of enumerating
- Additional slash commands beyond the 5 listed in `agent-workflow.md` — extensions can land per-need

## Notes
- The `/new-component` command intentionally does NOT run codegen — it scaffolds spec + CSS + placeholder tests. Codegen runs separately via `pnpm gen` once the spec is reviewed.
- The Stop hook for `check-comments.js` from #533 is preserved alongside the new `permissions` block.