### PR TITLE
fix(css): declare the @layer order in every emitted CSS file

### DIFF
--- a/.changeset/css-layer-order.md
+++ b/.changeset/css-layer-order.md
@@ -1,0 +1,5 @@
+---
+"@teseor/css": patch
+---
+
+Every emitted CSS file now declares the full `@layer` order up front, not just the bundle. CSS `@layer` precedence is fixed by first encounter, so loading a per-component file (`@teseor/css/components/*.css`) before — or without — the full bundle previously left the order undefined: reset rules could outrank component rules, and a component could render unstyled. The `@layer` statement is idempotent, so repeating it across files is harmless and makes the cascade independent of load order.

--- a/packages/css/__tests__/build-output.test.ts
+++ b/packages/css/__tests__/build-output.test.ts
@@ -1,0 +1,36 @@
+import { execSync } from "node:child_process";
+import { readdirSync, readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { beforeAll, expect, test } from "vitest";
+
+const cssRoot = resolve(import.meta.dirname, "..");
+const distDir = resolve(cssRoot, "dist");
+
+const LAYER_ORDER =
+  "@layer reset, tokens.scale, tokens.semantic, base, primitives, components.tokens, components.styles, utilities, themes;";
+
+function cssFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      out.push(...cssFiles(full));
+    } else if (entry.name.endsWith(".css")) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+beforeAll(() => {
+  execSync("node build.mjs", { cwd: cssRoot, stdio: "ignore" });
+});
+
+test("every emitted CSS file declares the full @layer order first", () => {
+  const files = cssFiles(distDir);
+  expect(files.length).toBeGreaterThan(0);
+  for (const file of files) {
+    const content = readFileSync(file, "utf8");
+    expect(content.startsWith(LAYER_ORDER), file).toBe(true);
+  }
+});

--- a/packages/css/build.mjs
+++ b/packages/css/build.mjs
@@ -13,6 +13,12 @@ const DIST = resolve(ROOT, "dist");
 const COMPONENTS_SRC = resolve(SRC, "components");
 const COMPONENTS_DIST = resolve(DIST, "components");
 
+// Prepended to every emitted file. CSS @layer precedence is fixed by first
+// encounter, so each file must declare the full order — otherwise whichever
+// loads first decides it. Idempotent across files.
+const LAYER_ORDER =
+  "@layer reset, tokens.scale, tokens.semantic, base, primitives, components.tokens, components.styles, utilities, themes;";
+
 const TOP_LEVEL_ENTRIES = [
   { from: "teseor.css", to: "teseor.css" },
   { from: "tokens.css", to: "tokens.css" },
@@ -36,7 +42,7 @@ async function buildOne(inputPath, outputPath) {
   for (const warn of result.warnings()) {
     process.stderr.write(`build-css ${inputPath}: ${warn.toString()}\n`);
   }
-  await writeFile(outputPath, `${result.css.trimEnd()}\n`, "utf8");
+  await writeFile(outputPath, `${LAYER_ORDER}\n\n${result.css.trimEnd()}\n`, "utf8");
 }
 
 async function listComponents() {

--- a/packages/css/src/teseor.css
+++ b/packages/css/src/teseor.css
@@ -1,5 +1,3 @@
-@layer reset, tokens.scale, tokens.semantic, base, primitives, components.tokens, components.styles, utilities, themes;
-
 @import url("./reset.css");
 @import url("./tokens.css");
 @import url("./base.css");


### PR DESCRIPTION
## What

`build.mjs` now prepends the canonical `@layer reset, tokens.scale, … , themes;` declaration to every emitted file — per-component (`dist/components/*.css`) and standalone foundation files, not just the full bundle. The redundant declaration in `src/teseor.css` is removed; `build.mjs` is the single source.

## Why

CSS `@layer` precedence is fixed by *first encounter*. Only `dist/teseor.css` carried the order declaration; the per-component and foundation files did not. When a page loads more than one `@teseor/css` file and one *without* the declaration loads first, it registers its own layers as the earliest (weakest) ones — and a later file's declaration can no longer reposition them.

Surfaced in `apps/docs/` (#590): the page loads `dist/components/button.css` before `dist/teseor.css`. `button.css` registered `components.*` as layers 1–2; `teseor.css` then appended `reset` *after* them, so `reset` outranked `components.styles` — the reset's `button { background: none; border: 0 }` beat `.t-button`, and the button rendered unstyled. The dogfood site caught a real cascade defect on day one.

The `@layer` statement is idempotent, so repeating it across files is harmless and makes the cascade independent of load order.

## Test plan

- `pnpm build:css` — every `dist/**/*.css` now begins with the `@layer` declaration (verified).
- New `packages/css/__tests__/build-output.test.ts` runs the build and asserts it for every emitted file — a new file can't regress.
- `pnpm typecheck && pnpm test` — green (42 unit tests).

## Out of scope

- The `apps/docs/` scaffold itself (#590 / #600) — it only surfaced this.

Closes #601