### PR TITLE
feat(css): inline literal floors via postcss-teseor-floor

### DIFF
--- a/.changeset/inline-literal-floors.md
+++ b/.changeset/inline-literal-floors.md
@@ -1,0 +1,5 @@
+---
+"@teseor/css": minor
+---
+
+Component CSS now ships with a literal fallback inlined into every `--t-*` token reference, resolved from `tokens.css` at build time by the in-house `postcss-teseor-floor` plugin. A per-component file (`@teseor/css/components/button.css`) renders with correct default values even when `tokens.css` is absent — `var(--t-button-bg, var(--t-accent))` ships as `var(--t-button-bg, var(--t-accent, oklch(65% 0.18 250deg)))`. The build fails if component CSS references a `--t-*` token not declared in `tokens.css`.

--- a/packages/css/__tests__/build-output.test.ts
+++ b/packages/css/__tests__/build-output.test.ts
@@ -34,3 +34,18 @@ test("every emitted CSS file declares the full @layer order first", () => {
     expect(content.startsWith(LAYER_ORDER), file).toBe(true);
   }
 });
+
+test("shipped component CSS floors every token reference (acid test)", () => {
+  const bareToken = /var\(\s*--t-[\w-]+\s*\)/;
+  const files = cssFiles(join(distDir, "components"));
+  expect(files.length).toBeGreaterThan(0);
+  for (const file of files) {
+    const css = readFileSync(file, "utf8");
+    expect(bareToken.test(css), `${file}: token reference with no literal floor`).toBe(false);
+  }
+});
+
+test("shipped component CSS inlines the literal resolved from tokens.css", () => {
+  const button = readFileSync(join(distDir, "components", "button.css"), "utf8");
+  expect(button).toContain("var(--t-accent, oklch(65% 0.18 250deg))");
+});

--- a/packages/css/build.mjs
+++ b/packages/css/build.mjs
@@ -6,6 +6,7 @@ import postcss from "postcss";
 import postcssCustomMedia from "postcss-custom-media";
 import postcssEach from "postcss-each";
 import postcssImport from "postcss-import";
+import { buildTokenMap, teseorFloor } from "./postcss-teseor-floor.ts";
 
 const ROOT = dirname(fileURLToPath(import.meta.url));
 const SRC = resolve(ROOT, "src");
@@ -28,21 +29,23 @@ const TOP_LEVEL_ENTRIES = [
   { from: "tailwind.css", to: "tailwind.css" },
 ];
 
-function buildPlugins() {
-  return [postcssImport(), postcssEach(), postcssCustomMedia()];
-}
-
-async function buildOne(inputPath, outputPath) {
+// Pass 1 expands @import/@each/@custom-media. Pass 2 (postcss-teseor-floor)
+// then sees concrete var() chains and appends each token's literal floor.
+async function buildOne(inputPath, outputPath, tokens) {
   const css = await readFile(inputPath, "utf8");
-  const result = await postcss(buildPlugins()).process(css, {
+  const expanded = await postcss([postcssImport(), postcssEach(), postcssCustomMedia()]).process(
+    css,
+    { from: inputPath, to: outputPath, map: false },
+  );
+  const floored = await postcss([teseorFloor({ tokens })]).process(expanded.css, {
     from: inputPath,
     to: outputPath,
     map: false,
   });
-  for (const warn of result.warnings()) {
+  for (const warn of [...expanded.warnings(), ...floored.warnings()]) {
     process.stderr.write(`build-css ${inputPath}: ${warn.toString()}\n`);
   }
-  await writeFile(outputPath, `${LAYER_ORDER}\n\n${result.css.trimEnd()}\n`, "utf8");
+  await writeFile(outputPath, `${LAYER_ORDER}\n\n${floored.css.trimEnd()}\n`, "utf8");
 }
 
 async function listComponents() {
@@ -57,10 +60,11 @@ async function listComponents() {
 
 async function main() {
   await mkdir(DIST, { recursive: true });
+  const tokens = buildTokenMap(await readFile(resolve(SRC, "tokens.css"), "utf8"));
   for (const entry of TOP_LEVEL_ENTRIES) {
     const inputPath = resolve(SRC, entry.from);
     const outputPath = resolve(DIST, entry.to);
-    await buildOne(inputPath, outputPath);
+    await buildOne(inputPath, outputPath, tokens);
     process.stdout.write(`build-css: ${entry.from} -> dist/${entry.to}\n`);
   }
 
@@ -70,7 +74,7 @@ async function main() {
     for (const name of components) {
       const inputPath = resolve(COMPONENTS_SRC, name, `${name}.css`);
       const outputPath = resolve(COMPONENTS_DIST, `${name}.css`);
-      await buildOne(inputPath, outputPath);
+      await buildOne(inputPath, outputPath, tokens);
       process.stdout.write(
         `build-css: components/${name}/${name}.css -> dist/components/${name}.css\n`,
       );

--- a/packages/css/package.json
+++ b/packages/css/package.json
@@ -32,6 +32,7 @@
   ],
   "scripts": {
     "build": "node build.mjs",
+    "typecheck": "tsc --noEmit",
     "test": "vitest run --root ../.."
   },
   "publishConfig": {
@@ -48,6 +49,7 @@
     "postcss": "^8.5.15",
     "postcss-custom-media": "^12.0.1",
     "postcss-each": "^1.1.0",
-    "postcss-import": "^16.1.1"
+    "postcss-import": "^16.1.1",
+    "postcss-value-parser": "^4.2.0"
   }
 }

--- a/packages/css/postcss-teseor-floor.test.ts
+++ b/packages/css/postcss-teseor-floor.test.ts
@@ -1,0 +1,77 @@
+import postcss from "postcss";
+import { describe, expect, test } from "vitest";
+import { buildTokenMap, teseorFloor } from "./postcss-teseor-floor.ts";
+
+const tokens = new Map([
+  ["--t-accent", "oklch(65% 0.18 250deg)"],
+  ["--t-space-2", "0.5rem"],
+]);
+
+function floor(css: string): string {
+  return postcss([teseorFloor({ tokens })]).process(css, { from: undefined }).css;
+}
+
+describe("buildTokenMap", () => {
+  const tokensCss = `
+    @layer tokens.scale {
+      :root {
+        --t-accent-500: oklch(65% 0.18 250deg);
+        --t-space-2: 0.5rem;
+        --t-motion-scale: 1;
+      }
+      @media (prefers-reduced-motion: reduce) {
+        :root { --t-motion-scale: 0; }
+      }
+    }
+    @layer tokens.semantic {
+      :root { --t-accent: var(--t-accent-500); }
+      @media (forced-colors: active) {
+        :root { --t-accent: ButtonText; }
+      }
+    }
+  `;
+
+  test("keeps a scale literal as-is", () => {
+    expect(buildTokenMap(tokensCss).get("--t-space-2")).toBe("0.5rem");
+  });
+
+  test("resolves a semantic alias to its terminal literal", () => {
+    expect(buildTokenMap(tokensCss).get("--t-accent")).toBe("oklch(65% 0.18 250deg)");
+  });
+
+  test("reads the default :root, not the forced-colors branch", () => {
+    expect(buildTokenMap(tokensCss).get("--t-accent")).not.toBe("ButtonText");
+  });
+
+  test("reads the default :root, not the reduced-motion branch", () => {
+    expect(buildTokenMap(tokensCss).get("--t-motion-scale")).toBe("1");
+  });
+});
+
+describe("teseorFloor", () => {
+  test("appends a literal floor to a fallback-less token reference", () => {
+    expect(floor(".t-x { gap: var(--t-space-2); }")).toContain("var(--t-space-2, 0.5rem)");
+  });
+
+  test("floors the inner token of a two-level var() chain", () => {
+    expect(floor(".t-x { color: var(--t-button-fg, var(--t-accent)); }")).toContain(
+      "var(--t-button-fg, var(--t-accent, oklch(65% 0.18 250deg)))",
+    );
+  });
+
+  test("leaves --_ private references untouched", () => {
+    expect(floor(".t-x { color: var(--_bg); }")).toContain("var(--_bg)");
+  });
+
+  test("leaves token definitions untouched", () => {
+    expect(floor(":root { --t-foo: var(--t-space-2); }")).not.toContain("0.5rem");
+  });
+
+  test("respects a hand-written fallback", () => {
+    expect(floor(".t-x { color: var(--t-accent, red); }")).toContain("var(--t-accent, red)");
+  });
+
+  test("throws when a token is not declared in tokens.css", () => {
+    expect(() => floor(".t-x { color: var(--t-missing); }")).toThrow(/not declared in tokens\.css/);
+  });
+});

--- a/packages/css/postcss-teseor-floor.ts
+++ b/packages/css/postcss-teseor-floor.ts
@@ -1,0 +1,165 @@
+/**
+ * postcss-teseor-floor — gives every `--t-*` token reference in component CSS a
+ * literal fallback resolved from `tokens.css`, so a shipped file renders
+ * correctly even when `tokens.css` is absent.
+ *
+ *   authored   var(--t-button-bg, var(--t-accent))
+ *   shipped    var(--t-button-bg, var(--t-accent, oklch(65% 0.18 250deg)))
+ *
+ * The literal lives once in `tokens.css`; the build copies it into the third
+ * `var()` position. `--_*` private references are left alone — they resolve
+ * through their own floored `components.tokens` declaration.
+ */
+import type { Container, Declaration, Plugin, Root } from "postcss";
+import postcss from "postcss";
+import valueParser from "postcss-value-parser";
+
+type Node = valueParser.Node;
+
+const TOKEN_PREFIX = "--t-";
+const PRIVATE_PREFIX = "--_";
+const CONDITIONAL_AT_RULES = new Set(["media", "supports", "container"]);
+
+/** Value of the first `word` child, or undefined when there is none. */
+function firstWord(nodes: Node[]): string | undefined {
+  for (const node of nodes) {
+    if (node.type === "word") {
+      return node.value;
+    }
+  }
+  return undefined;
+}
+
+/** Index of the top-level `,` separating a `var()`'s name from its fallback. */
+function commaIndex(nodes: Node[]): number {
+  return nodes.findIndex((node) => node.type === "div" && node.value === ",");
+}
+
+/**
+ * Collect `--t-*` declarations from default `:root` rules. `@media`-gated
+ * branches (`forced-colors`, `prefers-reduced-motion`) are skipped so the floor
+ * carries the default-mode literal.
+ */
+function collectDefaultTokens(container: Container, raw: Map<string, string>): void {
+  container.each((node) => {
+    if (node.type === "atrule") {
+      if (!CONDITIONAL_AT_RULES.has(node.name)) {
+        collectDefaultTokens(node, raw);
+      }
+    } else if (node.type === "rule" && node.selector === ":root") {
+      node.walkDecls((decl) => {
+        if (decl.prop.startsWith(TOKEN_PREFIX)) {
+          raw.set(decl.prop, decl.value);
+        }
+      });
+    }
+  });
+}
+
+/** Replace every `var()` whose token resolves in `raw` with its terminal value. */
+function resolveNodes(nodes: Node[], raw: Map<string, string>, seen: Set<string>): Node[] {
+  const out: Node[] = [];
+  for (const node of nodes) {
+    if (node.type !== "function") {
+      out.push(node);
+      continue;
+    }
+    if (node.value !== "var") {
+      out.push({ ...node, nodes: resolveNodes(node.nodes, raw, seen) });
+      continue;
+    }
+    const name = firstWord(node.nodes);
+    const comma = commaIndex(node.nodes);
+    if (name !== undefined && raw.has(name)) {
+      if (seen.has(name)) {
+        throw new Error(`postcss-teseor-floor: token cycle through ${name}`);
+      }
+      const value = raw.get(name) ?? "";
+      out.push(...resolveNodes(valueParser(value).nodes, raw, new Set(seen).add(name)));
+    } else if (comma !== -1) {
+      out.push(...resolveNodes(node.nodes.slice(comma + 1), raw, seen));
+    } else {
+      out.push(node);
+    }
+  }
+  return out;
+}
+
+/** Resolve `tokens.css` into a `--t-*` → terminal-literal map. */
+export function buildTokenMap(tokensCss: string): Map<string, string> {
+  const raw = new Map<string, string>();
+  collectDefaultTokens(postcss.parse(tokensCss), raw);
+  const resolved = new Map<string, string>();
+  for (const [name, value] of raw) {
+    resolved.set(
+      name,
+      valueParser.stringify(resolveNodes(valueParser(value).nodes, raw, new Set([name]))),
+    );
+  }
+  return resolved;
+}
+
+/** Append a literal fallback to every fallback-less `--t-*` reference. */
+function floorNodes(nodes: Node[], tokens: Map<string, string>, unresolved: Set<string>): Node[] {
+  return nodes.map((node) => {
+    if (node.type !== "function") {
+      return node;
+    }
+    if (node.value !== "var" || commaIndex(node.nodes) !== -1) {
+      return { ...node, nodes: floorNodes(node.nodes, tokens, unresolved) };
+    }
+    const name = firstWord(node.nodes);
+    if (name === undefined || name.startsWith(PRIVATE_PREFIX) || !name.startsWith(TOKEN_PREFIX)) {
+      return node;
+    }
+    const literal = tokens.get(name);
+    if (literal === undefined) {
+      unresolved.add(name);
+      return node;
+    }
+    const separator: valueParser.DivNode = {
+      type: "div",
+      value: ",",
+      before: "",
+      after: " ",
+      sourceIndex: 0,
+      sourceEndIndex: 0,
+    };
+    return { ...node, nodes: [...node.nodes, separator, ...valueParser(literal).nodes] };
+  });
+}
+
+/**
+ * PostCSS plugin. Run last, after import/each/custom-media have expanded the
+ * CSS, so every `var()` reference is concrete.
+ */
+export function teseorFloor(options: { tokens: Map<string, string> }): Plugin {
+  const { tokens } = options;
+  return {
+    postcssPlugin: "postcss-teseor-floor",
+    Once(root: Root) {
+      const unresolved = new Set<string>();
+      let firstUnresolved: Declaration | undefined;
+      root.walkDecls((decl) => {
+        if (decl.prop.startsWith(TOKEN_PREFIX) || !decl.value.includes("var(")) {
+          return;
+        }
+        const before = unresolved.size;
+        const floored = valueParser.stringify(
+          floorNodes(valueParser(decl.value).nodes, tokens, unresolved),
+        );
+        if (unresolved.size > before && firstUnresolved === undefined) {
+          firstUnresolved = decl;
+        }
+        if (floored !== decl.value) {
+          decl.value = floored;
+        }
+      });
+      if (firstUnresolved !== undefined) {
+        throw firstUnresolved.error(
+          `cannot resolve a literal floor for ${[...unresolved].join(", ")} — not declared in tokens.css`,
+        );
+      }
+    },
+  };
+}

--- a/packages/css/tsconfig.json
+++ b/packages/css/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["*.ts", "__tests__/**/*.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -160,6 +160,9 @@ importers:
       postcss-import:
         specifier: ^16.1.1
         version: 16.1.1(postcss@8.5.15)
+      postcss-value-parser:
+        specifier: ^4.2.0
+        version: 4.2.0
 
   packages/react:
     dependencies:


### PR DESCRIPTION
## What

Adds `postcss-teseor-floor`, an in-house PostCSS plugin that resolves every `--t-*` token to its terminal literal from `tokens.css` and appends it as the third `var()` position in component CSS. `build.mjs` runs it as a second pass, after import/each/custom-media have expanded the CSS.

```
authored   var(--t-button-bg, var(--t-accent))
shipped    var(--t-button-bg, var(--t-accent, oklch(65% 0.18 250deg)))
```

## Why

Per-component CSS depended on `tokens.css` for every colour, size, and duration. Loading `@teseor/css/components/button.css` alone left those `var()` chains unresolved. The literal floor is the failsafe tier from ADR-0003 — the value lives once in `tokens.css`, the build copies it into each chain, so a shipped component file renders correctly on its own.

The build now fails loudly if component CSS references a `--t-*` token not declared in `tokens.css`, catching typos that would otherwise ship two-tier output.

## Test plan

- `postcss-teseor-floor.test.ts` — unit covers token-map resolution (alias chains, forced-colors and reduced-motion branches skipped) and floor injection (chains, `--_` private refs left alone, token definitions skipped, hand-written fallbacks respected, unresolved token throws).
- `build-output.test.ts` — acid test: no shipped component file carries a bare `var(--t-*)`; the resolved literal is inlined.
- `pnpm typecheck`, `pnpm lint`, `pnpm test` all green. `@teseor/css` gains a `tsconfig.json` + `typecheck` script so the plugin is typechecked.

## Out of scope

- Forced-colors `@media` synthesis — ADR-0003 has `postcss-teseor-floor` also synthesize per-component `@media (forced-colors: active)` blocks; tracked as a follow-up.
- Per-component `@media (--md)` breakpoint aliases still ship unresolved (custom-media definitions live in `tokens.css`); separate from literal floors.

Closes #605