### PR TITLE
chore(codegen): scaffold @teseor/codegen workspace package

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "lint:ts": "biome check .",
     "lint:css": "stylelint 'packages/**/*.css'",
     "lint:spec": "echo 'lint:spec: lands when specs/ has content' && exit 0",
-    "gen": "echo 'gen: codegen lands at v0.2' && exit 0",
+    "gen": "pnpm --filter @teseor/codegen run gen",
     "typecheck": "tsc --noEmit",
     "size": "size-limit",
     "migrate-specs": "node scripts/migrate-specs.ts",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,6 +43,8 @@ importers:
 
   packages/css: {}
 
+  scripts/codegen: {}
+
 packages:
 
   '@babel/code-frame@7.29.0':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,4 @@
 packages:
   - 'packages/*'
   - 'apps/*'
+  - 'scripts/codegen'

--- a/scripts/codegen/package.json
+++ b/scripts/codegen/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@teseor/codegen",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Teseor codegen — registry-driven entrypoint for spec-derived artifacts.",
+  "type": "module",
+  "scripts": {
+    "gen": "node src/cli.ts"
+  },
+  "files": [
+    "src"
+  ]
+}

--- a/scripts/codegen/src/cli.ts
+++ b/scripts/codegen/src/cli.ts
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+import { parseArgs } from "node:util";
+import type { GeneratorContext } from "./registry.ts";
+import { getGenerator, listGenerators } from "./registry.ts";
+
+function formatGeneratorList(): string {
+  const registered = listGenerators();
+  if (registered.length === 0) {
+    return "  (none — register via registerGenerator(name, fn))";
+  }
+  return registered.map((id) => `  ${id}`).join("\n");
+}
+
+function printUsage(): void {
+  process.stdout.write(`Usage: pnpm gen <generator> [args]
+
+Available generators:
+${formatGeneratorList()}
+`);
+}
+
+async function main(): Promise<void> {
+  const { values, positionals } = parseArgs({
+    options: {
+      help: { type: "boolean", short: "h" },
+    },
+    strict: false,
+    allowPositionals: true,
+  });
+
+  if (values.help) {
+    printUsage();
+    return;
+  }
+
+  const name = positionals[0];
+  if (!name) {
+    printUsage();
+    return;
+  }
+
+  const fn = getGenerator(name);
+  if (!fn) {
+    process.stderr.write(`gen: unknown generator "${name}"\n`);
+    const registered = listGenerators();
+    process.stderr.write(
+      `Registered: ${registered.length > 0 ? registered.join(", ") : "(none)"}\n`,
+    );
+    process.exit(1);
+  }
+
+  const ctx: GeneratorContext = {
+    args: { ...(values as Record<string, string | undefined>) },
+    positionals: positionals.slice(1),
+  };
+  const report = await fn(ctx);
+  for (const note of report.notes) {
+    process.stdout.write(`  ${note}\n`);
+  }
+  process.stdout.write(
+    `gen ${name}: ${report.filesWritten.length} file${report.filesWritten.length === 1 ? "" : "s"} written\n`,
+  );
+}
+
+main().catch((err) => {
+  process.stderr.write(`gen: ${err instanceof Error ? err.message : String(err)}\n`);
+  process.exit(1);
+});

--- a/scripts/codegen/src/registry.ts
+++ b/scripts/codegen/src/registry.ts
@@ -1,0 +1,31 @@
+type GeneratorContext = {
+  args: Record<string, string | undefined>;
+  positionals: readonly string[];
+};
+
+type GeneratorReport = {
+  filesWritten: string[];
+  notes: string[];
+};
+
+type GeneratorFn = (ctx: GeneratorContext) => Promise<GeneratorReport> | GeneratorReport;
+
+const REGISTRY = new Map<string, GeneratorFn>();
+
+function registerGenerator(name: string, fn: GeneratorFn): void {
+  if (REGISTRY.has(name)) {
+    throw new Error(`generator "${name}" is already registered`);
+  }
+  REGISTRY.set(name, fn);
+}
+
+function getGenerator(name: string): GeneratorFn | undefined {
+  return REGISTRY.get(name);
+}
+
+function listGenerators(): string[] {
+  return [...REGISTRY.keys()].sort();
+}
+
+export type { GeneratorContext, GeneratorFn, GeneratorReport };
+export { getGenerator, listGenerators, registerGenerator };

--- a/scripts/codegen/tsconfig.json
+++ b/scripts/codegen/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["src/**/*.ts"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
     "esModuleInterop": true,
     "isolatedModules": true,
     "verbatimModuleSyntax": true,
+    "allowImportingTsExtensions": true,
     "skipLibCheck": true,
     "allowJs": true,
     "resolveJsonModule": true,


### PR DESCRIPTION
## What

Stand up `scripts/codegen/` as a real `@teseor/codegen` workspace package:

- `scripts/codegen/package.json` — private, `type: module`, `gen` script.
- `scripts/codegen/tsconfig.json` — extends root, scoped to `src/`.
- `scripts/codegen/src/cli.ts` — `parseArgs`-based CLI, dispatches to the registry, exits non-zero on unknown generator name.
- `scripts/codegen/src/registry.ts` — `registerGenerator(name, fn)` / `getGenerator(name)` / `listGenerators()`. No generators registered yet.
- `pnpm-workspace.yaml` — re-adds `scripts/codegen` (workspace count goes from 3 → 4).
- Root `gen` script delegates: `pnpm --filter @teseor/codegen run gen`.
- `tsconfig.json` — enables `allowImportingTsExtensions` so Node-native TS imports type-check.

## Why

Every C* issue (#558–#561) needs to register a generator into this package. Without the scaffold, each codegen PR rebuilds the same boilerplate. A3 is the next blocker after A1 (#552) lands; A1 just removed the stale dangling `scripts/codegen` member, so this PR re-adds it with a real package behind it.

The issue text reads `pnpm --filter @teseor/codegen exec gen`, but `exec` requires the workspace package's own `bin` to be linked into a `node_modules/.bin` reachable from itself — pnpm only links bins of declared dependencies, not the package's own. `run gen` invokes the package script directly, works under `--ignore-scripts`, and matches the pattern used elsewhere (`migrate-specs`, etc.). Same routing, no bin gymnastics.

## Test plan

- `pnpm install --frozen-lockfile --ignore-scripts` — clean, lockfile diff is the workspace-member registration only.
- `pnpm gen` — prints usage, exits 0, produces no file diff (gen-drift CI stays green).
- `pnpm gen unknown-name` — prints `gen: unknown generator "unknown-name"`, exits 1.
- `pnpm typecheck` — clean.
- `pnpm lint` — clean (Biome + Stylelint).
- `pnpm verify:no-dev-leak` — clean (no `dist/` yet, no-op as designed).
- `node scripts/check-comments.js` — clean.

## Out of scope

- Actual generators (gen-contract, gen-react, gen-docs, gen-tests) — C1–C4.
- Spec loading — lands with gen-contract (#558).
- Output diff strategy for codegen drift — current `git diff --quiet` check is sufficient until the first generator writes files.

Closes #554