### PR TITLE
docs(repo): add contribution paths, end-to-end migration, RFC template

### DIFF
--- a/docs/RFC/_template.md
+++ b/docs/RFC/_template.md
@@ -1,0 +1,138 @@
+---
+status: draft
+proposed: YYYY-MM-DD
+decided:
+---
+
+# <NNNN> — <short title>
+
+> Copy this file to `docs/RFC/<NNNN>-<short-slug>.md`. Pick the next free
+> number. Fill every section. "Unresolved questions" can be substantive —
+> RFCs land in `status: draft` and graduate as the design firms up.
+>
+> Delete this blockquote before opening the PR.
+
+## Summary
+
+One paragraph. What is the proposal? Plain prose, no jargon a first-time
+reader of this repo wouldn't recognize. If you can't summarize the proposal
+in a paragraph, the proposal is two RFCs.
+
+## Motivation
+
+The concrete problem this RFC exists to solve.
+
+- Who hit it? (a contributor, a consumer, a specific component, CI, the
+  release pipeline)
+- What does the current state cost them? Lost time, wrong output, blocked
+  work, surprising behavior — be specific.
+- Why can't the existing process or tooling handle it?
+
+"We should be more consistent" is not motivation. "Three contributors in
+the last quarter wrote `.t-btn` instead of `.t-button` because the docs
+example shows the old name" is motivation.
+
+## Detailed design
+
+The proposal in full. Anyone reading just this section should be able to
+implement the RFC without asking follow-up questions.
+
+Cover, where relevant:
+
+- The shape of the change — new file, new field on an existing schema,
+  new package, new CI gate.
+- Examples of the new shape in use. Use real component names, real prop
+  names, real tokens — not `Foo` and `bar`.
+- How the change interacts with existing rules and tooling. Which lint
+  rules need updating, which validators need new clauses, which CI gates
+  need to know about the change.
+- What "done" looks like — what files exist, what tests pass, what error
+  messages a contributor or consumer sees in the new world.
+
+Prefer code blocks and tables over prose where they fit. The detailed
+design is reference material; it gets re-read whenever someone
+implements or audits the RFC.
+
+## Drawbacks
+
+Why might we not want to do this?
+
+Be honest. Every RFC has drawbacks; an RFC with no listed drawbacks hasn't
+been thought through. Examples of real drawbacks:
+
+- Adds a new tool with its own learning curve.
+- Increases the time-to-first-contribution for newcomers.
+- Couples two parts of the system that were previously independent.
+- Costs bundle size, build time, or CI minutes.
+- Conflicts with a probable future change (name a specific one).
+
+If the drawbacks outweigh the motivation, the RFC should be rejected, not
+patched until the section is empty.
+
+## Alternatives
+
+List at least one realistic alternative that was considered and rejected.
+"Do nothing" is always an alternative; in many RFCs it's the right one,
+which is why the section is mandatory.
+
+Each alternative gets a paragraph: what would it look like, what does it
+cost, why is it weaker than the proposal? "We considered using X but
+decided not to" is not enough — say what X would have meant in practice
+and what specifically tipped the decision the other way.
+
+## Adoption strategy
+
+What does this change look like for someone using Teseor today?
+
+- Migration window — does this require a major bump? A deprecation cycle?
+  None of the above (additive)?
+- Codemod — does the change ship a codemod? If not, why is it
+  judgment-required rather than mechanical? (See
+  `process/versioning.md` § "Codemods".)
+- Default vs opt-in — does the change become the default immediately, or
+  is there a phase where consumers opt in by setting a flag, an attribute,
+  or an import path?
+- Backwards compatibility — what consumer code keeps working unchanged?
+  What breaks?
+
+If "no consumers are affected, this is repo-internal," say so explicitly.
+That's a valid adoption story.
+
+## Unresolved questions
+
+Open questions the RFC doesn't answer. Be specific:
+
+- Names that aren't finalized.
+- Edge cases the design might not handle.
+- Decisions deferred to implementation.
+- Things you'd like reviewer input on before promoting to `proposed`.
+
+It's fine for this section to be long while the RFC is in `draft`. By the
+time the RFC is `accepted`, every question here should be resolved or
+moved into a follow-up RFC.
+
+## What this doesn't propose
+
+Bound the scope. List adjacent ideas the RFC is *not* trying to settle so
+reviewers don't argue about them in the PR thread:
+
+- "This RFC doesn't change the existing `--t-*` token naming."
+- "This RFC doesn't address Vue/Svelte parity — that's tracked separately."
+- "This RFC doesn't propose tooling changes; if accepted, the validator
+  update is a follow-up PR."
+
+A bounded RFC lands. An unbounded one accumulates objections.
+
+## Lifecycle reminder
+
+- `draft` — opened for discussion. The PR adds the file in `draft`.
+- `proposed` — design is stable; ready for a final pass before implementation.
+- `accepted` — implementation has landed (or is landing in the same PR for
+  small RFCs). `decided:` is filled in.
+- `rejected` — closed without implementation. Kept in `docs/RFC/` so the
+  reasoning survives.
+- `superseded` — replaced by a later RFC. Cross-link to the replacement in
+  the frontmatter.
+
+Files are kept on every terminal state. The reasoning is the artifact,
+not the outcome.

--- a/docs/process/contribution-paths.md
+++ b/docs/process/contribution-paths.md
@@ -1,0 +1,204 @@
+# Contribution paths
+
+Each contribution kind has its own shape. Pick the right path before you open
+a PR — the wrong path triggers the wrong gates and slows review down.
+
+| Path | What you file | What gets reviewed | Typical turnaround |
+| --- | --- | --- | --- |
+| [Component](#component) | spec + CSS + tests | spec coverage, CSS rules, visual + a11y output | 1–2 review cycles |
+| [Theme](#theme) | one token-only CSS file | token-set completeness, contrast, fallback chain | 1 cycle |
+| [Vocabulary addition](#vocabulary-addition) | PR against `_vocabulary.yaml` | term necessity, naming consistency | 1 cycle |
+| [Codemod](#codemod) | new transform in `packages/codemods/` | transform correctness, fixtures, idempotency | 1–2 cycles |
+| [RFC](#rfc) | a doc in `docs/RFC/` from the template | shape of the proposal, motivation, alternatives | 1 cycle to land in `proposed`; weeks to `accepted` |
+
+If you're not sure which path applies, file an issue first and ask. The wrong
+path is recoverable; an unscoped PR is not.
+
+## Component
+
+When the change introduces a new component, or adds variants/intents/sizes to
+an existing one.
+
+**What to file**
+
+- `specs/<name>.yaml` — declares variants, intents, sizes, props, tokens, a11y
+  contract, examples, motion. See `architecture/codegen-pipeline.md` for the
+  full schema.
+- `packages/css/src/components/<name>/<name>.css` — the handwritten CSS.
+  Token contract in the spec must match every `--t-<name>-*` declared in CSS
+  (validator enforces both directions).
+- `pnpm gen` regenerates wrappers, contract types, docs data, and test
+  scaffolds. Commit the regenerated output — `gen-drift` CI fails if it's
+  missing.
+- A Playwright example per `spec.examples[]` entry. Default scaffold from
+  `gen-tests.ts` is the starting point; add assertions beyond rendering when
+  the behavior calls for it.
+- A changeset — `pnpm changeset` — at the level dictated by the change:
+  new component → minor, new variant → minor, bug fix → patch.
+
+**What gets reviewed**
+
+- Spec follows the schema and uses canonical vocabulary (`_vocabulary.yaml`).
+- CSS obeys hard rules (`rules/hard-rules.md`), motion rules
+  (`rules/motion.md`), and the responsive contract (`rules/responsive.md`).
+- a11y: keyboard map + ARIA contract listed in spec match what the Playwright
+  + axe tests assert.
+- Visual snapshots: new examples have baselines; existing baselines unchanged.
+- Bundle delta is reasonable for the added surface.
+
+**Out of scope on this path**
+
+Refactors of unrelated components, token additions, or theme tweaks. Bundle
+those separately.
+
+## Theme
+
+When the change adds or updates a `[data-theme="…"]` skin.
+
+**What to file**
+
+- One file at `themes/<theme>.css` (or edits to an existing one).
+- Token-only. The Stylelint theme-purity rule blocks any declaration that
+  isn't a `--t-*` custom property. Allowed selectors are `:root`,
+  `[data-theme="<id>"]`, the mode-pair `[data-theme="<id>"][data-mode="…"]`,
+  and the `@media (prefers-color-scheme: …)` form. See
+  `architecture/themes.md` for the canonical file shape.
+- A changeset (minor — a new theme is consumer-facing surface).
+
+**What gets reviewed**
+
+- Every token in the public contract has a value (no missing variables once
+  the theme is active).
+- Contrast pairs documented in `rules/accessibility.md` clear the WCAG floor.
+- No class selectors, element selectors, `@import`, or `!important`.
+- The fallback chain still resolves when the theme is partially supported
+  (older browsers).
+
+**Out of scope**
+
+Component-shape changes, new tokens. Theme files consume the token contract;
+they don't extend it. Adding a token is a separate PR against `tokens.css`.
+
+## Vocabulary addition
+
+When the change adds a term to the shared vocabulary (variant names, intent
+names, size names, prop names, slot names).
+
+**What to file**
+
+- A PR against `specs/_vocabulary.yaml` adding the term and a one-line
+  rationale.
+- If the term lands a new value in an existing axis (e.g. a sixth size), the
+  PRs that adopt the value follow — but the vocabulary PR is independent and
+  reviewable on its own.
+
+**What gets reviewed**
+
+- The term doesn't already exist under a different name.
+- It composes with the rest of the vocabulary (a new intent should pair with
+  every variant; a new size should slot into the existing scale).
+- Naming follows `rules/naming.md` — short, lowercase, kebab where multi-word,
+  no abbreviations that aren't already in the vocabulary.
+
+**Out of scope**
+
+Adopting the new term in components. Land vocabulary first, then the
+component PRs that use it. This keeps each PR small and reverts clean.
+
+## Codemod
+
+When a breaking change ships and a mechanical rewrite covers most consumer
+code paths.
+
+**What to file**
+
+- A new transform in `packages/codemods/src/<from>-to-<to>/<rule>.ts`.
+- Fixtures: paired `input.<ext>` / `output.<ext>` in
+  `packages/codemods/test/<from>-to-<to>/<rule>/`. The test runner asserts
+  `transform(input) === output` and `transform(output) === output`
+  (idempotency).
+- A README at `packages/codemods/src/<from>-to-<to>/README.md` listing the
+  available rules.
+- A changeset against `@teseor/codemods` (minor or patch — codemods don't
+  bump the design-system version).
+
+**What gets reviewed**
+
+- Transform covers the documented cases (the migration guide lists them).
+- Tests include at least one fixture where the transform is a no-op
+  (proving idempotency).
+- The rule is named after the *change*, not the version
+  (`--rule=class-rename`, not `--rule=v0-6`).
+- Edge cases that can't be transformed are detected and reported, not silently
+  passed through.
+
+**Out of scope**
+
+Judgment-required transformations — anything that changes the *meaning* of
+the code rather than just renaming or restructuring it. Those go into the
+migration guide as prose, not as a codemod.
+
+**See also**
+
+`process/versioning.md` § "Codemods" for the mechanical / judgment-required
+split, and `process/migrations-end-to-end.md` for the full lifecycle of a
+breaking change.
+
+## RFC
+
+When the change is a design or process proposal that deserves discussion
+before implementation. Use the RFC path when:
+
+- The change touches the public API contract beyond a single component.
+- The change adopts or replaces a tool that the whole codebase depends on.
+- The change introduces a new architectural concept (a new package, a new
+  generator, a new build pipeline).
+- Reasonable contributors might disagree on the right shape.
+
+**What to file**
+
+- Copy `docs/RFC/_template.md` to `docs/RFC/<NNNN>-<short-slug>.md`. Pick the
+  next free number.
+- Fill every section. "Unresolved questions" can be substantive — RFCs land
+  in `status: draft` and graduate.
+- Open a PR. The PR's only purpose is landing the RFC in `draft` (or
+  `proposed`); implementation is a follow-up PR.
+
+**What gets reviewed**
+
+- Motivation is concrete (a problem someone has hit, not "we should be more
+  consistent").
+- "Alternatives" lists at least one realistic option that was considered and
+  rejected.
+- "Adoption strategy" answers the question "what does this look like for
+  someone using Teseor today" — migration window, codemod or guide, default
+  vs opt-in.
+- The proposal is bounded. "What this *doesn't* propose" is as important as
+  what it does.
+
+**After landing in `draft`**
+
+- Discussion happens on the PR (or, if it's settled, on follow-up PRs that
+  reference the RFC by file path — never by number, since RFCs renumber on
+  merge conflicts).
+- The author or a maintainer moves it to `proposed` when the design is
+  stable, then to `accepted` when implementation lands, then to `superseded`
+  if a later RFC replaces it. `rejected` is a valid terminal state — closed
+  RFCs are kept, not deleted, so the reasoning survives.
+
+**Out of scope on this path**
+
+Implementation. Land the RFC first, file the implementation issue from it,
+then ship the implementation in a normal component / theme / codemod PR.
+
+## When none of the above fits
+
+Tooling changes, repo-scoped configuration, CI tweaks, dev-script edits —
+file an issue with the `type:chore` label and propose the change. These
+don't need a dedicated path because the surface is small and the review is
+"does this work locally and in CI."
+
+If the chore PR turns out to be larger than expected (touches more than
+~3 files of substance, or changes contributor workflow), pause it and open
+an RFC instead. The path you started on isn't binding — switching paths is
+cheap; landing a big change on the wrong path is not.

--- a/docs/process/migrations-end-to-end.md
+++ b/docs/process/migrations-end-to-end.md
@@ -1,0 +1,297 @@
+# Migrations end-to-end
+
+A worked example of a breaking change, from the spec edit to the consumer
+upgrade command. Reference for anyone authoring a rename, removing a prop,
+or changing a default that consumers depend on.
+
+Worked rename: **`.t-btn` → `.t-button`**. The class is API; renaming it is
+a major bump. The same shape applies to token renames, prop renames, and
+removed variants.
+
+## 0. Decide whether to do it at all
+
+Class names land in consumer markup. Tokens land in consumer themes and
+overrides. Props land in consumer code. Every breaking rename is a tax on
+every consumer that's adopted that surface. The bar is:
+
+- The current name is actively wrong (typo, ambiguous, conflicts with a
+  reserved keyword in a target framework).
+- The current name blocks a future addition (no room to expand without
+  ambiguity).
+- A migration costs the consumer less than living with the wrong name
+  forever.
+
+If the rename is purely aesthetic ("`.t-btn` feels short to me"), close the
+issue. Breaking changes accumulate frustration consumers don't see in the
+PR — they hit it later, when they try to upgrade.
+
+## 1. Edit the spec
+
+The spec is the source of truth. Change it first.
+
+```yaml
+# specs/button.yaml
+name: button
+rootClass: t-button        # was: t-btn
+file: components/button/button.css
+```
+
+`validate-spec.ts` runs on every save (via lefthook and the lint CI gate).
+It compares `rootClass` against the class actually declared in
+`packages/css/src/components/button/button.css`. Spec and CSS are out of
+sync until step 2.
+
+## 2. Run the schema migrator
+
+For trivial renames the spec edit + a search-replace in the component CSS
+is enough. For non-trivial schema shifts (a prop changes shape, a variant
+splits into two) the repo ships `scripts/migrate-specs.ts`. The migrator
+takes a rule file describing the transform and rewrites every affected
+spec + CSS file in one pass. The rule lands alongside the breaking change
+in the same PR.
+
+For the class rename, the migrator step is two commands:
+
+```bash
+# Rename the class in the component CSS file
+pnpm migrate-specs --rule class-rename --from t-btn --to t-button
+
+# Verify spec + CSS now agree
+pnpm lint:spec
+```
+
+The migrator updates `packages/css/src/components/button/button.css` and
+any sibling files that referenced `t-btn` (sub-elements like
+`.t-btn__icon` get the same suffix substitution). It leaves consumer-facing
+files (showcase apps, docs site source) untouched — those go through the
+codemod path in step 4.
+
+## 3. Regenerate wrappers + contract + docs + tests
+
+```bash
+pnpm gen
+```
+
+This re-runs every generator listed in `architecture/codegen-pipeline.md`:
+React/Vue/Svelte/Angular/webc wrappers, the TypeScript contract, the docs
+site's components data, the Playwright scaffolds, and `teseor-ast.json`.
+Every file that referenced `t-btn` now references `t-button` because the
+spec did.
+
+Commit the regenerated output. `gen-drift` is a CI gate; it runs
+`pnpm gen && git diff --exit-code` and fails the PR if the committed
+output differs from a fresh regeneration.
+
+## 4. Write the changeset
+
+```bash
+pnpm changeset
+```
+
+Pick the affected packages (the whole `@teseor/*` fixed group bumps
+together — see `process/release.md`). Pick **major**. Write the
+changeset entry with a `migration:` block:
+
+```md
+---
+"@teseor/css": major
+"@teseor/react": major
+"@teseor/vue": major
+"@teseor/svelte": major
+"@teseor/angular": major
+"@teseor/webc": major
+migration: |
+  ## `.t-btn` → `.t-button`
+
+  The Button root class is renamed for consistency with the spec contract
+  (every component's `rootClass` is now `t-<spec-name>`). Search-replace
+  in consumer HTML and CSS.
+
+  Codemod available:
+
+  ```
+  npx @teseor/codemods/<from>-to-<to> --rule=class-rename
+  ```
+
+  The codemod rewrites `.t-btn` occurrences in `.html`, `.tsx`, `.jsx`,
+  `.vue`, `.svelte`, and `.css` files under the working directory.
+---
+
+Renames the Button root class to align with the spec contract.
+```
+
+The build step concatenates every breaking changeset's `migration:` block
+into one document at `docs/migrations/v<from>-to-v<to>.md` on release. See
+`process/versioning.md` § "Migration guides" for the full assembly.
+
+## 5. Author the codemod
+
+The codemod is a separate file under `packages/codemods/`. It ships in the
+same PR as the breaking change, so consumers can run it the moment the new
+version publishes.
+
+```
+packages/codemods/
+├── src/
+│   └── <from>-to-<to>/
+│       ├── class-rename.ts          # the transform
+│       ├── index.ts                 # registers the rule
+│       └── README.md                # what rules exist, how to run
+└── test/
+    └── <from>-to-<to>/
+        └── class-rename/
+            ├── input.html
+            ├── output.html
+            ├── input.tsx
+            ├── output.tsx
+            └── input.css
+            └── output.css
+```
+
+The transform itself is small — a regex over class attribute values for
+HTML/JSX, a regex over class selectors for CSS. Use `jscodeshift` for
+JS/TS so AST scoping is right; use the in-house CSS transformer for
+`.css` and `.scss`. Both are wired up in `packages/codemods/src/runner.ts`.
+
+**Testing**
+
+Two fixtures per file type: one input that should change, one input that
+shouldn't (idempotency). The test runner asserts:
+
+```ts
+expect(transform(input)).toEqual(output);
+expect(transform(output)).toEqual(output);  // idempotent
+```
+
+Running the codemod twice is a no-op. This matters because consumers may
+run it once, hit an unrelated error, fix the error, and re-run.
+
+## 6. Release notes
+
+`changesets/action` writes the npm release notes from the changeset entries
+plus the assembled migration guide. The published notes include:
+
+- The version (`@teseor/*@<to>.0.0`).
+- The migration guide URL (`teseor.dev/migrations/v<from>-to-v<to>`).
+- The codemod command (`npx @teseor/codemods/<from>-to-<to>`).
+- The list of changes at this version.
+
+The release-notes shape isn't hand-authored — it falls out of the
+mechanism. See `process/release.md`.
+
+## 7. Consumer upgrades
+
+The consumer-facing flow, from the upgrade prompt to a working app:
+
+```bash
+# 1. Update the package versions
+pnpm up "@teseor/*"
+
+# 2. Run the codemod against the source tree
+npx @teseor/codemods/<from>-to-<to>
+
+# 3. Or scope to a single rule
+npx @teseor/codemods/<from>-to-<to> --rule=class-rename
+```
+
+The codemod walks the working directory, applies every registered rule for
+the `<from>-to-<to>` pair, prints a summary, and exits. Unchanged files
+aren't touched. Files with un-rewritable patterns (e.g. dynamically
+constructed class names) emit a warning with the file path and line.
+
+## Deprecation window
+
+Removal is preceded by deprecation. The lifecycle is **2 minor releases**
+between `deprecated: true` in the spec and the actual removal. Version-
+based, not time-based, because release cadence varies and version
+arithmetic doesn't. See `process/versioning.md` § "Deprecation lifecycle".
+
+For the class rename:
+
+| Version | State |
+| --- | --- |
+| current | `.t-btn` is the documented class. |
+| current + 1 minor | `.t-button` ships as the new name. `.t-btn` still works (CSS aliases) and is marked `deprecated: true` in the spec. IDE shows the deprecation; docs page shows a banner. |
+| current + 2 minors | Reminder warnings; consumer apps that build with strict mode see the deprecation in their lint output. |
+| current + 3 minors (= next major) | `.t-btn` is removed. The codemod ships with the major release. |
+
+The migration is *announced* over three minors; the *removal* is a single
+major. Consumers who upgrade incrementally never get surprised.
+
+**Fast path.** When a rename can't wait — security fix, blocking bug,
+conflict with a new browser feature — the deprecation window can be
+collapsed to zero, but the change still rides a major and ships a codemod.
+The migration guide explicitly notes "no deprecation cycle" in that case
+so consumers know to expect the change in a single jump.
+
+## Testing the codemod against a real project
+
+Beyond the fixture tests inside the repo, run the codemod against a real
+consumer-shaped project before publishing.
+
+```bash
+# In the design-system repo
+pnpm --filter "@teseor/codemods" build
+
+# In a consumer-shaped sandbox
+git clone <a-real-app-using-teseor>  ./sandbox
+cd sandbox
+npx /path/to/teseor/packages/codemods/dist/<from>-to-<to>
+git diff   # review the rewrite
+pnpm build # confirm the app still builds
+```
+
+The sandbox can be one of the showcase apps in the same monorepo — they
+consume the design system end-to-end, which is what consumers are doing.
+A codemod that breaks a showcase app is shipping broken.
+
+## When a codemod isn't possible
+
+Some breaking changes can't be transformed. They require human judgment.
+Examples:
+
+- A component's *behavior* changes even though the API surface looks the
+  same. Modal used to focus the first focusable child on open; now it
+  focuses the trigger after close. A codemod can't rewrite the user's
+  intent.
+- A component is split into two. `Dropdown` becomes `Menu` (action picker)
+  and `Select` (form control). The right replacement depends on what the
+  consumer was using it for.
+- A prop's *semantics* shift. `size: lg` used to be a `40px` row; it now
+  refers to a token that resolves to `44px`. Some consumers want the
+  new value; others were targeting the old one numerically.
+
+The migration guide covers these cases as prose, with concrete examples
+of "if your code looks like X, change it to Y." No codemod ships for them.
+The migration guide section header is `## <change> (manual)` so consumers
+running the codemod know it doesn't cover this case.
+
+## The full PR shape
+
+A breaking-change PR carries:
+
+- Spec edit (1 file).
+- Component CSS edit (1 file).
+- Regenerated wrappers + contract + docs + tests (many files, but they
+  come out of `pnpm gen` — they don't count against the 500-LOC budget;
+  see `process/pr-shape.md`).
+- A changeset with the `migration:` block.
+- A codemod transform + fixtures + README in `packages/codemods/`.
+- A changelog entry will fall out of the changeset on release; you don't
+  hand-write one.
+
+Closes 1–3 issues — usually one tracking issue for the breaking change
+plus the codemod issue if filed separately. Two reviewers minimum
+post-v1.0; the maintainer self-merges before that.
+
+## Escape hatch: when none of this fits
+
+If you've hit a case where the spec-driven flow above doesn't apply —
+something CSS can't express, a behavior that has to be hand-authored, a
+removal with no successor — open an RFC (`process/contribution-paths.md`
+§ "RFC"). The RFC documents what doesn't fit and proposes a new shape.
+Don't ship the breaking change against the existing process; the
+discipline exists so consumers can predict upgrades.
+
+This document is the path the discipline supports. Everything else is an
+RFC.


### PR DESCRIPTION
## What

Three docs that close the audit-identified gaps in the contributor onboarding surface:

- `docs/process/contribution-paths.md` — one section per contribution type (component, theme, vocabulary, codemod, RFC, chore fallback). Each section: when to use, what to file, what gets reviewed, expected turnaround. Wraps up with a path-switch escape hatch.
- `docs/process/migrations-end-to-end.md` — worked rename `.t-btn` → `.t-button`. Walks spec edit → schema migrator → wrapper regeneration → changeset (major) → codemod authored at `packages/codemods/<from>-to-<to>` → release notes → consumer-side `npx @teseor/codemods/<from>-to-<to>` invocation. Covers the 2-minor deprecation window, codemod testing strategy (idempotency + sandbox-against-showcase), the fast path, and the "codemod isn't possible" escape hatch.
- `docs/RFC/_template.md` — frontmatter (`status: draft | proposed | accepted | rejected | superseded`, `proposed:`, `decided:`) plus React-style sections (Summary, Motivation, Detailed design, Drawbacks, Alternatives, Adoption strategy, Unresolved questions, What this doesn't propose, Lifecycle reminder).

## Why

Closes #531.

`CONTRIBUTING.md` (landed in #549) forward-references `contribution-paths.md`. The migration walkthrough is the concrete worked example that the versioning policy abstracts. The RFC template unblocks the RFC path that `contribution-paths.md` describes.

## Test plan

- [ ] PR-discipline gates pass (linked issue, title format, body sections, labels).
- [ ] Links from `CONTRIBUTING.md` to `docs/process/contribution-paths.md` resolve.
- [ ] Cross-references inside the three docs (to `versioning.md`, `codegen-pipeline.md`, `pr-shape.md`, `release.md`, `rules/*`) all point to existing files.
- [ ] `pnpm lint:spec` passes (no spec changes, but it confirms the workspace is healthy).

## Out of scope

- `scripts/migrate-specs.ts` itself — the migrations doc references it as the tool; the implementation is part of #529.
- The `@teseor/codemods` package — referenced by both docs as the consumer-facing tool; the package itself lands when the first major bump needs it.
- Numbered RFCs filled from the template — the template is the artifact for this PR.