### PR TITLE
chore(repo): add community files, legal, and Renovate config

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -36,3 +36,7 @@
 - name: no-issue
   color: cccccc
   description: PR intentionally without a closing issue; bypasses linked-issue gate
+
+- name: dep
+  color: 0366d6
+  description: Renovate-driven dependency update

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,85 @@
+
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at letanure@gmail.com. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,48 @@
+# Contributing
+
+Thanks for considering a contribution.
+
+## File an issue first
+
+Every PR closes at least one issue. If none exists, file one with the
+appropriate template (`Bug`, `Feature`, `RFC`) at
+https://github.com/teseor/teseor/issues/new/choose.
+
+## Open a PR
+
+- Branch from `main`. Name it `<type>/<issue-number>-<slug>` (for example
+  `feat/123-button-loading`).
+- Title: conventional-commit format, `type(scope): subject`. See
+  `docs/process/pr-shape.md` for scopes.
+- Body: fill in **What**, **Why**, **Test plan**, **Out of scope**, and
+  `Closes #N`.
+- Keep handwritten LOC at or below 500. Generated files do not count.
+- Add a changeset (`pnpm changeset`) if `packages/` changed.
+- One concern per PR.
+
+PR-discipline CI checks linked issue, title format, body sections, and
+labels. See `docs/process/agent-workflow.md`.
+
+## Run locally
+
+Requires Node 24 and pnpm 11.
+
+```bash
+pnpm install
+pnpm dev        # docs site and watchers
+pnpm lint       # Biome, Stylelint, spec validator
+pnpm typecheck  # tsc --noEmit
+pnpm test       # unit, visual, a11y
+```
+
+See `docs/process/dev-scripts.md` for the full script catalog.
+
+## Path-specific guidance
+
+Per-area conventions (CSS, codegen, specs, framework wrappers, docs,
+i18n) live in `docs/process/contribution-paths.md`. Read the section
+matching your change before opening the PR.
+
+## Code of conduct
+
+By participating, you agree to the `CODE_OF_CONDUCT.md`.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 letanure
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,32 @@
+# Security policy
+
+## Reporting a vulnerability
+
+**Do not file a public issue or pull request for security findings.**
+
+Report the issue through GitHub's private security advisory flow:
+https://github.com/teseor/teseor/security/advisories/new
+
+Include:
+
+- A description of the vulnerability and its impact.
+- Steps to reproduce, or a minimal proof-of-concept.
+- The version (or commit SHA) you tested against.
+- Any suggested mitigation, if you have one.
+
+You will receive an acknowledgement within 5 business days.
+
+## Disclosure window
+
+The maintainer will work with you to assess the report, develop a fix, and
+coordinate disclosure. The default disclosure window is **90 days from the
+acknowledgement date** — after a fix ships, or after 90 days have elapsed
+(whichever comes first), the advisory becomes public.
+
+For findings actively being exploited, the window can be shortened by mutual
+agreement.
+
+## Supported versions
+
+Only the most recent minor release of `@teseor/*` packages receives security
+fixes. Older releases are end-of-life on the day a new minor ships.

--- a/TRADEMARK.md
+++ b/TRADEMARK.md
@@ -1,0 +1,24 @@
+# Trademark policy
+
+"Teseor" and the Teseor logo are trademarks of the project maintainer. The
+codebase is open-source under the MIT License, but the name and brand assets
+are not.
+
+## Permitted (fair use)
+
+- Saying your project "uses Teseor", is "built on Teseor", or is "compatible
+  with Teseor".
+- Linking to the project, referencing the name in tutorials, blog posts, talks,
+  and documentation.
+- Using the unmodified logo to indicate that your project uses Teseor.
+
+## Not permitted without written permission
+
+- Using "Teseor" (or a confusingly similar name) for a fork, redistribution,
+  commercial product, hosted service, or component library.
+- Modifying the Teseor logo, or using it in a way that implies endorsement
+  the project hasn't given.
+- Domain names, package names on public registries, or social handles that
+  could be mistaken for the official project.
+
+If you're unsure, file an issue or email the maintainer before publishing.

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "schedule": ["* * * * 0,6"],
+  "labels": ["dep"],
+  "commitMessageTopic": "{{depName}}",
+  "commitMessageExtra": "{{currentVersion}} → {{newVersion}}",
+  "semanticCommits": "enabled",
+  "semanticCommitType": "chore",
+  "semanticCommitScope": "deps",
+  "prHourlyLimit": 4,
+  "prConcurrentLimit": 10,
+  "automerge": false,
+  "rangeStrategy": "bump",
+  "lockFileMaintenance": {
+    "enabled": true,
+    "schedule": ["* * 1 * *"]
+  },
+  "packageRules": [
+    {
+      "matchDatasources": ["npm"],
+      "matchPackageNames": [
+        "react",
+        "react-dom",
+        "@types/react",
+        "@types/react-dom",
+        "vue",
+        "@vue/**",
+        "svelte",
+        "@sveltejs/**",
+        "@angular/**"
+      ],
+      "groupName": "frameworks"
+    },
+    {
+      "matchDatasources": ["npm"],
+      "matchPackageNames": [
+        "@biomejs/**",
+        "stylelint",
+        "stylelint-**",
+        "@playwright/test",
+        "playwright"
+      ],
+      "groupName": "dev tooling"
+    },
+    {
+      "matchDatasources": ["npm"],
+      "matchPackageNames": ["postcss", "postcss-**", "vite", "@vitejs/**", "vite-plugin-**"],
+      "groupName": "build tooling"
+    }
+  ]
+}

--- a/scripts/check-comments.js
+++ b/scripts/check-comments.js
@@ -44,6 +44,7 @@ const EXEMPT_PATH_RES = [
   /^CLAUDE\.md$/,
   /^README\.md$/i,
   /^CONTRIBUTING\.md$/i,
+  /^CODE_OF_CONDUCT\.md$/i,
   /^CHANGELOG\.md$/i,
   /(^|\/)\.changeset\//,
 ];


### PR DESCRIPTION
## What

Adds the repo-root community, legal, and dependency-update files:

- `LICENSE` — MIT, copyright `letanure`.
- `TRADEMARK.md` — fair-use policy for the Teseor name and logo.
- `SECURITY.md` — GHSA private-advisory disclosure flow, 90-day window.
- `CODE_OF_CONDUCT.md` — Contributor Covenant 2.1, contact set to the maintainer email.
- `CONTRIBUTING.md` — one-screen guide (issue first, PR shape, dev commands, link to `docs/process/contribution-paths.md`).
- `renovate.json` — weekend schedule, `dep` label, grouped framework / dev tooling / build tooling updates, monthly lockfile maintenance, no automerge.
- `.github/labels.yml` — adds the `dep` label so Renovate PRs land correctly.
- `scripts/check-comments.js` — exempts `CODE_OF_CONDUCT.md` from the no-plan-markers scan (the upstream Covenant text references its own version, which is fixed, not a roadmap phase).

## Why

Closes #530.

These files unblock public discovery, set the disclosure flow before the first publish, and put dependency updates on a predictable cadence under the same PR-discipline gates as everything else.

## Test plan

- [ ] `gh repo view` shows LICENSE detected as MIT.
- [ ] Security tab points to `SECURITY.md`.
- [ ] Community Standards page shows COC, CONTRIBUTING, LICENSE green.
- [ ] PR-discipline gates pass (linked issue, title format, body sections, labels).
- [ ] On the next scheduled weekend Renovate produces grouped PRs titled `chore(deps): <name> <old> -> <new>` with the `dep` label.

## Out of scope

- `docs/process/contribution-paths.md` referenced from CONTRIBUTING.md is tracked under #531.
- Renovate dashboard issue auto-creation — defaults are fine for now; revisit if signal/noise gets bad.