### PR TITLE
feat(button): button.css with variants, intents, sizes, and visual states

### DIFF
--- a/.changeset/b2-button-css.md
+++ b/.changeset/b2-button-css.md
@@ -1,0 +1,5 @@
+---
+"@teseor/css": minor
+---
+
+First component: `.t-button`. Drives all four variants (solid, outline, ghost, link), five intents (primary, neutral, success, warning, danger), three sizes (sm, md, lg), and the visual states for hover, active, focus-visible, disabled, and loading. Bundled into the full `@teseor/css` entry; per-component bundle arrives when more than one component ships.

--- a/packages/css/src/components/button/button.css
+++ b/packages/css/src/components/button/button.css
@@ -1,0 +1,181 @@
+@layer components.tokens {
+  .t-button {
+    --_h: var(--t-button-height, var(--t-row-3));
+    --_pad-x: var(--t-button-pad-x, var(--t-space-4));
+    --_bg: var(--t-button-bg, var(--t-accent));
+    --_fg: var(--t-button-fg, var(--t-on-accent));
+    --_radius: var(--t-button-radius, var(--t-radius-md));
+    --_dur: var(--t-button-dur, var(--t-dur-fast));
+    --_ease: var(--t-button-ease, var(--t-ease-out));
+  }
+}
+
+@layer components.styles {
+  .t-button,
+  .t-button * {
+    box-sizing: border-box;
+  }
+
+  .t-button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    position: relative;
+    gap: var(--t-space-2);
+    block-size: var(--_h);
+    padding-inline: var(--_pad-x);
+    padding-block: 0;
+    background: var(--_bg);
+    color: var(--_fg);
+    border: 0;
+    border-radius: var(--_radius);
+    font: inherit;
+    font-weight: 500;
+    line-height: 1;
+    text-decoration: none;
+    cursor: pointer;
+    user-select: none;
+    transition:
+      background-color calc(var(--_dur) * var(--t-motion-scale)) var(--_ease),
+      color calc(var(--_dur) * var(--t-motion-scale)) var(--_ease),
+      box-shadow calc(var(--_dur) * var(--t-motion-scale)) var(--_ease),
+      transform calc(var(--_dur) * var(--t-motion-scale)) var(--_ease);
+  }
+
+  .t-button:where([data-size="sm"]) {
+    --_h: var(--t-row-2);
+    --_pad-x: var(--t-space-3);
+
+    font-size: var(--t-text-sm);
+  }
+
+  .t-button:where([data-size="md"]) {
+    --_h: var(--t-row-3);
+    --_pad-x: var(--t-space-4);
+
+    font-size: var(--t-text-base);
+  }
+
+  .t-button:where([data-size="lg"]) {
+    --_h: var(--t-row-4);
+    --_pad-x: var(--t-space-5);
+
+    font-size: var(--t-text-lg);
+  }
+
+  .t-button:where([data-intent="primary"]) {
+    --_bg: var(--t-accent);
+    --_fg: var(--t-on-accent);
+  }
+
+  .t-button:where([data-intent="neutral"]) {
+    --_bg: var(--t-surface);
+    --_fg: var(--t-on-surface);
+  }
+
+  .t-button:where([data-intent="success"]) {
+    --_bg: var(--t-success);
+    --_fg: var(--t-on-success);
+  }
+
+  .t-button:where([data-intent="warning"]) {
+    --_bg: var(--t-warning);
+    --_fg: var(--t-on-warning);
+  }
+
+  .t-button:where([data-intent="danger"]) {
+    --_bg: var(--t-danger);
+    --_fg: var(--t-on-danger);
+  }
+
+  .t-button:where([data-variant="outline"]) {
+    background: transparent;
+    color: var(--_bg);
+    box-shadow: inset 0 0 0 1px currentcolor;
+  }
+
+  .t-button:where([data-variant="ghost"]) {
+    background: transparent;
+    color: var(--_bg);
+  }
+
+  .t-button:where([data-variant="link"]) {
+    block-size: auto;
+    padding-inline: 0;
+    padding-block: 0;
+    background: transparent;
+    color: var(--_bg);
+    text-decoration: underline;
+    text-underline-offset: 0.2em;
+  }
+
+  .t-button:where([data-block="true"]) {
+    inline-size: 100%;
+  }
+
+  .t-button:where([data-loading="true"]) {
+    cursor: progress;
+  }
+
+  .t-button:where([data-loading="true"]) [data-button-label] {
+    visibility: hidden;
+  }
+
+  .t-button:where(:not([data-loading="true"])) [data-button-spinner] {
+    display: none;
+  }
+
+  .t-button:where([data-loading="true"]) [data-button-spinner] {
+    position: absolute;
+    inline-size: 1em;
+    block-size: 1em;
+    border: 2px solid currentcolor;
+    border-block-start-color: transparent;
+    border-radius: 50%;
+    animation: t-button-spin calc(800ms * var(--t-motion-scale)) linear infinite;
+  }
+
+  .t-button > svg,
+  .t-button [data-button-icon] {
+    flex-shrink: 0;
+    inline-size: 1em;
+    block-size: 1em;
+  }
+
+  .t-button:where(:hover):not([disabled], [aria-disabled="true"]) {
+    background-color: color-mix(in oklch, var(--_bg) 92%, black);
+  }
+
+  .t-button:where(:active):not([disabled], [aria-disabled="true"]) {
+    background-color: color-mix(in oklch, var(--_bg) 84%, black);
+    transform: translateY(1px);
+  }
+
+  .t-button:focus-visible {
+    outline: 2px solid var(--t-focus-ring);
+    outline-offset: 2px;
+  }
+
+  .t-button:is([disabled], [aria-disabled="true"]) {
+    cursor: not-allowed;
+    opacity: 0.6;
+  }
+
+  .t-button:where(
+    [data-variant="outline"],
+    [data-variant="ghost"]
+  ):hover:not([disabled], [aria-disabled="true"]) {
+    background-color: color-mix(in oklch, var(--_bg) 12%, transparent);
+  }
+
+  .t-button:where([data-variant="link"]):hover:not([disabled], [aria-disabled="true"]) {
+    background: transparent;
+    text-decoration-thickness: 2px;
+  }
+}
+
+@keyframes t-button-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/packages/css/src/teseor.css
+++ b/packages/css/src/teseor.css
@@ -4,3 +4,4 @@
 @import url("./tokens.css");
 @import url("./base.css");
 @import url("./utilities.css");
+@import url("./components/button/button.css");


### PR DESCRIPTION
## What

First real component CSS. `packages/css/src/components/button/button.css` implements `.t-button` per the spec and per the `Component shape` doc. Two sublayers, scoped reset, logical properties throughout, `:where()` selectors so specificity stays at 0,1,0 / 0,2,0 / 0,3,0 across the variant + state combinations.

Consumers select rendering via three data attributes:

```html
<button class="t-button" data-variant="solid" data-intent="primary" data-size="md">Save</button>
<button class="t-button" data-variant="outline" data-intent="danger">Delete</button>
<button class="t-button" data-variant="link" data-intent="primary">Read more</button>
<button class="t-button" data-block="true" data-size="lg">Full-width CTA</button>
<button class="t-button" data-loading="true">…</button>
```

The component file is imported into `src/teseor.css`, so it lands in `dist/teseor.css` automatically. Full-bundle size went from 2.58 kB to 3.32 kB brotli (8 kB budget).

## Why

The Button spec and the generated TypeScript contract have been on `main` for several PRs without a CSS implementation, so the demo couldn't actually render anything yet. This closes that loop: the styling rules now exist for every variant × intent × size combination the spec declares, plus the five visual states. With this in, the next step (a React wrapper) can prove the spec → contract → CSS → wrapper pipeline end-to-end against a real component.

## Design choices

Visual treatments I picked. Easy to redirect.

- **Solid (default)**: filled background from the intent's `bg` token, label from the matching `fg` token.
- **Outline**: transparent background, intent-colored label, 1 px inset box-shadow ring.
- **Ghost**: transparent background, intent-colored label. No ring; relies on hover/focus to surface.
- **Link**: text-only, no padding, underlined with `text-underline-offset: 0.2em`.
- **Hover**: solid darkens 8% via `color-mix(in oklch, … black)`. Outline/ghost get a 12% transparent fill of the intent. Link goes from 1 px to 2 px underline thickness.
- **Active**: another 8% darken + `translateY(1 px)` for tactile press.
- **Focus-visible**: 2 px solid `--t-focus-ring` outline, 2 px offset.
- **Disabled / aria-disabled**: opacity 0.6, `cursor: not-allowed`.
- **Loading**: `cursor: progress`; label hidden via `[data-button-label]`; spinner appears via `[data-button-spinner]` as a rotating border ring sized to 1em. Wrapper components render the label / spinner DOM; CSS handles visibility.
- **Block (`data-block="true"`)**: `inline-size: 100%` for full-width.
- **Icons**: any direct-child `<svg>` or `[data-button-icon]` is sized to 1em × 1em and prevented from shrinking.

All values come from tokens — zero hard-coded colors or sizes. Sizes pull `--t-row-{2,3,4}` for height and `--t-space-{3,4,5}` for inline padding.

## Test plan

- `pnpm --filter @teseor/css build` — clean, deterministic across two consecutive runs.
- `pnpm size` — full bundle 3.32 kB brotli, well under the 8 kB budget.
- `pnpm lint` clean (stylelint accepts `@layer`, `:where()`, `color-mix`, logical properties).
- `pnpm typecheck` clean.
- `pnpm verify:no-dev-leak` clean.
- `pnpm gen` still a no-op against the contract output (no spec changes).
- Visual verification deferred to the visual-tests suite, which gates on `tests/__snapshots__` (none yet; arrives with the test generator).

## Out of scope

- React / Vue / Svelte / Angular / web-component wrappers — that's the wrapper generators.
- Per-component `dist/button.css` entry — the bundle inlines the rules now; a separate publishable file lands when more than one component exists.
- Visual baselines via Playwright — gated on the test scaffold generator.
- Reduced-motion-specific paths — covered globally by `--t-motion-scale` (consumer sets `--t-motion-scale: 0` for instant transitions, already wired in tokens).
- A real spinner SVG — the CSS reserves the slot and styles it; the React/Vue wrappers will render the actual SVG element. CSS-only consumers can drop any 1em element with `data-button-spinner`.

Closes #557