### PR TITLE
chore(repo): clean up pnpm-workspace.yaml dangling members

### DIFF
--- a/apps/preview/package.json
+++ b/apps/preview/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@teseor/preview",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Static preview page for hand-checking tokens, reset, and base styles."
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,6 +39,8 @@ importers:
         specifier: ^6.0.3
         version: 6.0.3
 
+  apps/preview: {}
+
   packages/css: {}
 
 packages:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,3 @@
 packages:
   - 'packages/*'
   - 'apps/*'
-  - 'scripts/codegen'


### PR DESCRIPTION
## What

Drop `scripts/codegen` from `pnpm-workspace.yaml` (directory does not exist; the real package lands with #554). Add a minimal private `apps/preview/package.json` stub so the existing `index.html` lives under a declared workspace member.

After the change:

- 3 workspace projects (root + `packages/css` + `apps/preview`).
- `pnpm install --frozen-lockfile --ignore-scripts` clean.
- `pnpm lint` clean.
- `pnpm-lock.yaml` picks up `apps/preview: {}` under `importers`.

## Why

`#553`, `#554`, and every C* PR consume the workspace. Resolving the dangling references now is cheaper than chasing install warnings during component work. Closes #552.

## Test plan

- [x] `pnpm install --frozen-lockfile --ignore-scripts`
- [x] `pnpm lint`
- [ ] CI green

## Out of scope

- Real `scripts/codegen` package — tracked under #554.
- Filling `apps/preview` with real content — separate work once a docs / playground app shape is decided.

Closes #552