### PR TITLE
feat(css): real PostCSS build pipeline with spacing and display utilities

### DIFF
--- a/.changeset/a4-postcss-build-pipeline.md
+++ b/.changeset/a4-postcss-build-pipeline.md
@@ -1,0 +1,10 @@
+---
+"@teseor/css": minor
+---
+
+Real PostCSS build pipeline (`postcss-import` + `postcss-each` + `postcss-custom-media`) replaces the stub `build` script. `dist/` now contains:
+
+- `dist/teseor.css` — full bundle (reset + tokens + base + utilities) in layer order.
+- `dist/tokens.css`, `dist/utilities.css`, `dist/tailwind.css` — individual entry points.
+
+New utility classes (`t-` prefix): `t-p-{0..8}`, `t-px-{0..8}`, `t-py-{0..8}`, `t-m-{0..8}`, `t-mx-{0..8}`, `t-my-{0..8}`, `t-gap-{0..8}` over the `--t-space-*` scale; `t-block`, `t-inline`, `t-inline-block`, `t-flex`, `t-inline-flex`, `t-grid`, `t-inline-grid`, `t-contents`, `t-hidden`. Output is deterministic across runs. Size-limit budget added.

--- a/package.json
+++ b/package.json
@@ -30,6 +30,28 @@
     "release": "changeset publish",
     "prepare": "lefthook install"
   },
+  "size-limit": [
+    {
+      "name": "@teseor/css (full bundle)",
+      "path": "packages/css/dist/teseor.css",
+      "limit": "8 kB"
+    },
+    {
+      "name": "@teseor/css/tokens.css",
+      "path": "packages/css/dist/tokens.css",
+      "limit": "4 kB"
+    },
+    {
+      "name": "@teseor/css/utilities.css",
+      "path": "packages/css/dist/utilities.css",
+      "limit": "2 kB"
+    },
+    {
+      "name": "@teseor/css/tailwind.css",
+      "path": "packages/css/dist/tailwind.css",
+      "limit": "6 kB"
+    }
+  ],
   "devDependencies": {
     "@biomejs/biome": "^2.4.15",
     "@changesets/changelog-git": "^0.2.1",

--- a/packages/css/README.md
+++ b/packages/css/README.md
@@ -1,0 +1,66 @@
+# `@teseor/css`
+
+CSS source of truth for Teseor. Tokens, reset, base elements, and a small
+spacing + display utility set, distributed as four entry points.
+
+## Install
+
+```bash
+npm install @teseor/css
+```
+
+## Entry points
+
+| Import | What it ships |
+| --- | --- |
+| `@teseor/css` | Full bundle: reset + tokens + base + utilities, in layer order. |
+| `@teseor/css/tokens.css` | Tokens only (`--t-*` scale + semantic aliases). |
+| `@teseor/css/utilities.css` | Utility classes only. |
+| `@teseor/css/tailwind.css` | Tailwind v4 `@theme` bridge mapping `--t-*` to `--color-*` / `--spacing-*` / `--radius-*`. |
+
+## Utility classes
+
+All utilities are prefixed `t-` to avoid collisions when vendored alongside
+other CSS frameworks. Spacing utilities pull their value from the
+`--t-space-{0..8}` scale (see `src/tokens.css`).
+
+### Spacing
+
+| Class | Property |
+| --- | --- |
+| `.t-p-{0..8}` | `padding` |
+| `.t-px-{0..8}` | `padding-inline` |
+| `.t-py-{0..8}` | `padding-block` |
+| `.t-m-{0..8}` | `margin` |
+| `.t-mx-{0..8}` | `margin-inline` |
+| `.t-my-{0..8}` | `margin-block` |
+| `.t-gap-{0..8}` | `gap` |
+
+Directional logical pairs (`padding-inline-start` etc.) are applied
+per-rule inside component CSS rather than shipped as utility classes.
+
+### Display
+
+| Class | `display` value |
+| --- | --- |
+| `.t-block` | `block` |
+| `.t-inline` | `inline` |
+| `.t-inline-block` | `inline-block` |
+| `.t-flex` | `flex` |
+| `.t-inline-flex` | `inline-flex` |
+| `.t-grid` | `grid` |
+| `.t-inline-grid` | `inline-grid` |
+| `.t-contents` | `contents` |
+| `.t-hidden` | `none` |
+
+## Build
+
+The published `dist/` is generated from `src/` by `packages/css/build.mjs`,
+a PostCSS pipeline (`postcss-import` + `postcss-each` + `postcss-custom-media`).
+Run locally:
+
+```bash
+pnpm --filter @teseor/css build
+```
+
+Output is deterministic across runs.

--- a/packages/css/build.mjs
+++ b/packages/css/build.mjs
@@ -1,0 +1,51 @@
+#!/usr/bin/env node
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import postcss from "postcss";
+import postcssCustomMedia from "postcss-custom-media";
+import postcssEach from "postcss-each";
+import postcssImport from "postcss-import";
+
+const ROOT = dirname(fileURLToPath(import.meta.url));
+const SRC = resolve(ROOT, "src");
+const DIST = resolve(ROOT, "dist");
+
+const ENTRIES = [
+  { from: "teseor.css", to: "teseor.css" },
+  { from: "tokens.css", to: "tokens.css" },
+  { from: "utilities.css", to: "utilities.css" },
+  { from: "tailwind.css", to: "tailwind.css" },
+];
+
+function buildPlugins() {
+  return [postcssImport(), postcssEach(), postcssCustomMedia()];
+}
+
+async function buildOne({ from, to }) {
+  const inputPath = resolve(SRC, from);
+  const outputPath = resolve(DIST, to);
+  const css = await readFile(inputPath, "utf8");
+  const result = await postcss(buildPlugins()).process(css, {
+    from: inputPath,
+    to: outputPath,
+    map: false,
+  });
+  for (const warn of result.warnings()) {
+    process.stderr.write(`build-css ${from}: ${warn.toString()}\n`);
+  }
+  await writeFile(outputPath, `${result.css.trimEnd()}\n`, "utf8");
+  process.stdout.write(`build-css: ${from} -> dist/${to}\n`);
+}
+
+async function main() {
+  await mkdir(DIST, { recursive: true });
+  for (const entry of ENTRIES) {
+    await buildOne(entry);
+  }
+}
+
+main().catch((err) => {
+  process.stderr.write(`build-css: ${err instanceof Error ? err.message : String(err)}\n`);
+  process.exit(1);
+});

--- a/packages/css/package.json
+++ b/packages/css/package.json
@@ -31,7 +31,7 @@
     "src"
   ],
   "scripts": {
-    "build": "echo 'build:css pipeline lands at v0.2 with the first component' && exit 0",
+    "build": "node build.mjs",
     "test": "vitest run"
   },
   "publishConfig": {
@@ -43,5 +43,11 @@
     "type": "git",
     "url": "git+https://github.com/teseor/teseor.git",
     "directory": "packages/css"
+  },
+  "devDependencies": {
+    "postcss": "^8.5.15",
+    "postcss-custom-media": "^12.0.1",
+    "postcss-each": "^1.1.0",
+    "postcss-import": "^16.1.1"
   }
 }

--- a/packages/css/src/teseor.css
+++ b/packages/css/src/teseor.css
@@ -1,1 +1,6 @@
 @layer reset, tokens.scale, tokens.semantic, base, primitives, components.tokens, components.styles, utilities, themes;
+
+@import url("./reset.css");
+@import url("./tokens.css");
+@import url("./base.css");
+@import url("./utilities.css");

--- a/packages/css/src/utilities.css
+++ b/packages/css/src/utilities.css
@@ -1,0 +1,73 @@
+@layer utilities {
+  /* Spacing utilities — driven by the --t-space-* scale (tokens.scale).
+   * Shorthand and block/inline logical pairs only; directional forms
+   * (padding-inline-start etc.) are applied per-rule by components. */
+
+  @each $i in 0, 1, 2, 3, 4, 5, 6, 7, 8 {
+    .t-p-$(i) {
+      padding: var(--t-space-$(i));
+    }
+
+    .t-px-$(i) {
+      padding-inline: var(--t-space-$(i));
+    }
+
+    .t-py-$(i) {
+      padding-block: var(--t-space-$(i));
+    }
+
+    .t-m-$(i) {
+      margin: var(--t-space-$(i));
+    }
+
+    .t-mx-$(i) {
+      margin-inline: var(--t-space-$(i));
+    }
+
+    .t-my-$(i) {
+      margin-block: var(--t-space-$(i));
+    }
+
+    .t-gap-$(i) {
+      gap: var(--t-space-$(i));
+    }
+  }
+
+  /* Display utilities — no scale, fixed set. */
+
+  .t-block {
+    display: block;
+  }
+
+  .t-inline {
+    display: inline;
+  }
+
+  .t-inline-block {
+    display: inline-block;
+  }
+
+  .t-flex {
+    display: flex;
+  }
+
+  .t-inline-flex {
+    display: inline-flex;
+  }
+
+  .t-grid {
+    display: grid;
+  }
+
+  .t-inline-grid {
+    display: inline-grid;
+  }
+
+  .t-contents {
+    display: contents;
+  }
+
+  .t-hidden {
+    display: none;
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,7 +47,20 @@ importers:
 
   apps/preview: {}
 
-  packages/css: {}
+  packages/css:
+    devDependencies:
+      postcss:
+        specifier: ^8.5.15
+        version: 8.5.15
+      postcss-custom-media:
+        specifier: ^12.0.1
+        version: 12.0.1(postcss@8.5.15)
+      postcss-each:
+        specifier: ^1.1.0
+        version: 1.1.0(postcss@8.5.15)
+      postcss-import:
+        specifier: ^16.1.1
+        version: 16.1.1(postcss@8.5.15)
 
   scripts/codegen: {}
 
@@ -182,6 +195,13 @@ packages:
 
   '@changesets/write@0.4.0':
     resolution: {integrity: sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q==}
+
+  '@csstools/cascade-layer-name-parser@3.0.0':
+    resolution: {integrity: sha512-/3iksyevwRfSJx5yH0RkcrcYXwuhMQx3Juqf40t97PeEy2/Mz2TItZ/z/216qpe4GgOyFBP8MKIwVvytzHmfIQ==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
 
   '@csstools/css-calc@3.2.1':
     resolution: {integrity: sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==}
@@ -584,6 +604,10 @@ packages:
   error-ex@1.3.4:
     resolution: {integrity: sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==}
 
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
   es-module-lexer@2.1.0:
     resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
 
@@ -663,6 +687,9 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
   get-east-asian-width@1.6.0:
     resolution: {integrity: sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==}
     engines: {node: '>=18'}
@@ -700,6 +727,10 @@ packages:
   hashery@1.5.1:
     resolution: {integrity: sha512-iZyKG96/JwPz1N55vj2Ie2vXbhu440zfUfJvSwEqEbeLluk7NnapfGqa7LH0mOsnDxTF85Mx8/dyR6HfqcbmbQ==}
     engines: {node: '>=20'}
+
+  hasown@2.0.3:
+    resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
+    engines: {node: '>= 0.4'}
 
   hookified@1.15.1:
     resolution: {integrity: sha512-MvG/clsADq1GPM2KGo2nyfaWVyn9naPiXrqIe4jYjXNZQt238kWyOGrsyc/DmRAQ+Re6yeo6yX/yoNCG5KAEVg==}
@@ -739,6 +770,10 @@ packages:
 
   is-arrayish@0.2.1:
     resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
+
+  is-core-module@2.16.2:
+    resolution: {integrity: sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==}
+    engines: {node: '>= 0.4'}
 
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
@@ -1028,6 +1063,9 @@ packages:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
 
+  path-parse@1.0.7:
+    resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
+
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
@@ -1046,6 +1084,10 @@ packages:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
+  pify@2.3.0:
+    resolution: {integrity: sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==}
+    engines: {node: '>=0.10.0'}
+
   pify@4.0.1:
     resolution: {integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==}
     engines: {node: '>=6'}
@@ -1060,6 +1102,23 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  postcss-custom-media@12.0.1:
+    resolution: {integrity: sha512-66syE14+VeqkUf0rRX0bvbTCbNRJF132jD+ceo8th1dap2YJEAqpdh5uG98CE3IbgHT7m9XM0GIlOazNWqQdeA==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      postcss: ^8.4
+
+  postcss-each@1.1.0:
+    resolution: {integrity: sha512-YfTPHHAPFVRgEJfLg9RM4R9WYEHVU9Rf1R8QgZfnObwV2dgNqzTLzTl0w5tF71ApFcYLiJAXiTpHAoqJFYcZVw==}
+    peerDependencies:
+      postcss: ^8.0.0
+
+  postcss-import@16.1.1:
+    resolution: {integrity: sha512-2xVS1NCZAfjtVdvXiyegxzJ447GyqCeEI5V7ApgQVOWnros1p5lGNovJNapwPpMombyFBfqDwt7AD3n2l0KOfQ==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      postcss: ^8.0.0
+
   postcss-safe-parser@7.0.1:
     resolution: {integrity: sha512-0AioNCJZ2DPYz5ABT6bddIqlhgwhpHZ/l65YAYo0BCIn0xiDpsnTHz0gnoTGk0OXZW0JRs+cDwL8u/teRdz+8A==}
     engines: {node: '>=18.0'}
@@ -1069,6 +1128,12 @@ packages:
   postcss-selector-parser@7.1.1:
     resolution: {integrity: sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==}
     engines: {node: '>=4'}
+
+  postcss-simple-vars@6.0.3:
+    resolution: {integrity: sha512-fkNn4Zio8vN4vIig9IFdb8lVlxWnYR769RgvxCM6YWlFKie/nQaOcaMMMFz/s4gsfHW4/5bJW+i57zD67mQU7g==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      postcss: ^8.2.1
 
   postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
@@ -1092,6 +1157,9 @@ packages:
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
+  read-cache@1.0.0:
+    resolution: {integrity: sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==}
+
   read-yaml-file@1.1.0:
     resolution: {integrity: sha512-VIMnQi/Z4HT2Fxuwg5KrY174U1VdUIASQVWXXyqtNRtxSr9IYkn1rsI6Tb6HsrHCmB7gVpNwX6JxPTHcH6IoTA==}
     engines: {node: '>=6'}
@@ -1107,6 +1175,11 @@ packages:
   resolve-from@5.0.0:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
     engines: {node: '>=8'}
+
+  resolve@1.22.12:
+    resolution: {integrity: sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==}
+    engines: {node: '>= 0.4'}
+    hasBin: true
 
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
@@ -1225,6 +1298,10 @@ packages:
   supports-hyperlinks@4.4.0:
     resolution: {integrity: sha512-UKbpT93hN5Nr9go5UY7bopIB9YQlMz9nm/ct4IXt/irb5YRkn9WaqrOBJGZ5Pwvsd5FQzSVeYlGdXoCAPQZrPg==}
     engines: {node: '>=20'}
+
+  supports-preserve-symlinks-flag@1.0.0:
+    resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
+    engines: {node: '>= 0.4'}
 
   svg-tags@1.0.0:
     resolution: {integrity: sha512-ovssysQTa+luh7A5Weu3Rta6FJlFBBbInjOh722LIt6klpU2/HtdUbszju/G4devcvk8PGt7FCLv5wftu3THUA==}
@@ -1582,6 +1659,11 @@ snapshots:
       human-id: 4.1.3
       prettier: 2.8.8
 
+  '@csstools/cascade-layer-name-parser@3.0.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
   '@csstools/css-calc@3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
     dependencies:
       '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
@@ -1916,6 +1998,8 @@ snapshots:
     dependencies:
       is-arrayish: 0.2.1
 
+  es-errors@1.3.0: {}
+
   es-module-lexer@2.1.0: {}
 
   esprima@4.0.1: {}
@@ -1989,6 +2073,8 @@ snapshots:
   fsevents@2.3.3:
     optional: true
 
+  function-bind@1.1.2: {}
+
   get-east-asian-width@1.6.0: {}
 
   glob-parent@5.1.2:
@@ -2033,6 +2119,10 @@ snapshots:
     dependencies:
       hookified: 1.15.1
 
+  hasown@2.0.3:
+    dependencies:
+      function-bind: 1.1.2
+
   hookified@1.15.1: {}
 
   hookified@2.2.0: {}
@@ -2059,6 +2149,10 @@ snapshots:
   ini@1.3.8: {}
 
   is-arrayish@0.2.1: {}
+
+  is-core-module@2.16.2:
+    dependencies:
+      hasown: 2.0.3
 
   is-extglob@2.1.1: {}
 
@@ -2277,6 +2371,8 @@ snapshots:
 
   path-key@3.1.1: {}
 
+  path-parse@1.0.7: {}
+
   path-type@4.0.0: {}
 
   pathe@2.0.3: {}
@@ -2286,6 +2382,8 @@ snapshots:
   picomatch@2.3.2: {}
 
   picomatch@4.0.4: {}
+
+  pify@2.3.0: {}
 
   pify@4.0.1: {}
 
@@ -2297,6 +2395,26 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.2
 
+  postcss-custom-media@12.0.1(postcss@8.5.15):
+    dependencies:
+      '@csstools/cascade-layer-name-parser': 3.0.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+      '@csstools/media-query-list-parser': 5.0.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      postcss: 8.5.15
+
+  postcss-each@1.1.0(postcss@8.5.15):
+    dependencies:
+      postcss: 8.5.15
+      postcss-simple-vars: 6.0.3(postcss@8.5.15)
+
+  postcss-import@16.1.1(postcss@8.5.15):
+    dependencies:
+      postcss: 8.5.15
+      postcss-value-parser: 4.2.0
+      read-cache: 1.0.0
+      resolve: 1.22.12
+
   postcss-safe-parser@7.0.1(postcss@8.5.15):
     dependencies:
       postcss: 8.5.15
@@ -2305,6 +2423,10 @@ snapshots:
     dependencies:
       cssesc: 3.0.0
       util-deprecate: 1.0.2
+
+  postcss-simple-vars@6.0.3(postcss@8.5.15):
+    dependencies:
+      postcss: 8.5.15
 
   postcss-value-parser@4.2.0: {}
 
@@ -2324,6 +2446,10 @@ snapshots:
 
   queue-microtask@1.2.3: {}
 
+  read-cache@1.0.0:
+    dependencies:
+      pify: 2.3.0
+
   read-yaml-file@1.1.0:
     dependencies:
       graceful-fs: 4.2.11
@@ -2336,6 +2462,13 @@ snapshots:
   resolve-from@4.0.0: {}
 
   resolve-from@5.0.0: {}
+
+  resolve@1.22.12:
+    dependencies:
+      es-errors: 1.3.0
+      is-core-module: 2.16.2
+      path-parse: 1.0.7
+      supports-preserve-symlinks-flag: 1.0.0
 
   reusify@1.1.0: {}
 
@@ -2486,6 +2619,8 @@ snapshots:
     dependencies:
       has-flag: 5.0.1
       supports-color: 10.2.2
+
+  supports-preserve-symlinks-flag@1.0.0: {}
 
   svg-tags@1.0.0: {}
 


### PR DESCRIPTION
## What

Replace the `echo … exit 0` `build` stub with a real PostCSS pipeline.

- `packages/css/build.mjs` — Node script driving PostCSS programmatically: `postcss-import` to inline source `@import`s, `postcss-each` for `--t-space-*` loops, `postcss-custom-media` for the existing `--md` / `--lg` aliases. Source maps disabled, trailing whitespace trimmed → output is byte-deterministic across runs.
- `packages/css/src/utilities.css` — new authored CSS, `@layer utilities`. Spacing utilities (`t-p-{0..8}`, `t-px-{0..8}`, `t-py-{0..8}`, `t-m-{0..8}`, `t-mx-{0..8}`, `t-my-{0..8}`, `t-gap-{0..8}`) driven by `@each` over the existing `--t-space-{0..8}` scale; display utilities (`t-block`, `t-inline`, `t-inline-block`, `t-flex`, `t-inline-flex`, `t-grid`, `t-inline-grid`, `t-contents`, `t-hidden`).
- `packages/css/src/teseor.css` — entry now also `@import`s `reset.css`, `tokens.css`, `base.css`, `utilities.css` so the full bundle assembles in layer order.
- `packages/css/package.json` — `build` script now runs `node build.mjs`; new devDeps: `postcss`, `postcss-import`, `postcss-each`, `postcss-custom-media` (latest stable per `npm view`).
- `package.json` — `size-limit` budgets for the four entry points (`@teseor/css`, `tokens.css`, `utilities.css`, `tailwind.css`). Defaults to brotli; initial budgets carry ~2-3× headroom over today's sizes (full bundle: 2.58 kB brotli vs 8 kB budget).
- `packages/css/README.md` — documents the entry points + the utility classes the build emits.
- `.changeset/a4-postcss-build-pipeline.md` — minor bump for `@teseor/css` (first release with real artifacts).

Directional logical pairs (`padding-inline-start` etc.) are intentionally not utility classes; components apply those properties directly inside their own `@layer components.styles`.

## Why

V0.1 audit flagged the build script as a stub. Every v0.2 component (B2, D1, D2) consumes spacing utilities directly; without a real pipeline `packages/css/dist/` is empty and there's nothing to publish, size-limit can't measure, and `verify-no-dev-leak` is a no-op. A4 turns all three on at once.

## Test plan

- `pnpm install --frozen-lockfile --ignore-scripts` — clean.
- `pnpm --filter @teseor/css build` twice in a row → identical `dist/` (verified locally with `diff`).
- `pnpm verify:no-dev-leak` — scans `packages/css/dist`, no dev leaks (no `__DEV__` / `console.*` in CSS).
- `pnpm size` — all four entries report under budget (full bundle 2.58 kB brotli vs 8 kB; utilities 448 B vs 2 kB).
- `pnpm lint` clean: Biome 25 files; Stylelint accepts the new `@each` (already in `ignoreAtRules`); spec validator placeholder.
- `pnpm typecheck` clean.
- `pnpm gen` still a no-op (gen-drift CI stays green; the `dist/` directory is gitignored, so it doesn't surface as drift either).
- `pnpm test` (vitest in `packages/css`) — `passWithNoTests` returns 0.
- `node scripts/check-comments.js` clean.
- `size-data.yml` CI job will now produce real numbers since `packages/css/dist/` exists after `pnpm build:css`.

## Out of scope

- Component CSS (B2 onward) — utilities-only here, no `.t-button` rules.
- Directional spacing utilities (`t-pis-*` / `t-pie-*` / `t-pbs-*` / `t-pbe-*`) — components apply those properties directly.
- Tree-shaking / per-component bundles — A4 ships the monolith; per-component carving lands when C2 introduces framework wrappers.
- Real `size-report.yml` diff-vs-main — the workflow exists; baseline math arrives in CF1 (#565) once a `main` build is up.
- Density layer (`--t-density` / `data-density` sugar) — tracked under #565.
- Custom in-house `postcss-teseor-floor` plugin mentioned in `dev-scripts.md` — not needed until tokens contain runtime `clamp()` calls that should be inlined as literals.

Closes #555