### PR TITLE
docs(repo): partial CF1 — schema reconciliation, ADR log, perf budgets, Renovate

### DIFF
--- a/docs/ADR/0005-adrs-are-the-decision-log.md
+++ b/docs/ADR/0005-adrs-are-the-decision-log.md
@@ -1,0 +1,61 @@
+# ADR-0005 — ADRs are the decision log
+
+- **Status:** Accepted.
+- **Deciders:** repo owner (letanure).
+
+## Decision
+
+`docs/ADR/` is the canonical decision log for Teseor. Anything
+load-bearing — a structural choice, a rejected alternative, a public
+surface change, a non-obvious constraint — lands as a numbered ADR. PR
+descriptions, commit messages, Slack threads, and `.claude/handover.md`
+do not count as decision records.
+
+The `docs/ADR/README.md` document spells out when to write one, what
+shape it takes, and how to modify an existing one.
+
+## Why this and not the alternatives
+
+- **Not PR descriptions.** PR titles and bodies vanish into search noise
+  the moment the next PR lands. Future contributors hitting the same
+  fork won't dig through `git log` to find why a class prefix is `t-` or
+  why we ship `@teseor/contracts` separately from `@teseor/css`.
+- **Not the changelog.** `CHANGELOG.md` answers "what shipped"; ADRs
+  answer "why we built it this way." Both are needed; neither replaces
+  the other.
+- **Not the handover.** `.claude/handover.md` is per-session and
+  gitignored. It's the agent's working memory, not the project's
+  durable record.
+- **Not RFCs.** RFCs explore proposals before a decision is made
+  (`docs/RFC/`). An RFC may end up becoming an ADR — but the ADR is the
+  record, not the RFC.
+
+The ADR format is older than this project (Michael Nygard's 2011 essay,
+ThoughtWorks' radar entry). Cost is low: one file per decision, ~30
+lines on average. Payoff compounds: every contributor reads the index
+before opening a PR on a touched surface, which removes whole categories
+of "should we…?" questions from review.
+
+## Consequences
+
+- **The ADR README is the entry point.** Every contributor (human and
+  agent) lands there before opening an ADR. Project `CLAUDE.md` already
+  lists `docs/ADR/` under "Pointers."
+- **Modifying an ADR requires the "Ask before" gate.** Listed in project
+  `CLAUDE.md` alongside removing components / tokens / themes. ADRs are
+  durable; silent rewrites destroy the record.
+- **Superseding is preferred over editing.** When a decision flips, the
+  old ADR's status changes to `Superseded by ADR-NNNN`; the body stays
+  intact for the historical record.
+- **Numbers are immutable.** ADR-0003 is forever ADR-0003 even if it's
+  superseded by ADR-0042 three years later. No renumbering, no gaps
+  filled.
+- **The decision log starts at ADR-0001.** Pre-rewrite decisions that
+  matter were re-recorded as ADRs 0001–0004 during the v0.1 rewrite. ADR
+  history before that point is in `legacy/v2` and not authoritative for
+  the current repo (per ADR-0001).
+
+## References
+
+- `docs/ADR/README.md` — the index and the writing guide.
+- `CLAUDE.md` — "Ask before: Modifying ADRs" gate.

--- a/docs/ADR/README.md
+++ b/docs/ADR/README.md
@@ -1,0 +1,92 @@
+# Architecture decision records
+
+ADRs are Teseor's decision log. Anything load-bearing — a structural
+choice, a constraint, a "we considered X and rejected it" — lands here as
+a numbered, durable file.
+
+## Index
+
+| # | Title | Status |
+| --- | --- | --- |
+| [0001](0001-rewrite-not-migrate.md) | Rewrite, don't migrate | Accepted |
+| [0002](0002-per-component-yaml-over-manifest.md) | Per-component YAML over a single manifest | Accepted |
+| [0003](0003-postcss-build-step.md) | PostCSS build step (literal floors) | Accepted |
+| [0004](0004-practical-strict-semver.md) | Practical strict semver | Accepted |
+| [0005](0005-adrs-are-the-decision-log.md) | ADRs are the decision log | Accepted |
+
+## When to write one
+
+Write an ADR when a decision satisfies any of:
+
+- **Constrains future PRs.** Anyone working on the touched surface needs
+  to know the rule to avoid relitigating it.
+- **Rejected a real alternative.** The reasoning matters more than the
+  outcome; the next contributor will hit the same fork and need the same
+  context.
+- **Changes how a public surface behaves.** Class names, public tokens,
+  prop renames, package boundaries, version policy.
+- **Is non-obvious from the code.** If reading the source doesn't explain
+  *why* — write the ADR. If it does, skip it.
+
+If a decision is local to one PR and has no future consequence, the PR
+description is enough. ADRs are for choices that have to survive past
+the PR that introduced them.
+
+## What an ADR is not
+
+- **Not an RFC.** RFCs (`docs/RFC/`) explore proposals before a decision
+  is made. ADRs record decisions after they're made. An RFC may produce
+  an ADR; an ADR never produces an RFC.
+- **Not a changelog entry.** `CHANGELOG.md` (generated from changesets)
+  tells consumers what shipped. ADRs tell contributors why we built it
+  this way.
+- **Not a session note.** Notes about an in-flight task belong in
+  `.claude/handover.md` (maintainer-only) or a working branch — not
+  committed under `docs/ADR/`.
+
+## Shape
+
+Each ADR is one file, kebab-cased after its number:
+`<NNNN>-<short-slug>.md`. Numbers are assigned in commit order. Never
+reuse a number; never reorder existing files.
+
+Required sections, in this order:
+
+```markdown
+# ADR-NNNN — <Title>
+
+- **Status:** <Proposed | Accepted | Superseded by ADR-XXXX | Deprecated>.
+- **Deciders:** <names or roles>.
+
+## Decision
+
+One paragraph. State the outcome — not the discussion.
+
+## Why <this> and not <that>
+
+Bulleted. Each bullet is one reason, terse.
+
+## Consequences
+
+What the project now has to live with. Wins AND costs.
+```
+
+Optional sections (use when relevant): `Context`, `Alternatives
+considered`, `Open questions`, `References`.
+
+## Modifying an existing ADR
+
+The bar is high. ADRs are durable. Three patterns:
+
+1. **Superseding.** A new ADR replaces an old one. The old ADR's status
+   flips to `Superseded by ADR-NNNN`; its body stays intact for the
+   historical record. The new ADR cites the old one in its `References:`.
+2. **Deprecating.** A constraint is no longer in force but no replacement
+   is needed. Status flips to `Deprecated`; body stays intact; a one-line
+   header notes the PR that retired it.
+3. **Correcting a factual error.** Edit in place with a footnote
+   acknowledging the correction. Don't rewrite the reasoning — that's a
+   supersede.
+
+Never silently rewrite an ADR. Project `CLAUDE.md` lists modifying an ADR
+under the "Ask before" gate; this paragraph is why.

--- a/docs/architecture/codegen-pipeline.md
+++ b/docs/architecture/codegen-pipeline.md
@@ -76,7 +76,7 @@ motion:
 
 The `motion:` field is required at the atomic milestone. See `rules/motion.md` for the full rule set.
 
-### Maps, not lists (M8)
+### Maps, not lists
 
 `variants`, `intents`, and `sizes` are **maps** keyed on the value name, not bare lists. Every key carries a required `description:` field. Intents and sizes also carry a `tokens:` map binding the value to the semantic tokens the CSS layer reads. `gen-docs` surfaces the descriptions directly on the docs page; `gen-contract` ignores them.
 

--- a/docs/architecture/codegen-pipeline.md
+++ b/docs/architecture/codegen-pipeline.md
@@ -11,24 +11,47 @@ One spec per component. Many outputs. CI fails if the outputs drift from the spe
 
 ```yaml
 name: button
-description: A trigger for an action.
+description: A trigger that performs an action when activated.
 kind: atomic           # atomic | composite
 dependencies: []       # ["icon"] for composites
 element: button        # default semantic tag
 rootClass: t-button
 file: components/button/button.css
 
-variants: [solid, outline, ghost, link]
-intents:  [neutral, accent, danger, success, warning]
-sizes:    [sm, md, lg]
+variants:
+  solid:   { description: Filled background with intent color. }
+  outline: { description: Transparent background, intent-colored border. }
+  ghost:   { description: Transparent background, no border. }
+  link:    { description: Renders as text with an underline. }
+
+intents:
+  primary: { description: Most important action on the surface., tokens: { bg: --t-accent,  fg: --t-on-accent } }
+  neutral: { description: Default action; non-emphasized.,        tokens: { bg: --t-surface, fg: --t-on-surface } }
+  success: { description: Confirms a positive outcome.,           tokens: { bg: --t-success, fg: --t-on-success } }
+  warning: { description: Needs attention but isn't destructive., tokens: { bg: --t-warning, fg: --t-on-warning } }
+  danger:  { description: Destructive or irreversible action.,    tokens: { bg: --t-danger,  fg: --t-on-danger  } }
+
+sizes:
+  sm: { description: Compact density., tokens: { height: --t-row-2, pad-x: --t-space-3 } }
+  md: { description: Default size.,    tokens: { height: --t-row-3, pad-x: --t-space-4 } }
+  lg: { description: Emphatic CTA.,    tokens: { height: --t-row-4, pad-x: --t-space-5 } }
 
 props:
-  loading:  { type: boolean, default: false, responsive: false }
-  disabled: { type: boolean, default: false, responsive: false }
+  loading:
+    type: boolean
+    default: false
+    responsive: false
+    description: Shows a spinner in place of the label and disables interaction.
+  disabled:
+    type: boolean
+    default: false
+    responsive: false
+    description: Disables interaction; mapped to native `disabled` on `button`, `aria-disabled="true"` otherwise.
 
 tokens:                 # public token contract (--t-button-*)
-  height:   { fallback: --t-row, desc: control height }
-  bg:       { fallback: --t-accent, desc: background fill }
+  height: { fallback: --t-row,       desc: Control height. }
+  bg:     { fallback: --t-accent,    desc: Background fill. }
+  fg:     { fallback: --t-on-accent, desc: Foreground color (label and icon). }
 
 private: [--_h, --_bg, --_pad-x]   # documented for reference, not API
 
@@ -39,8 +62,8 @@ a11y:
     Space: activate
 
 examples:
-  - id: solid-accent
-    props: { variant: solid, intent: accent }
+  - id: solid-primary
+    props: { variant: solid, intent: primary }
   - id: loading
     props: { loading: true }
 
@@ -51,7 +74,13 @@ motion:
   # exits:  [close]
 ```
 
-The `motion:` field is required at v0.2. See `rules/motion.md` for the full rule set.
+The `motion:` field is required at the atomic milestone. See `rules/motion.md` for the full rule set.
+
+### Maps, not lists (M8)
+
+`variants`, `intents`, and `sizes` are **maps** keyed on the value name, not bare lists. Every key carries a required `description:` field. Intents and sizes also carry a `tokens:` map binding the value to the semantic tokens the CSS layer reads. `gen-docs` surfaces the descriptions directly on the docs page; `gen-contract` ignores them.
+
+The same `description:` requirement applies to every entry under `props:`. `validate-spec.ts` rejects a spec where any `prop`, `variant`, or `intent` is missing a `description:`. The rule exists because the docs page (`gen-docs`) is generated from these descriptions — leaving one blank leaves a hole in the public surface.
 
 **Reserved fields (designed at later milestones, not yet usable):**
 

--- a/docs/process/dev-scripts.md
+++ b/docs/process/dev-scripts.md
@@ -62,3 +62,91 @@ The bare-verb defaults are the verbs you reach for daily: `dev`, `build`, `test`
 | `renovate` | dependency updates | Weekly batched PRs |
 | `lit` | webc | Authoring base for generated web-components |
 | Lighthouse CI | docs gate | `lighthouserc.json` |
+
+## Renovate policy
+
+Configured in `renovate.json`. The policy keeps Renovate honest without
+drowning the queue:
+
+- **Schedule**: weekends only (`* * * * 0,6`). Workweek inboxes stay quiet.
+- **Preset**: `config:recommended` (not the deprecated `config:base`).
+- **Commits**: `semanticCommits: enabled`, scope `deps`, type `chore` —
+  every Renovate PR lands as `chore(deps): <pkg> <old> → <new>`.
+- **Labels**: every PR tagged `dep` so triage queries (`is:pr label:dep`)
+  pull the whole stream.
+- **Automerge**: off. Every dependency PR runs through the same review
+  gates as a human PR. Worth the friction; turn this on only after the
+  test surface is mature enough to catch regressions reliably.
+- **Range strategy**: `bump`. PRs update the `^` range, not lockfile-only,
+  so package.json drift stays visible.
+- **Throughput limits**: `prHourlyLimit: 4`, `prConcurrentLimit: 10`. Bursts
+  capped, queue depth bounded.
+- **Lockfile maintenance**: monthly (first of the month). Keeps the
+  resolved tree fresh without weekly noise.
+
+### Grouped updates
+
+Three named groups keep semantically-related bumps together:
+
+| Group | Members |
+| --- | --- |
+| `frameworks` | `react`, `react-dom`, `vue`, `@vue/**`, `svelte`, `@sveltejs/**`, `@angular/**`, matching `@types/react*` |
+| `dev tooling` | `@biomejs/**`, `stylelint`, `stylelint-**`, `@playwright/test`, `playwright` |
+| `build tooling` | `postcss`, `postcss-**`, `vite`, `@vitejs/**`, `vite-plugin-**` |
+
+A change to any member opens one PR for the group, so a Stylelint bump
+that touches `stylelint-config-standard` doesn't queue two PRs that race
+each other.
+
+### Out of scope
+
+The Playwright container image (`mcr.microsoft.com/playwright:vX.Y-jammy`
+in `.github/workflows/visual-tests.yml` and `ci.yml`) is **not** governed by
+Renovate — it's a Docker image, not an npm dep. Bump it manually together
+with `@playwright/test` whenever the dev-tooling group fires; the
+container tag must match the installed Playwright minor.
+
+## Perf budgets
+
+Two tiers: hard CI gates and soft targets.
+
+### Hard gates
+
+| Surface | Tool | Where the budget lives |
+| --- | --- | --- |
+| Per-entry CSS bundle | `size-limit` (`@size-limit/file`) | `package.json` → `"size-limit"` array |
+| Codegen drift | `pnpm gen && git diff --exit-code` | `.github/workflows/ci.yml` → `gen-drift` |
+| Dev-only marker leak | `pnpm verify:no-dev-leak` | `scripts/verify-no-dev-leak.js` |
+
+Current `size-limit` budgets (brotli-compressed, set in root
+`package.json`):
+
+| Entry | Budget |
+| --- | --- |
+| `@teseor/css` (full bundle) | 8 kB |
+| `@teseor/css/tokens.css` | 4 kB |
+| `@teseor/css/utilities.css` | 2 kB |
+| `@teseor/css/tailwind.css` | 6 kB |
+
+Budgets carry ~2–3× headroom over the current floor. Per-component
+budgets land alongside the first per-component CSS files emit from the
+build (≤4 kB minified / ≤1.5 kB brotli per component, per
+`process/ci-gates.md` § "bundle").
+
+### Soft targets
+
+Soft targets aren't CI gates; missing one earns a discussion, not a
+failed PR. Tracked via Lighthouse CI (`lighthouserc.json`) against the
+docs site:
+
+| Metric | Target | Source |
+| --- | --- | --- |
+| LCP | < 2.0 s on 3G | Lighthouse `largest-contentful-paint` |
+| CLS | < 0.05 | Lighthouse `cumulative-layout-shift` |
+| INP | < 200 ms | Lighthouse `interaction-to-next-paint` |
+| JS payload (docs site) | < 50 kB gzipped | Lighthouse `total-byte-weight` minus images |
+| First component-page load | < 1.5 s on 3G | Lighthouse `speed-index` |
+
+Targets are calibrated against the docs site (the only thing Teseor
+itself ships at runtime); consumers' targets depend on their own surface
+and aren't enforced here.


### PR DESCRIPTION
## What

Four doc updates that align the canonical docs with what's already in the repo.

- `docs/architecture/codegen-pipeline.md` — the spec-shape example now uses maps with a `description:` per variant, intent, and size, matching `specs/button.yaml`. New subsection codifies the rule.
- `docs/process/dev-scripts.md` — new "Perf budgets" subsection lists the brotli size-limit budgets and the soft Lighthouse targets.
- `docs/process/dev-scripts.md` — new "Renovate policy" subsection describes the actual `renovate.json` config: weekend schedule, no automerge, three grouped updates, monthly lockfile maintenance, and the manual carve-out for the Playwright Docker image.
- `docs/ADR/README.md` and `docs/ADR/0005-adrs-are-the-decision-log.md` — adds an ADR index and the ADR that codifies "ADRs are the decision log."

## Why

Each of these decisions already lives in code or config. The docs hadn't caught up. The spec-shape example in particular contradicted the Button spec that just landed, which would confuse anyone authoring the second component.

## Test plan

- `pnpm lint` clean.
- `node scripts/check-comments.js` clean.
- ADR-0005's two cross-links (`docs/ADR/README.md`, `CLAUDE.md`) both resolve.
- The spec-shape example in `codegen-pipeline.md` matches `specs/button.yaml` field for field.

## Out of scope

This is the first slice of #565. The bullets still open there need design input or fresh writing:

- A schema slot for controllable inputs (Switch / Checkbox / Combobox).
- A scoped-overrides section in `themes.md`.
- A decision rubric for media queries vs container queries.
- Slash-command failure modes per command.
- The `--t-density` multiplier values and the `data-density` attribute.

No code changes; no CI workflow changes; no `protect-main.sh` changes.

Closes #571