### PR TITLE
chore(scripts): add migrate-specs skeleton and verify-no-dev-leak

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,14 @@ jobs:
             exit 1
           fi
 
+  verify-no-dev-leak:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup
+      - run: pnpm -r --if-present run build
+      - run: pnpm verify:no-dev-leak
+
   changeset:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -23,6 +23,8 @@
     "gen": "echo 'gen: codegen lands at v0.2' && exit 0",
     "typecheck": "tsc --noEmit",
     "size": "size-limit",
+    "migrate-specs": "node scripts/migrate-specs.ts",
+    "verify:no-dev-leak": "node scripts/verify-no-dev-leak.js",
     "changeset": "changeset",
     "release": "changeset publish",
     "prepare": "lefthook install"

--- a/scripts/migrate-specs.ts
+++ b/scripts/migrate-specs.ts
@@ -1,0 +1,124 @@
+#!/usr/bin/env node
+import { parseArgs } from "node:util";
+
+type MigratorContext = {
+  from: string;
+  to: string;
+  rule?: string;
+  args: Record<string, string | undefined>;
+};
+
+type Migrator = {
+  id: string;
+  description: string;
+  run: (ctx: MigratorContext) => Promise<MigrationReport> | MigrationReport;
+};
+
+type MigrationReport = {
+  filesChanged: string[];
+  notes: string[];
+};
+
+const REGISTRY: Migrator[] = [];
+
+function registerMigrator(m: Migrator): void {
+  REGISTRY.push(m);
+}
+
+export type { MigrationReport, Migrator, MigratorContext };
+export { registerMigrator };
+
+function printUsage(): void {
+  process.stdout.write(`Usage: pnpm migrate-specs --from <oldSchema> --to <newSchema> [--rule <id>] [extra args]
+
+Examples:
+  pnpm migrate-specs --from 0.5 --to 0.6 --rule class-rename --old t-btn --new t-button
+
+Available migrators:
+${
+  REGISTRY.length === 0
+    ? "  (none — register migrators by importing this file and calling registerMigrator())"
+    : REGISTRY.map((m) => `  ${m.id} — ${m.description}`).join("\n")
+}
+
+Notes:
+  - Schema change + migrator + gen-drift catch-up land in a single PR.
+  - Migrators are idempotent. Running twice is a no-op.
+`);
+}
+
+function parseCli(): {
+  from?: string;
+  to?: string;
+  rule?: string;
+  rest: Record<string, string | undefined>;
+} {
+  const { values } = parseArgs({
+    options: {
+      from: { type: "string" },
+      to: { type: "string" },
+      rule: { type: "string" },
+      old: { type: "string" },
+      new: { type: "string" },
+      help: { type: "boolean", short: "h" },
+    },
+    strict: false,
+    allowPositionals: true,
+  });
+  if (values.help) {
+    printUsage();
+    process.exit(0);
+  }
+  return {
+    from: values.from as string | undefined,
+    to: values.to as string | undefined,
+    rule: values.rule as string | undefined,
+    rest: values as Record<string, string | undefined>,
+  };
+}
+
+async function main(): Promise<void> {
+  const { from, to, rule, rest } = parseCli();
+
+  if (!from || !to) {
+    printUsage();
+    process.exit(from || to ? 1 : 0);
+  }
+
+  if (REGISTRY.length === 0) {
+    process.stdout.write(
+      `migrate-specs: no migrators registered. from=${from} to=${to}${rule ? ` rule=${rule}` : ""}\n`,
+    );
+    process.stdout.write("Nothing to do. Register a migrator before running.\n");
+    process.exit(0);
+  }
+
+  const ctx: MigratorContext = { from, to, rule, args: rest };
+  const selected = rule ? REGISTRY.filter((m) => m.id === rule) : REGISTRY;
+
+  if (selected.length === 0) {
+    process.stderr.write(`migrate-specs: no migrator matches rule="${rule}"\n`);
+    process.stderr.write(`Registered: ${REGISTRY.map((m) => m.id).join(", ")}\n`);
+    process.exit(1);
+  }
+
+  const totalChanges: string[] = [];
+  for (const migrator of selected) {
+    process.stdout.write(`migrate-specs: running ${migrator.id}\n`);
+    const report = await migrator.run(ctx);
+    totalChanges.push(...report.filesChanged);
+    for (const note of report.notes) process.stdout.write(`  ${note}\n`);
+  }
+
+  process.stdout.write(
+    `\nmigrate-specs: ${totalChanges.length} file${totalChanges.length === 1 ? "" : "s"} changed\n`,
+  );
+  if (totalChanges.length > 0) {
+    process.stdout.write("Run pnpm gen and commit the regenerated output.\n");
+  }
+}
+
+main().catch((err) => {
+  process.stderr.write(`migrate-specs: ${err instanceof Error ? err.message : String(err)}\n`);
+  process.exit(1);
+});

--- a/scripts/verify-no-dev-leak.js
+++ b/scripts/verify-no-dev-leak.js
@@ -1,0 +1,115 @@
+#!/usr/bin/env node
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { extname, join, relative, resolve } from "node:path";
+
+const ROOT = resolve(import.meta.dirname, "..");
+const PACKAGES_DIR = join(ROOT, "packages");
+
+const SCANNED_EXTENSIONS = new Set([".js", ".mjs", ".cjs", ".css"]);
+
+const DEV_PATTERNS = [
+  { label: "__DEV__", re: /\b__DEV__\b/ },
+  { label: "console.warn", re: /\bconsole\.warn\s*\(/ },
+  { label: "console.error", re: /\bconsole\.error\s*\(/ },
+  { label: "console.debug", re: /\bconsole\.debug\s*\(/ },
+  { label: "console.info", re: /\bconsole\.info\s*\(/ },
+  { label: "console.trace", re: /\bconsole\.trace\s*\(/ },
+];
+
+function walk(dir) {
+  let out = [];
+  let entries;
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return out;
+  }
+  for (const entry of entries) {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === "node_modules") continue;
+      out = out.concat(walk(path));
+    } else if (entry.isFile() && SCANNED_EXTENSIONS.has(extname(entry.name))) {
+      out.push(path);
+    }
+  }
+  return out;
+}
+
+function findDistDirs() {
+  let pkgs;
+  try {
+    pkgs = readdirSync(PACKAGES_DIR, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+  const dists = [];
+  for (const pkg of pkgs) {
+    if (!pkg.isDirectory()) continue;
+    const dist = join(PACKAGES_DIR, pkg.name, "dist");
+    try {
+      if (statSync(dist).isDirectory()) dists.push(dist);
+    } catch {
+      // package has no dist yet — fine
+    }
+  }
+  return dists;
+}
+
+function scanFile(path) {
+  const content = readFileSync(path, "utf8");
+  const violations = [];
+  const lines = content.split(/\r?\n/);
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i] ?? "";
+    for (const { label, re } of DEV_PATTERNS) {
+      const match = line.match(re);
+      if (match) {
+        violations.push({
+          path,
+          line: i + 1,
+          column: (match.index ?? 0) + 1,
+          label,
+          text: line.trim().slice(0, 120),
+        });
+      }
+    }
+  }
+  return violations;
+}
+
+function main() {
+  const distDirs = findDistDirs();
+  if (distDirs.length === 0) {
+    process.stdout.write("verify-no-dev-leak: no packages/*/dist directories found; skipping.\n");
+    process.exit(0);
+  }
+
+  let total = 0;
+  for (const dist of distDirs) {
+    for (const file of walk(dist)) {
+      for (const v of scanFile(file)) {
+        const rel = relative(ROOT, v.path);
+        process.stdout.write(`${rel}:${v.line}:${v.column}: [${v.label}] ${v.text}\n`);
+        total += 1;
+      }
+    }
+  }
+
+  if (total > 0) {
+    process.stdout.write(
+      `\n${total} dev-only marker${total === 1 ? "" : "s"} found in production bundles.\n`,
+    );
+    process.stdout.write(
+      "Dev-only branches must be guarded by __DEV__ (or equivalent) so the bundler tree-shakes them.\n",
+    );
+    process.exit(1);
+  }
+
+  process.stdout.write(
+    `verify-no-dev-leak: scanned ${distDirs.length} dist director${distDirs.length === 1 ? "y" : "ies"}, no dev leaks.\n`,
+  );
+  process.exit(0);
+}
+
+main();


### PR DESCRIPTION
## What

- `scripts/migrate-specs.ts` — skeleton CLI with a migrator registry. `pnpm migrate-specs --from <oldSchema> --to <newSchema> [--rule <id>]` invokes registered migrators; the initial implementation is a no-op stub with an exported `registerMigrator()` interface so real migrations register here as the schema reopens at later milestones.
- `scripts/verify-no-dev-leak.js` — walks `packages/*/dist/**/*.{js,mjs,cjs,css}` and greps for `__DEV__`, `console.warn`, `console.error`, `console.debug`, `console.info`, `console.trace`. Exits 1 if any survives in a production bundle. Skips with exit 0 when no `dist/` directories exist yet (pre-build state).
- `package.json` — adds `pnpm migrate-specs` and `pnpm verify:no-dev-leak`.
- `.github/workflows/ci.yml` — new `verify-no-dev-leak` job runs `pnpm -r --if-present run build` then `pnpm verify:no-dev-leak` as a post-build assertion. Today the job is a no-op (no packages yet); it activates the moment the first `@teseor/*` package builds.

## Why

Closes #529.

The migrations walkthrough that landed in #550 references `pnpm migrate-specs` as the spec-rewrite tool. Without the skeleton the walkthrough cites a tool that doesn't exist. The verify script ports the equivalent Vue treeshaking check so dev-only branches in published bundles fail CI rather than ship.

## Test plan

- [ ] `pnpm migrate-specs --help` prints usage and exits 0.
- [ ] `pnpm migrate-specs --from 0.5 --to 0.6` prints "no migrators registered" and exits 0.
- [ ] `pnpm verify:no-dev-leak` prints "no packages/*/dist directories found; skipping" and exits 0 (pre-build).
- [ ] `pnpm typecheck` and `pnpm lint` stay green.
- [ ] The new CI `verify-no-dev-leak` job runs on this PR and passes.

## Out of scope

- Real migrator implementations — register them when the schema reopens at the milestones noted in `docs/architecture/codegen-pipeline.md` § "Spec shape".
- Build-output tests for the verify script — meaningful only once the first package ships a real `dist/`.
- Adding the new `verify-no-dev-leak` check as a required status check on `main` — that's done via `scripts/protect-main.sh` once the job has at least one successful run on `main`.