### PR TITLE
fix(css): scope component selectors and drop the dead spinner node

### DIFF
--- a/.changeset/component-css-hygiene.md
+++ b/.changeset/component-css-hygiene.md
@@ -1,0 +1,7 @@
+---
+"@teseor/css": patch
+"@teseor/react": patch
+"@teseor/vue": patch
+---
+
+Component CSS/DOM hygiene. The button's spinner span renders only when `loading` — non-loading buttons no longer carry an empty `<span data-button-spinner>`. Component CSS box-sizes itself and its named parts instead of every descendant (`& *`), so a layout primitive no longer reaches into nested components; a stylelint rule (`selector-max-universal: 0`) enforces it. The loading state hides the label with `opacity: 0` instead of `visibility: hidden`, keeping it in the accessibility tree.

--- a/.stylelintrc.cjs
+++ b/.stylelintrc.cjs
@@ -29,4 +29,12 @@ module.exports = {
     "custom-property-pattern": null,
     "custom-media-pattern": "^[a-z0-9-]+$",
   },
+  overrides: [
+    {
+      files: ["packages/css/src/components/**/*.css"],
+      rules: {
+        "selector-max-universal": 0,
+      },
+    },
+  ],
 };

--- a/docs/rules/accessibility.md
+++ b/docs/rules/accessibility.md
@@ -71,6 +71,8 @@ Windows High Contrast / Forced Colors mode replaces author colors with user-defi
 - ~30 min per release for atomic phases; longer for stateful ones.
 - JAWS deferred post-v1.0 — costly license; NVDA covers ~90% of JAWS-relevant regressions.
 
+**Visually hiding accessible content.** `visibility: hidden` and `display: none` remove an element from the accessibility tree. To hide something visually while keeping it for assistive tech — e.g. a button's label behind a loading spinner — use `opacity: 0` (keeps the node, its layout box, and its accessible name) or a clip-based visually-hidden utility.
+
 ## Documentation
 
 Every component's docs page surfaces its a11y story (per `spec.a11y` and `docs-site.md` section 11):

--- a/docs/rules/component-shape.md
+++ b/docs/rules/component-shape.md
@@ -19,9 +19,12 @@ Every component is one CSS file. It looks like this — every line is intentiona
 }
 
 @layer components.styles {
-  /* Scoped reset. Only touches descendants of .t-button. */
+  /* Box-size the component and its own named parts — never `*`. A
+     universal descendant reaches consumer content and nested components.
+     Enforced by Stylelint (selector-max-universal: 0). */
   .t-button,
-  .t-button * {
+  .t-button [data-button-label],
+  .t-button [data-button-spinner] {
     box-sizing: border-box;
   }
 
@@ -68,7 +71,7 @@ Every component is one CSS file. It looks like this — every line is intentiona
 ## Anatomy
 
 1. **Two sublayers.** `components.tokens` declares `--_*` variables on the root selector. `components.styles` writes rule bodies. Splitting them lets themes override token values without specificity wars (see `architecture/layer-order.md`).
-2. **Scoped reset.** Two-selector reset (`.t-button, .t-button *`) — small enough to be free, big enough to immunize the component against global element styles.
+2. **Box-sizing — self and named parts.** A component box-sizes itself and its own named parts (`[data-<name>-*]`) — never a universal descendant (`.t-component *`), which reaches consumer content and nested components. A layout primitive (Stack, Cluster) has no internal parts and box-sizes only itself. Stylelint's `selector-max-universal: 0` enforces it on component CSS.
 3. **Three-tier `var()` chain at runtime.** Authored as `var(--t-button-x, var(--t-semantic))`; the build inlines the resolved literal from `tokens.css` as the third position, so the shipped CSS is `var(--t-button-x, var(--t-semantic, <literal>))`. Changing a design value is one edit in `tokens.css` (ADR-0003). The literal floor is the failsafe — if both tokens are absent the component still renders correctly.
 4. **Logical properties.** `block-size`, `padding-inline`, `padding-block`. No `width`, `height`, `padding-left`, `padding-right`.
 5. **Motion via tokens × scale.** Every transition multiplies the duration token by `var(--t-motion-scale)`. Apps that set `--t-motion-scale: 0` get instant transitions.

--- a/packages/css/src/components/button/button.css
+++ b/packages/css/src/components/button/button.css
@@ -37,7 +37,9 @@
       box-shadow calc(var(--_dur) * var(--t-motion-scale)) var(--_ease),
       transform calc(var(--_dur) * var(--t-motion-scale)) var(--_ease);
 
-    & * {
+    & [data-button-label],
+    & [data-button-spinner],
+    & [data-button-icon] {
       box-sizing: border-box;
     }
 
@@ -124,11 +126,7 @@
     }
 
     &:where([data-loading="true"]) [data-button-label] {
-      visibility: hidden;
-    }
-
-    &:where(:not([data-loading="true"])) [data-button-spinner] {
-      display: none;
+      opacity: 0;
     }
 
     &:where([data-loading="true"]) [data-button-spinner] {

--- a/packages/css/src/components/cluster/cluster.css
+++ b/packages/css/src/components/cluster/cluster.css
@@ -11,10 +11,6 @@
     flex-flow: row wrap;
     gap: var(--_gap);
 
-    & * {
-      box-sizing: border-box;
-    }
-
     @each $i in 0, 1, 2, 3, 4, 5, 6, 7, 8 {
       &:where([data-gap="$(i)"]) {
         --_gap: var(--t-space-$(i));

--- a/packages/css/src/components/stack/stack.css
+++ b/packages/css/src/components/stack/stack.css
@@ -11,10 +11,6 @@
     flex-direction: column;
     gap: var(--_gap);
 
-    & * {
-      box-sizing: border-box;
-    }
-
     @each $i in 0, 1, 2, 3, 4, 5, 6, 7, 8 {
       &:where([data-gap="$(i)"]) {
         --_gap: var(--t-space-$(i));

--- a/packages/react/src/Button.tsx
+++ b/packages/react/src/Button.tsx
@@ -105,7 +105,7 @@ export function Button(props: ButtonProps) {
           {iconEnd}
         </span>
       ) : null}
-      <span data-button-spinner="" aria-hidden="true" />
+      {loading ? <span data-button-spinner="" aria-hidden="true" /> : null}
     </Component>
   );
 }

--- a/packages/vue/src/Button.vue
+++ b/packages/vue/src/Button.vue
@@ -86,6 +86,6 @@ const attrs = computed(() => ({
     <span v-if="$slots.iconEnd" data-button-icon="" data-position="end">
       <slot name="iconEnd" />
     </span>
-    <span data-button-spinner="" aria-hidden="true" />
+    <span v-if="loading" data-button-spinner="" aria-hidden="true" />
   </component>
 </template>

--- a/scripts/codegen/__tests__/__snapshots__/gen-react.test.ts.snap
+++ b/scripts/codegen/__tests__/__snapshots__/gen-react.test.ts.snap
@@ -108,7 +108,7 @@ export function Button(props: ButtonProps) {
           {iconEnd}
         </span>
       ) : null}
-      <span data-button-spinner="" aria-hidden="true" />
+      {loading ? <span data-button-spinner="" aria-hidden="true" /> : null}
     </Component>
   );
 }

--- a/scripts/codegen/__tests__/__snapshots__/gen-vue.test.ts.snap
+++ b/scripts/codegen/__tests__/__snapshots__/gen-vue.test.ts.snap
@@ -89,7 +89,7 @@ const attrs = computed(() => ({
     <span v-if="$slots.iconEnd" data-button-icon="" data-position="end">
       <slot name="iconEnd" />
     </span>
-    <span data-button-spinner="" aria-hidden="true" />
+    <span v-if="loading" data-button-spinner="" aria-hidden="true" />
   </component>
 </template>
 "

--- a/scripts/codegen/src/generators/gen-react.ts
+++ b/scripts/codegen/src/generators/gen-react.ts
@@ -215,7 +215,9 @@ function renderBody(spec: Spec, slots: SlotInfo[], hasLoading: boolean): string 
     ...slots.filter((s) => s.position === undefined).map((s) => renderSlot(spec, s)),
     hasLoading ? `      <span data-${spec.name}-label="">{children}</span>` : `      {children}`,
     ...slots.filter((s) => s.position === "end").map((s) => renderSlot(spec, s)),
-    hasLoading ? `      <span data-${spec.name}-spinner="" aria-hidden="true" />` : null,
+    hasLoading
+      ? `      {loading ? <span data-${spec.name}-spinner="" aria-hidden="true" /> : null}`
+      : null,
   ]
     .filter((line): line is string => line !== null)
     .join("\n");

--- a/scripts/codegen/src/generators/gen-vue.ts
+++ b/scripts/codegen/src/generators/gen-vue.ts
@@ -243,7 +243,9 @@ function renderBody(spec: Spec, slots: SlotInfo[], hasLoading: boolean): string 
     ...slots.filter((s) => s.position === undefined).map((s) => renderSlot(spec, s)),
     hasLoading ? `    <span data-${spec.name}-label=""><slot /></span>` : `    <slot />`,
     ...slots.filter((s) => s.position === "end").map((s) => renderSlot(spec, s)),
-    hasLoading ? `    <span data-${spec.name}-spinner="" aria-hidden="true" />` : null,
+    hasLoading
+      ? `    <span v-if="loading" data-${spec.name}-spinner="" aria-hidden="true" />`
+      : null,
   ]
     .filter((l): l is string => l !== null)
     .join("\n");

--- a/tests/contract/button.spec.ts-snapshots/button.html
+++ b/tests/contract/button.spec.ts-snapshots/button.html
@@ -1,20 +1,20 @@
 <!-- solid-primary -->
-<button class="t-button" data-intent="primary" data-variant="solid"><span data-button-label="">Label</span><span aria-hidden="true" data-button-spinner=""></span></button>
+<button class="t-button" data-intent="primary" data-variant="solid"><span data-button-label="">Label</span></button>
 
 <!-- solid-danger-md -->
-<button class="t-button" data-intent="danger" data-size="md" data-variant="solid"><span data-button-label="">Label</span><span aria-hidden="true" data-button-spinner=""></span></button>
+<button class="t-button" data-intent="danger" data-size="md" data-variant="solid"><span data-button-label="">Label</span></button>
 
 <!-- outline-neutral -->
-<button class="t-button" data-intent="neutral" data-variant="outline"><span data-button-label="">Label</span><span aria-hidden="true" data-button-spinner=""></span></button>
+<button class="t-button" data-intent="neutral" data-variant="outline"><span data-button-label="">Label</span></button>
 
 <!-- ghost-with-icon -->
-<button class="t-button" data-intent="neutral" data-variant="ghost"><span data-button-icon="" data-position="start"><span data-fixture-slot="arrow-left"></span></span><span data-button-label="">Label</span><span aria-hidden="true" data-button-spinner=""></span></button>
+<button class="t-button" data-intent="neutral" data-variant="ghost"><span data-button-icon="" data-position="start"><span data-fixture-slot="arrow-left"></span></span><span data-button-label="">Label</span></button>
 
 <!-- link-primary -->
-<a class="t-button" data-intent="primary" data-variant="link"><span data-button-label="">Label</span><span aria-hidden="true" data-button-spinner=""></span></a>
+<a class="t-button" data-intent="primary" data-variant="link"><span data-button-label="">Label</span></a>
 
 <!-- loading -->
 <button aria-busy="true" class="t-button" data-intent="primary" data-loading="true" data-variant="solid" disabled=""><span data-button-label="">Label</span><span aria-hidden="true" data-button-spinner=""></span></button>
 
 <!-- block-mobile -->
-<button class="t-button" data-block="true" data-intent="primary" data-size="lg" data-variant="solid"><span data-button-label="">Label</span><span aria-hidden="true" data-button-spinner=""></span></button>
+<button class="t-button" data-block="true" data-intent="primary" data-size="lg" data-variant="solid"><span data-button-label="">Label</span></button>


### PR DESCRIPTION
## What

Three component-hygiene fixes surfaced by inspecting the docs site:

1. **Dead DOM node.** The `data-button-spinner` span no longer renders in every button — `gen-react` / `gen-vue` emit it only when `loading` is set. `button.css` drops its now-dead `:not([data-loading]) [data-button-spinner] { display: none }` rule.
2. **Over-broad selector.** `button.css` / `stack.css` / `cluster.css` used `& *` (universal descendant) for `box-sizing` — it reached every nested descendant, including other components. Button now box-sizes its named parts (`[data-button-label]`, `[data-button-spinner]`, `[data-button-icon]`); the layout primitives box-size only themselves.
3. **Loading a11y.** The loading state hid the label with `visibility: hidden`, which removes it from the accessibility tree — a loading button then had no accessible name. Now `opacity: 0`: invisible, width preserved, accessible name kept.

## Why

Components are self-contained and minimal: each box-sizes itself and its own parts, never arbitrary descendants or consumer content; and ships no DOM a given prop-state doesn't use.

## Safeguard + lesson

- **Safeguard:** a stylelint rule — `selector-max-universal: 0` on `packages/css/src/components/**` — fails any component CSS that uses `*`.
- **Lesson:** `component-shape.md` rule 2 rewritten (box-size self + named parts, not `& *`); `accessibility.md` gains a note on hiding content without dropping it from the a11y tree.

## Test plan

- `pnpm typecheck && pnpm lint && pnpm test` — green (42 unit tests).
- `pnpm test:e2e` — 26 pass; the combined `button.html` snapshot regenerated — non-loading buttons no longer carry the spinner span, the `loading` fixture keeps it.

## Out of scope

- "Modifiers set only vars" as a CSS-authoring rule, and literal-floor injection (#605) — separate.

Closes #604