### PR TITLE
feat(button): author specs/button.yaml — first component spec

### DIFF
--- a/specs/button.yaml
+++ b/specs/button.yaml
@@ -1,0 +1,164 @@
+name: button
+description: A trigger that performs an action when activated.
+kind: atomic
+dependencies: []
+element: button
+rootClass: t-button
+file: components/button/button.css
+
+variants:
+  solid:
+    description: Filled background with intent color; default visual weight.
+  outline:
+    description: Transparent background, intent-colored border and label; for secondary actions.
+  ghost:
+    description: Transparent background with no border; for tertiary actions inside dense layouts or toolbars.
+  link:
+    description: Renders as text with an underline; for navigation-shaped triggers that still need button semantics.
+
+intents:
+  primary:
+    description: The page's most important action. One primary per surface.
+    tokens:
+      bg: --t-accent
+      fg: --t-on-accent
+  neutral:
+    description: Default action. Non-emphasized; used when no intent is needed.
+    tokens:
+      bg: --t-surface
+      fg: --t-on-surface
+  success:
+    description: Confirms a positive outcome (save, publish, accept).
+    tokens:
+      bg: --t-success
+      fg: --t-on-success
+  warning:
+    description: Indicates an action that needs attention but isn't destructive.
+    tokens:
+      bg: --t-warning
+      fg: --t-on-warning
+  danger:
+    description: Destructive or irreversible action (delete, cancel subscription).
+    tokens:
+      bg: --t-danger
+      fg: --t-on-danger
+
+sizes:
+  sm:
+    description: Compact density; safe at breakpoints above the mobile floor.
+    tokens:
+      height: --t-row-2
+      pad-x: --t-space-3
+  md:
+    description: Default size.
+    tokens:
+      height: --t-row-3
+      pad-x: --t-space-4
+  lg:
+    description: Emphatic; for hero CTAs and primary actions in mobile-first layouts.
+    tokens:
+      height: --t-row-4
+      pad-x: --t-space-5
+
+states:
+  - hover
+  - focus
+  - active
+  - disabled
+  - loading
+
+props:
+  as:
+    type: string
+    default: button
+    responsive: false
+    description: Polymorphic root element. Defaults to `button`; set to `a` for link-shaped triggers (paired with `variant: link`).
+  disabled:
+    type: boolean
+    default: false
+    responsive: false
+    description: Disables interaction and applies the disabled visual state. Mapped to the native `disabled` attribute on `button`, `aria-disabled="true"` otherwise.
+  loading:
+    type: boolean
+    default: false
+    responsive: false
+    description: Shows a spinner in place of the label and disables interaction. The original label stays in the accessibility tree.
+  iconLeft:
+    type: string
+    default: null
+    responsive: false
+    description: Icon name rendered before the label. Slot size scales with `size`. Requires the icon component once it lands.
+  iconRight:
+    type: string
+    default: null
+    responsive: false
+    description: Icon name rendered after the label.
+  block:
+    type: boolean
+    default: false
+    responsive: true
+    description: Stretches the button to the inline-size of its container. Responsive so layouts can pin block-width on mobile and shrink to content above.
+
+tokens:
+  height:
+    fallback: --t-row
+    desc: Control height; the size variant overrides this.
+  bg:
+    fallback: --t-accent
+    desc: Background fill; the intent variant overrides this.
+  fg:
+    fallback: --t-on-accent
+    desc: Foreground color (label and icon); pairs with `bg`.
+  pad-x:
+    fallback: --t-pad-x
+    desc: Inline padding; the size variant overrides this.
+  radius:
+    fallback: --t-radius-md
+    desc: Corner radius.
+  dur:
+    fallback: --t-dur-fast
+    desc: Transition duration; multiplied by `--t-motion-scale` at the call site.
+
+private:
+  - --_h
+  - --_bg
+  - --_fg
+  - --_pad-x
+  - --_radius
+  - --_dur
+
+a11y:
+  role: button
+  keyboard:
+    Enter: activate
+    Space: activate
+
+constraints:
+  - when: { variant: link }
+    forbid: { intent: [danger, warning, success] }
+    reason: "Link variant is text-colored; non-neutral intent fills have no surface to apply to."
+  - when: { loading: true }
+    forbid: { disabled: true }
+    reason: "Loading already disables interaction; disabling on top is redundant."
+
+examples:
+  - id: solid-primary
+    props: { variant: solid, intent: primary }
+  - id: solid-danger-md
+    props: { variant: solid, intent: danger, size: md }
+  - id: outline-neutral
+    props: { variant: outline, intent: neutral }
+  - id: ghost-with-icon
+    props: { variant: ghost, intent: neutral, iconLeft: arrow-left }
+  - id: link-primary
+    props: { variant: link, intent: primary, as: a }
+  - id: loading
+    props: { variant: solid, intent: primary, loading: true }
+  - id: block-mobile
+    props: { variant: solid, intent: primary, block: true, size: lg }
+
+motion:
+  transitions:
+    - background-color
+    - color
+    - transform


### PR DESCRIPTION
## What

First component spec. `specs/button.yaml` encodes Button's full API surface so B2 (CSS) and C1–C4 (codegen) have a single source of truth to consume.

Shape:

- **Top-level**: `name`, `description`, `kind: atomic`, `dependencies: []`, `element: button`, `rootClass: t-button`, `file: components/button/button.css`.
- **`variants`** (map with descriptions): `solid`, `outline`, `ghost`, `link`.
- **`intents`** (map with `description` + `tokens` mapping): `primary`, `neutral`, `success`, `warning`, `danger`. Each binds `bg` + `fg` to a semantic token pair (`--t-accent` / `--t-on-accent`, etc.).
- **`sizes`** (map with `description` + `tokens`): `sm`, `md`, `lg` → `--t-row-{2,3,4}` + matching `--t-space-*` for `pad-x`.
- **`states`**: `hover`, `focus`, `active`, `disabled`, `loading` (CSS-side surfaces, not props).
- **`props`** (every entry has `description` per M8): `as`, `disabled`, `loading`, `iconLeft`, `iconRight`, `block`. `block` is `responsive: true` so a layout can be block-width on mobile and shrink to content above.
- **`tokens`** — public token contract (`--t-button-{height, bg, fg, pad-x, radius, dur}`) with fallbacks into the semantic layer.
- **`private`** — the `--_*` runtime indirection vars from the [Component shape](../docs/rules/component-shape.md) doc.
- **`a11y`** — `role: button` + Enter / Space activation.
- **`constraints`** — declarative `when` / `forbid`: link variant rejects non-neutral intents (no surface to fill); `loading` rejects `disabled` (redundant).
- **`examples`** — seven entries covering each variant + a loading state + a block-width mobile CTA. Each becomes a Playwright scaffold via gen-tests when C4 lands.
- **`motion`** — `transitions: [background-color, color, transform]`. No `enters`/`exits` (Button has no overlay choreography).

## Why

B2's CSS reads `data-variant` / `data-intent` / `data-size` clauses straight from this spec; C1's `gen-contract` derives the TypeScript discriminated union from `variants` × `intents` × `sizes` minus the `constraints` block; C2's `gen-react` emits the wrapper signature; C3's `gen-docs` reads `description:` on every prop / variant / intent to populate the docs page. Shipping all of that needs the spec first.

The descriptions land here ahead of CF1 (#565) formalizing the M8 "description required" rule in `docs/architecture/codegen-pipeline.md`. The schema example in that doc still shows `variants: [solid, outline, ...]` as a flat list — my map-of-descriptions form is the M8 evolution; CF1 reconciles the doc.

## Test plan

- YAML structure visually verified against the schema in `docs/architecture/codegen-pipeline.md`.
- Every token referenced (`--t-accent`, `--t-on-accent`, `--t-surface`, `--t-on-surface`, `--t-success`, `--t-on-success`, `--t-warning`, `--t-on-warning`, `--t-danger`, `--t-on-danger`, `--t-row-{2,3,4}`, `--t-space-{3,4,5}`, `--t-row`, `--t-pad-x`, `--t-radius-md`, `--t-dur-fast`) is declared in `packages/css/src/tokens.css`.
- Every `prop`, `variant`, and `intent` carries a `description:` (M8 contract).
- `pnpm lint` clean (Biome + Stylelint untouched; `lint:spec` is the existing placeholder).
- `node scripts/check-comments.js specs/button.yaml` clean.
- `pnpm gen` still a no-op — gen-drift CI stays green.
- `feat(button)` scope: pr-discipline's title-format walks `specs/*.yaml` in the checked-out PR branch, so the new `button` spec gets added to the allowed scope list before the check runs.

## Out of scope

- Button CSS (`packages/css/src/components/button/button.css`) — B2 (#557).
- The `validate-spec.ts` validator that proves this file's shape — C1 (#558).
- Wrapper code (React/Vue/Svelte/Angular/webc) — C2 (#559).
- Docs page — C3 (#560).
- Playwright scaffold per example — C4 (#561).
- Schema reconciliation in `docs/architecture/codegen-pipeline.md` (flat list vs map-of-descriptions) — CF1 (#565).
- Icon component referenced by `iconLeft` / `iconRight` — there's no icon spec yet; the names are declared but `dependencies:` stays `[]` until the icon spec lands.

Closes #556