### PR TITLE
feat(codegen): gen-docs — component docs pages from specs

### DIFF
--- a/apps/docs/src/pages/components/button.astro
+++ b/apps/docs/src/pages/components/button.astro
@@ -4,19 +4,152 @@ import Base from "../../layouts/Base.astro";
 ---
 
 <Base title="Button — Teseor">
-  <main class="t-stack" data-gap="5">
+  <main class="t-stack" data-gap="6">
     <h1>Button</h1>
-    <p>
-      Placeholder component page. It proves the routing pattern and that the
-      docs render real <code>@teseor/react</code> components to static HTML at
-      build time — no client runtime. Generated per-component pages land with
-      gen-docs.
-    </p>
-
-    <div class="t-cluster" data-gap="3">
-      <Button variant="solid" intent="primary">Primary</Button>
-      <Button variant="outline" intent="neutral">Neutral</Button>
-      <Button variant="ghost" intent="neutral">Ghost</Button>
-    </div>
+    <p>A trigger that performs an action when activated.</p>
+    <section class="t-stack" data-gap="3">
+      <h2>Examples</h2>
+      <div class="t-stack" data-gap="2">
+        <h3>solid-primary</h3>
+        <div class="t-cluster" data-gap="3">
+          <Button variant="solid" intent="primary">Button</Button>
+        </div>
+        <code>variant="solid" intent="primary"</code>
+      </div>
+      <div class="t-stack" data-gap="2">
+        <h3>solid-danger-md</h3>
+        <div class="t-cluster" data-gap="3">
+          <Button variant="solid" intent="danger" size="md">Button</Button>
+        </div>
+        <code>variant="solid" intent="danger" size="md"</code>
+      </div>
+      <div class="t-stack" data-gap="2">
+        <h3>outline-neutral</h3>
+        <div class="t-cluster" data-gap="3">
+          <Button variant="outline" intent="neutral">Button</Button>
+        </div>
+        <code>variant="outline" intent="neutral"</code>
+      </div>
+      <div class="t-stack" data-gap="2">
+        <h3>ghost-with-icon</h3>
+        <div class="t-cluster" data-gap="3">
+          <Button variant="ghost" intent="neutral">Button</Button>
+        </div>
+        <code>variant="ghost" intent="neutral" iconStart="arrow-left"</code>
+      </div>
+      <div class="t-stack" data-gap="2">
+        <h3>link-primary</h3>
+        <div class="t-cluster" data-gap="3">
+          <Button variant="link" intent="primary" as="a">Button</Button>
+        </div>
+        <code>variant="link" intent="primary" as="a"</code>
+      </div>
+      <div class="t-stack" data-gap="2">
+        <h3>loading</h3>
+        <div class="t-cluster" data-gap="3">
+          <Button variant="solid" intent="primary" loading>Button</Button>
+        </div>
+        <code>variant="solid" intent="primary" loading</code>
+      </div>
+      <div class="t-stack" data-gap="2">
+        <h3>block-mobile</h3>
+        <div class="t-cluster" data-gap="3">
+          <Button variant="solid" intent="primary" block size="lg">Button</Button>
+        </div>
+        <code>variant="solid" intent="primary" block size="lg"</code>
+      </div>
+    </section>
+    <section class="t-stack" data-gap="3">
+      <h2>Props</h2>
+      <table>
+        <thead><tr><th>Prop</th><th>Type</th><th>Default</th><th>Description</th></tr></thead>
+        <tbody>
+        <tr><td><code>as</code></td><td><code>string</code></td><td><code>button</code></td><td>Polymorphic root element. Defaults to `button`; set to `a` for link-shaped triggers (paired with `variant: link`).</td></tr>
+        <tr><td><code>disabled</code></td><td><code>boolean</code></td><td><code>false</code></td><td>Disables interaction and applies the disabled visual state. Mapped to the native `disabled` attribute on `button`, `aria-disabled="true"` otherwise.</td></tr>
+        <tr><td><code>loading</code></td><td><code>boolean</code></td><td><code>false</code></td><td>Shows a spinner in place of the label and disables interaction. The original label stays in the accessibility tree.</td></tr>
+        <tr><td><code>iconStart</code></td><td><code>string, slot</code></td><td><code>null</code></td><td>Icon rendered before the label in the inline direction. Slot size scales with `size`. Accepts any node (icon component, SVG, etc.).</td></tr>
+        <tr><td><code>iconEnd</code></td><td><code>string, slot</code></td><td><code>null</code></td><td>Icon rendered after the label in the inline direction. Accepts any node.</td></tr>
+        <tr><td><code>block</code></td><td><code>boolean, responsive</code></td><td><code>false</code></td><td>Stretches the button to the inline-size of its container. Responsive so layouts can pin block-width on mobile and shrink to content above.</td></tr>
+        </tbody>
+      </table>
+    </section>
+    <section class="t-stack" data-gap="3">
+      <h2>Variants</h2>
+      <table>
+        <thead><tr><th>Name</th><th>Description</th></tr></thead>
+        <tbody>
+        <tr><td><code>solid</code></td><td>Filled background with intent color; default visual weight.</td></tr>
+        <tr><td><code>outline</code></td><td>Transparent background, intent-colored border and label; for secondary actions.</td></tr>
+        <tr><td><code>ghost</code></td><td>Transparent background with no border; for tertiary actions inside dense layouts or toolbars.</td></tr>
+        <tr><td><code>link</code></td><td>Renders as text with an underline; for navigation-shaped triggers that still need button semantics.</td></tr>
+        </tbody>
+      </table>
+    </section>
+    <section class="t-stack" data-gap="3">
+      <h2>Intents</h2>
+      <table>
+        <thead><tr><th>Name</th><th>Description</th></tr></thead>
+        <tbody>
+        <tr><td><code>primary</code></td><td>The page's most important action. One primary per surface.</td></tr>
+        <tr><td><code>neutral</code></td><td>Default action. Non-emphasized; used when no intent is needed.</td></tr>
+        <tr><td><code>success</code></td><td>Confirms a positive outcome (save, publish, accept).</td></tr>
+        <tr><td><code>warning</code></td><td>Indicates an action that needs attention but isn't destructive.</td></tr>
+        <tr><td><code>danger</code></td><td>Destructive or irreversible action (delete, cancel subscription).</td></tr>
+        </tbody>
+      </table>
+    </section>
+    <section class="t-stack" data-gap="3">
+      <h2>Sizes</h2>
+      <table>
+        <thead><tr><th>Name</th><th>Description</th></tr></thead>
+        <tbody>
+        <tr><td><code>sm</code></td><td>Compact density; safe at breakpoints above the mobile floor.</td></tr>
+        <tr><td><code>md</code></td><td>Default size.</td></tr>
+        <tr><td><code>lg</code></td><td>Emphatic; for hero CTAs and primary actions in mobile-first layouts.</td></tr>
+        </tbody>
+      </table>
+    </section>
+    <section class="t-stack" data-gap="3">
+      <h2>States</h2>
+      <ul>
+        <li><code>hover</code></li>
+        <li><code>focus</code></li>
+        <li><code>active</code></li>
+        <li><code>disabled</code></li>
+        <li><code>loading</code></li>
+      </ul>
+    </section>
+    <section class="t-stack" data-gap="3">
+      <h2>Tokens</h2>
+      <table>
+        <thead><tr><th>Token</th><th>Fallback</th><th>Description</th></tr></thead>
+        <tbody>
+        <tr><td><code>--t-button-height</code></td><td><code>--t-row</code></td><td>Control height; the size variant overrides this.</td></tr>
+        <tr><td><code>--t-button-bg</code></td><td><code>--t-accent</code></td><td>Background fill; the intent variant overrides this.</td></tr>
+        <tr><td><code>--t-button-fg</code></td><td><code>--t-on-accent</code></td><td>Foreground color (label and icon); pairs with `bg`.</td></tr>
+        <tr><td><code>--t-button-pad-x</code></td><td><code>--t-pad-x</code></td><td>Inline padding; the size variant overrides this.</td></tr>
+        <tr><td><code>--t-button-radius</code></td><td><code>--t-radius-md</code></td><td>Corner radius.</td></tr>
+        <tr><td><code>--t-button-dur</code></td><td><code>--t-dur-fast</code></td><td>Transition duration; multiplied by `--t-motion-scale` at the call site.</td></tr>
+        </tbody>
+      </table>
+    </section>
+    <section class="t-stack" data-gap="3">
+      <h2>Accessibility</h2>
+      <p>Role: <code>button</code></p>
+      <table>
+        <thead><tr><th>Key</th><th>Action</th></tr></thead>
+        <tbody>
+        <tr><td><code>Enter</code></td><td>activate</td></tr>
+        <tr><td><code>Space</code></td><td>activate</td></tr>
+        </tbody>
+      </table>
+    </section>
+    <section class="t-stack" data-gap="3">
+      <h2>Constraints</h2>
+      <ul>
+        <li>Link variant is text-colored; non-neutral intent fills have no surface to apply to.</li>
+        <li>Loading already disables interaction; disabling on top is redundant.</li>
+      </ul>
+    </section>
   </main>
 </Base>

--- a/apps/docs/src/pages/components/cluster.astro
+++ b/apps/docs/src/pages/components/cluster.astro
@@ -1,0 +1,90 @@
+---
+import { Cluster } from "@teseor/react";
+import Base from "../../layouts/Base.astro";
+---
+
+<Base title="Cluster — Teseor">
+  <main class="t-stack" data-gap="6">
+    <h1>Cluster</h1>
+    <p>A horizontal layout primitive. Wraps children on the inline axis with consistent spacing.</p>
+    <section class="t-stack" data-gap="3">
+      <h2>Examples</h2>
+      <div class="t-stack" data-gap="2">
+        <h3>gap-3</h3>
+        <div class="t-cluster" data-gap="3">
+          <Cluster gap="3">Cluster</Cluster>
+        </div>
+        <code>gap="3"</code>
+      </div>
+      <div class="t-stack" data-gap="2">
+        <h3>gap-0</h3>
+        <div class="t-cluster" data-gap="3">
+          <Cluster gap="0">Cluster</Cluster>
+        </div>
+        <code>gap="0"</code>
+      </div>
+      <div class="t-stack" data-gap="2">
+        <h3>justify-between</h3>
+        <div class="t-cluster" data-gap="3">
+          <Cluster gap="3" justify="between">Cluster</Cluster>
+        </div>
+        <code>gap="3" justify="between"</code>
+      </div>
+      <div class="t-stack" data-gap="2">
+        <h3>justify-around</h3>
+        <div class="t-cluster" data-gap="3">
+          <Cluster gap="2" justify="around">Cluster</Cluster>
+        </div>
+        <code>gap="2" justify="around"</code>
+      </div>
+      <div class="t-stack" data-gap="2">
+        <h3>align-center</h3>
+        <div class="t-cluster" data-gap="3">
+          <Cluster gap="3" align="center">Cluster</Cluster>
+        </div>
+        <code>gap="3" align="center"</code>
+      </div>
+      <div class="t-stack" data-gap="2">
+        <h3>align-baseline</h3>
+        <div class="t-cluster" data-gap="3">
+          <Cluster gap="2" align="baseline">Cluster</Cluster>
+        </div>
+        <code>gap="2" align="baseline"</code>
+      </div>
+      <div class="t-stack" data-gap="2">
+        <h3>responsive-gap</h3>
+        <div class="t-cluster" data-gap="3">
+          <Cluster gap={{ base: "2", md: "4" }}>Cluster</Cluster>
+        </div>
+        <code>gap=&lbrace;&lbrace; base: "2", md: "4" &rbrace;&rbrace;</code>
+      </div>
+      <div class="t-stack" data-gap="2">
+        <h3>responsive-justify</h3>
+        <div class="t-cluster" data-gap="3">
+          <Cluster gap="3" justify={{ base: "start", md: "between" }}>Cluster</Cluster>
+        </div>
+        <code>gap="3" justify=&lbrace;&lbrace; base: "start", md: "between" &rbrace;&rbrace;</code>
+      </div>
+    </section>
+    <section class="t-stack" data-gap="3">
+      <h2>Props</h2>
+      <table>
+        <thead><tr><th>Prop</th><th>Type</th><th>Default</th><th>Description</th></tr></thead>
+        <tbody>
+        <tr><td><code>gap</code></td><td><code>string, responsive</code></td><td><code>null</code></td><td>Spacing between children. Accepts a token suffix from the `--t-space-*` scale (`0`–`8`).</td></tr>
+        <tr><td><code>align</code></td><td><code>string, responsive</code></td><td><code>null</code></td><td>Block-axis alignment of children.</td></tr>
+        <tr><td><code>justify</code></td><td><code>string, responsive</code></td><td><code>null</code></td><td>Inline-axis distribution of children.</td></tr>
+        </tbody>
+      </table>
+    </section>
+    <section class="t-stack" data-gap="3">
+      <h2>Tokens</h2>
+      <table>
+        <thead><tr><th>Token</th><th>Fallback</th><th>Description</th></tr></thead>
+        <tbody>
+        <tr><td><code>--t-cluster-gap</code></td><td><code>--t-space-3</code></td><td>Default child spacing when `gap` is unset; overridable via `--t-cluster-gap`.</td></tr>
+        </tbody>
+      </table>
+    </section>
+  </main>
+</Base>

--- a/apps/docs/src/pages/components/stack.astro
+++ b/apps/docs/src/pages/components/stack.astro
@@ -1,0 +1,82 @@
+---
+import { Stack } from "@teseor/react";
+import Base from "../../layouts/Base.astro";
+---
+
+<Base title="Stack — Teseor">
+  <main class="t-stack" data-gap="6">
+    <h1>Stack</h1>
+    <p>A vertical layout primitive. Stacks children on the block axis with consistent spacing.</p>
+    <section class="t-stack" data-gap="3">
+      <h2>Examples</h2>
+      <div class="t-stack" data-gap="2">
+        <h3>gap-3</h3>
+        <div class="t-cluster" data-gap="3">
+          <Stack gap="3">Stack</Stack>
+        </div>
+        <code>gap="3"</code>
+      </div>
+      <div class="t-stack" data-gap="2">
+        <h3>gap-0</h3>
+        <div class="t-cluster" data-gap="3">
+          <Stack gap="0">Stack</Stack>
+        </div>
+        <code>gap="0"</code>
+      </div>
+      <div class="t-stack" data-gap="2">
+        <h3>align-center</h3>
+        <div class="t-cluster" data-gap="3">
+          <Stack gap="4" align="center">Stack</Stack>
+        </div>
+        <code>gap="4" align="center"</code>
+      </div>
+      <div class="t-stack" data-gap="2">
+        <h3>align-stretch</h3>
+        <div class="t-cluster" data-gap="3">
+          <Stack gap="2" align="stretch">Stack</Stack>
+        </div>
+        <code>gap="2" align="stretch"</code>
+      </div>
+      <div class="t-stack" data-gap="2">
+        <h3>responsive-gap</h3>
+        <div class="t-cluster" data-gap="3">
+          <Stack gap={{ base: "2", md: "4", lg: "6" }}>Stack</Stack>
+        </div>
+        <code>gap=&lbrace;&lbrace; base: "2", md: "4", lg: "6" &rbrace;&rbrace;</code>
+      </div>
+      <div class="t-stack" data-gap="2">
+        <h3>responsive-align</h3>
+        <div class="t-cluster" data-gap="3">
+          <Stack gap="3" align={{ base: "start", md: "center" }}>Stack</Stack>
+        </div>
+        <code>gap="3" align=&lbrace;&lbrace; base: "start", md: "center" &rbrace;&rbrace;</code>
+      </div>
+      <div class="t-stack" data-gap="2">
+        <h3>gap-and-align</h3>
+        <div class="t-cluster" data-gap="3">
+          <Stack gap="5" align="end">Stack</Stack>
+        </div>
+        <code>gap="5" align="end"</code>
+      </div>
+    </section>
+    <section class="t-stack" data-gap="3">
+      <h2>Props</h2>
+      <table>
+        <thead><tr><th>Prop</th><th>Type</th><th>Default</th><th>Description</th></tr></thead>
+        <tbody>
+        <tr><td><code>gap</code></td><td><code>string, responsive</code></td><td><code>null</code></td><td>Spacing between children. Accepts a token suffix from the `--t-space-*` scale (`0`–`8`).</td></tr>
+        <tr><td><code>align</code></td><td><code>string, responsive</code></td><td><code>null</code></td><td>Inline-axis alignment of children.</td></tr>
+        </tbody>
+      </table>
+    </section>
+    <section class="t-stack" data-gap="3">
+      <h2>Tokens</h2>
+      <table>
+        <thead><tr><th>Token</th><th>Fallback</th><th>Description</th></tr></thead>
+        <tbody>
+        <tr><td><code>--t-stack-gap</code></td><td><code>--t-space-3</code></td><td>Default child spacing when `gap` is unset; overridable via `--t-stack-gap`.</td></tr>
+        </tbody>
+      </table>
+    </section>
+  </main>
+</Base>

--- a/scripts/codegen/__tests__/__snapshots__/gen-docs.test.ts.snap
+++ b/scripts/codegen/__tests__/__snapshots__/gen-docs.test.ts.snap
@@ -1,0 +1,340 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`gen-docs > renders the Button docs page 1`] = `
+"---
+import { Button } from "@teseor/react";
+import Base from "../../layouts/Base.astro";
+---
+
+<Base title="Button — Teseor">
+  <main class="t-stack" data-gap="6">
+    <h1>Button</h1>
+    <p>A trigger that performs an action when activated.</p>
+    <section class="t-stack" data-gap="3">
+      <h2>Examples</h2>
+      <div class="t-stack" data-gap="2">
+        <h3>solid-primary</h3>
+        <div class="t-cluster" data-gap="3">
+          <Button variant="solid" intent="primary">Button</Button>
+        </div>
+        <code>variant="solid" intent="primary"</code>
+      </div>
+      <div class="t-stack" data-gap="2">
+        <h3>solid-danger-md</h3>
+        <div class="t-cluster" data-gap="3">
+          <Button variant="solid" intent="danger" size="md">Button</Button>
+        </div>
+        <code>variant="solid" intent="danger" size="md"</code>
+      </div>
+      <div class="t-stack" data-gap="2">
+        <h3>outline-neutral</h3>
+        <div class="t-cluster" data-gap="3">
+          <Button variant="outline" intent="neutral">Button</Button>
+        </div>
+        <code>variant="outline" intent="neutral"</code>
+      </div>
+      <div class="t-stack" data-gap="2">
+        <h3>ghost-with-icon</h3>
+        <div class="t-cluster" data-gap="3">
+          <Button variant="ghost" intent="neutral">Button</Button>
+        </div>
+        <code>variant="ghost" intent="neutral" iconStart="arrow-left"</code>
+      </div>
+      <div class="t-stack" data-gap="2">
+        <h3>link-primary</h3>
+        <div class="t-cluster" data-gap="3">
+          <Button variant="link" intent="primary" as="a">Button</Button>
+        </div>
+        <code>variant="link" intent="primary" as="a"</code>
+      </div>
+      <div class="t-stack" data-gap="2">
+        <h3>loading</h3>
+        <div class="t-cluster" data-gap="3">
+          <Button variant="solid" intent="primary" loading>Button</Button>
+        </div>
+        <code>variant="solid" intent="primary" loading</code>
+      </div>
+      <div class="t-stack" data-gap="2">
+        <h3>block-mobile</h3>
+        <div class="t-cluster" data-gap="3">
+          <Button variant="solid" intent="primary" block size="lg">Button</Button>
+        </div>
+        <code>variant="solid" intent="primary" block size="lg"</code>
+      </div>
+    </section>
+    <section class="t-stack" data-gap="3">
+      <h2>Props</h2>
+      <table>
+        <thead><tr><th>Prop</th><th>Type</th><th>Default</th><th>Description</th></tr></thead>
+        <tbody>
+        <tr><td><code>as</code></td><td><code>string</code></td><td><code>button</code></td><td>Polymorphic root element. Defaults to \`button\`; set to \`a\` for link-shaped triggers (paired with \`variant: link\`).</td></tr>
+        <tr><td><code>disabled</code></td><td><code>boolean</code></td><td><code>false</code></td><td>Disables interaction and applies the disabled visual state. Mapped to the native \`disabled\` attribute on \`button\`, \`aria-disabled="true"\` otherwise.</td></tr>
+        <tr><td><code>loading</code></td><td><code>boolean</code></td><td><code>false</code></td><td>Shows a spinner in place of the label and disables interaction. The original label stays in the accessibility tree.</td></tr>
+        <tr><td><code>iconStart</code></td><td><code>string, slot</code></td><td><code>null</code></td><td>Icon rendered before the label in the inline direction. Slot size scales with \`size\`. Accepts any node (icon component, SVG, etc.).</td></tr>
+        <tr><td><code>iconEnd</code></td><td><code>string, slot</code></td><td><code>null</code></td><td>Icon rendered after the label in the inline direction. Accepts any node.</td></tr>
+        <tr><td><code>block</code></td><td><code>boolean, responsive</code></td><td><code>false</code></td><td>Stretches the button to the inline-size of its container. Responsive so layouts can pin block-width on mobile and shrink to content above.</td></tr>
+        </tbody>
+      </table>
+    </section>
+    <section class="t-stack" data-gap="3">
+      <h2>Variants</h2>
+      <table>
+        <thead><tr><th>Name</th><th>Description</th></tr></thead>
+        <tbody>
+        <tr><td><code>solid</code></td><td>Filled background with intent color; default visual weight.</td></tr>
+        <tr><td><code>outline</code></td><td>Transparent background, intent-colored border and label; for secondary actions.</td></tr>
+        <tr><td><code>ghost</code></td><td>Transparent background with no border; for tertiary actions inside dense layouts or toolbars.</td></tr>
+        <tr><td><code>link</code></td><td>Renders as text with an underline; for navigation-shaped triggers that still need button semantics.</td></tr>
+        </tbody>
+      </table>
+    </section>
+    <section class="t-stack" data-gap="3">
+      <h2>Intents</h2>
+      <table>
+        <thead><tr><th>Name</th><th>Description</th></tr></thead>
+        <tbody>
+        <tr><td><code>primary</code></td><td>The page's most important action. One primary per surface.</td></tr>
+        <tr><td><code>neutral</code></td><td>Default action. Non-emphasized; used when no intent is needed.</td></tr>
+        <tr><td><code>success</code></td><td>Confirms a positive outcome (save, publish, accept).</td></tr>
+        <tr><td><code>warning</code></td><td>Indicates an action that needs attention but isn't destructive.</td></tr>
+        <tr><td><code>danger</code></td><td>Destructive or irreversible action (delete, cancel subscription).</td></tr>
+        </tbody>
+      </table>
+    </section>
+    <section class="t-stack" data-gap="3">
+      <h2>Sizes</h2>
+      <table>
+        <thead><tr><th>Name</th><th>Description</th></tr></thead>
+        <tbody>
+        <tr><td><code>sm</code></td><td>Compact density; safe at breakpoints above the mobile floor.</td></tr>
+        <tr><td><code>md</code></td><td>Default size.</td></tr>
+        <tr><td><code>lg</code></td><td>Emphatic; for hero CTAs and primary actions in mobile-first layouts.</td></tr>
+        </tbody>
+      </table>
+    </section>
+    <section class="t-stack" data-gap="3">
+      <h2>States</h2>
+      <ul>
+        <li><code>hover</code></li>
+        <li><code>focus</code></li>
+        <li><code>active</code></li>
+        <li><code>disabled</code></li>
+        <li><code>loading</code></li>
+      </ul>
+    </section>
+    <section class="t-stack" data-gap="3">
+      <h2>Tokens</h2>
+      <table>
+        <thead><tr><th>Token</th><th>Fallback</th><th>Description</th></tr></thead>
+        <tbody>
+        <tr><td><code>--t-button-height</code></td><td><code>--t-row</code></td><td>Control height; the size variant overrides this.</td></tr>
+        <tr><td><code>--t-button-bg</code></td><td><code>--t-accent</code></td><td>Background fill; the intent variant overrides this.</td></tr>
+        <tr><td><code>--t-button-fg</code></td><td><code>--t-on-accent</code></td><td>Foreground color (label and icon); pairs with \`bg\`.</td></tr>
+        <tr><td><code>--t-button-pad-x</code></td><td><code>--t-pad-x</code></td><td>Inline padding; the size variant overrides this.</td></tr>
+        <tr><td><code>--t-button-radius</code></td><td><code>--t-radius-md</code></td><td>Corner radius.</td></tr>
+        <tr><td><code>--t-button-dur</code></td><td><code>--t-dur-fast</code></td><td>Transition duration; multiplied by \`--t-motion-scale\` at the call site.</td></tr>
+        </tbody>
+      </table>
+    </section>
+    <section class="t-stack" data-gap="3">
+      <h2>Accessibility</h2>
+      <p>Role: <code>button</code></p>
+      <table>
+        <thead><tr><th>Key</th><th>Action</th></tr></thead>
+        <tbody>
+        <tr><td><code>Enter</code></td><td>activate</td></tr>
+        <tr><td><code>Space</code></td><td>activate</td></tr>
+        </tbody>
+      </table>
+    </section>
+    <section class="t-stack" data-gap="3">
+      <h2>Constraints</h2>
+      <ul>
+        <li>Link variant is text-colored; non-neutral intent fills have no surface to apply to.</li>
+        <li>Loading already disables interaction; disabling on top is redundant.</li>
+      </ul>
+    </section>
+  </main>
+</Base>
+"
+`;
+
+exports[`gen-docs > renders the Cluster docs page 1`] = `
+"---
+import { Cluster } from "@teseor/react";
+import Base from "../../layouts/Base.astro";
+---
+
+<Base title="Cluster — Teseor">
+  <main class="t-stack" data-gap="6">
+    <h1>Cluster</h1>
+    <p>A horizontal layout primitive. Wraps children on the inline axis with consistent spacing.</p>
+    <section class="t-stack" data-gap="3">
+      <h2>Examples</h2>
+      <div class="t-stack" data-gap="2">
+        <h3>gap-3</h3>
+        <div class="t-cluster" data-gap="3">
+          <Cluster gap="3">Cluster</Cluster>
+        </div>
+        <code>gap="3"</code>
+      </div>
+      <div class="t-stack" data-gap="2">
+        <h3>gap-0</h3>
+        <div class="t-cluster" data-gap="3">
+          <Cluster gap="0">Cluster</Cluster>
+        </div>
+        <code>gap="0"</code>
+      </div>
+      <div class="t-stack" data-gap="2">
+        <h3>justify-between</h3>
+        <div class="t-cluster" data-gap="3">
+          <Cluster gap="3" justify="between">Cluster</Cluster>
+        </div>
+        <code>gap="3" justify="between"</code>
+      </div>
+      <div class="t-stack" data-gap="2">
+        <h3>justify-around</h3>
+        <div class="t-cluster" data-gap="3">
+          <Cluster gap="2" justify="around">Cluster</Cluster>
+        </div>
+        <code>gap="2" justify="around"</code>
+      </div>
+      <div class="t-stack" data-gap="2">
+        <h3>align-center</h3>
+        <div class="t-cluster" data-gap="3">
+          <Cluster gap="3" align="center">Cluster</Cluster>
+        </div>
+        <code>gap="3" align="center"</code>
+      </div>
+      <div class="t-stack" data-gap="2">
+        <h3>align-baseline</h3>
+        <div class="t-cluster" data-gap="3">
+          <Cluster gap="2" align="baseline">Cluster</Cluster>
+        </div>
+        <code>gap="2" align="baseline"</code>
+      </div>
+      <div class="t-stack" data-gap="2">
+        <h3>responsive-gap</h3>
+        <div class="t-cluster" data-gap="3">
+          <Cluster gap={{ base: "2", md: "4" }}>Cluster</Cluster>
+        </div>
+        <code>gap=&lbrace;&lbrace; base: "2", md: "4" &rbrace;&rbrace;</code>
+      </div>
+      <div class="t-stack" data-gap="2">
+        <h3>responsive-justify</h3>
+        <div class="t-cluster" data-gap="3">
+          <Cluster gap="3" justify={{ base: "start", md: "between" }}>Cluster</Cluster>
+        </div>
+        <code>gap="3" justify=&lbrace;&lbrace; base: "start", md: "between" &rbrace;&rbrace;</code>
+      </div>
+    </section>
+    <section class="t-stack" data-gap="3">
+      <h2>Props</h2>
+      <table>
+        <thead><tr><th>Prop</th><th>Type</th><th>Default</th><th>Description</th></tr></thead>
+        <tbody>
+        <tr><td><code>gap</code></td><td><code>string, responsive</code></td><td><code>null</code></td><td>Spacing between children. Accepts a token suffix from the \`--t-space-*\` scale (\`0\`–\`8\`).</td></tr>
+        <tr><td><code>align</code></td><td><code>string, responsive</code></td><td><code>null</code></td><td>Block-axis alignment of children.</td></tr>
+        <tr><td><code>justify</code></td><td><code>string, responsive</code></td><td><code>null</code></td><td>Inline-axis distribution of children.</td></tr>
+        </tbody>
+      </table>
+    </section>
+    <section class="t-stack" data-gap="3">
+      <h2>Tokens</h2>
+      <table>
+        <thead><tr><th>Token</th><th>Fallback</th><th>Description</th></tr></thead>
+        <tbody>
+        <tr><td><code>--t-cluster-gap</code></td><td><code>--t-space-3</code></td><td>Default child spacing when \`gap\` is unset; overridable via \`--t-cluster-gap\`.</td></tr>
+        </tbody>
+      </table>
+    </section>
+  </main>
+</Base>
+"
+`;
+
+exports[`gen-docs > renders the Stack docs page with responsive examples 1`] = `
+"---
+import { Stack } from "@teseor/react";
+import Base from "../../layouts/Base.astro";
+---
+
+<Base title="Stack — Teseor">
+  <main class="t-stack" data-gap="6">
+    <h1>Stack</h1>
+    <p>A vertical layout primitive. Stacks children on the block axis with consistent spacing.</p>
+    <section class="t-stack" data-gap="3">
+      <h2>Examples</h2>
+      <div class="t-stack" data-gap="2">
+        <h3>gap-3</h3>
+        <div class="t-cluster" data-gap="3">
+          <Stack gap="3">Stack</Stack>
+        </div>
+        <code>gap="3"</code>
+      </div>
+      <div class="t-stack" data-gap="2">
+        <h3>gap-0</h3>
+        <div class="t-cluster" data-gap="3">
+          <Stack gap="0">Stack</Stack>
+        </div>
+        <code>gap="0"</code>
+      </div>
+      <div class="t-stack" data-gap="2">
+        <h3>align-center</h3>
+        <div class="t-cluster" data-gap="3">
+          <Stack gap="4" align="center">Stack</Stack>
+        </div>
+        <code>gap="4" align="center"</code>
+      </div>
+      <div class="t-stack" data-gap="2">
+        <h3>align-stretch</h3>
+        <div class="t-cluster" data-gap="3">
+          <Stack gap="2" align="stretch">Stack</Stack>
+        </div>
+        <code>gap="2" align="stretch"</code>
+      </div>
+      <div class="t-stack" data-gap="2">
+        <h3>responsive-gap</h3>
+        <div class="t-cluster" data-gap="3">
+          <Stack gap={{ base: "2", md: "4", lg: "6" }}>Stack</Stack>
+        </div>
+        <code>gap=&lbrace;&lbrace; base: "2", md: "4", lg: "6" &rbrace;&rbrace;</code>
+      </div>
+      <div class="t-stack" data-gap="2">
+        <h3>responsive-align</h3>
+        <div class="t-cluster" data-gap="3">
+          <Stack gap="3" align={{ base: "start", md: "center" }}>Stack</Stack>
+        </div>
+        <code>gap="3" align=&lbrace;&lbrace; base: "start", md: "center" &rbrace;&rbrace;</code>
+      </div>
+      <div class="t-stack" data-gap="2">
+        <h3>gap-and-align</h3>
+        <div class="t-cluster" data-gap="3">
+          <Stack gap="5" align="end">Stack</Stack>
+        </div>
+        <code>gap="5" align="end"</code>
+      </div>
+    </section>
+    <section class="t-stack" data-gap="3">
+      <h2>Props</h2>
+      <table>
+        <thead><tr><th>Prop</th><th>Type</th><th>Default</th><th>Description</th></tr></thead>
+        <tbody>
+        <tr><td><code>gap</code></td><td><code>string, responsive</code></td><td><code>null</code></td><td>Spacing between children. Accepts a token suffix from the \`--t-space-*\` scale (\`0\`–\`8\`).</td></tr>
+        <tr><td><code>align</code></td><td><code>string, responsive</code></td><td><code>null</code></td><td>Inline-axis alignment of children.</td></tr>
+        </tbody>
+      </table>
+    </section>
+    <section class="t-stack" data-gap="3">
+      <h2>Tokens</h2>
+      <table>
+        <thead><tr><th>Token</th><th>Fallback</th><th>Description</th></tr></thead>
+        <tbody>
+        <tr><td><code>--t-stack-gap</code></td><td><code>--t-space-3</code></td><td>Default child spacing when \`gap\` is unset; overridable via \`--t-stack-gap\`.</td></tr>
+        </tbody>
+      </table>
+    </section>
+  </main>
+</Base>
+"
+`;

--- a/scripts/codegen/__tests__/gen-docs.test.ts
+++ b/scripts/codegen/__tests__/gen-docs.test.ts
@@ -1,0 +1,32 @@
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { describe, expect, test } from "vitest";
+import { parse as parseYaml } from "yaml";
+import type { DocsSpec } from "../src/generators/gen-docs.ts";
+import { renderDocsPage } from "../src/generators/gen-docs.ts";
+
+const REPO_ROOT = resolve(import.meta.dirname, "..", "..", "..");
+
+async function loadSpec(name: string): Promise<DocsSpec> {
+  const raw = await readFile(resolve(REPO_ROOT, "specs", `${name}.yaml`), "utf8");
+  return parseYaml(raw);
+}
+
+describe("gen-docs", () => {
+  test("renders the Button docs page", async () => {
+    expect(renderDocsPage(await loadSpec("button"))).toMatchSnapshot();
+  });
+
+  test("renders the Stack docs page with responsive examples", async () => {
+    expect(renderDocsPage(await loadSpec("stack"))).toMatchSnapshot();
+  });
+
+  test("renders the Cluster docs page", async () => {
+    expect(renderDocsPage(await loadSpec("cluster"))).toMatchSnapshot();
+  });
+
+  test("is deterministic across runs", async () => {
+    const spec = await loadSpec("button");
+    expect(renderDocsPage(spec)).toBe(renderDocsPage(spec));
+  });
+});

--- a/scripts/codegen/src/generators/gen-docs.ts
+++ b/scripts/codegen/src/generators/gen-docs.ts
@@ -1,0 +1,253 @@
+import { mkdir, readdir, readFile, writeFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { parse as parseYaml } from "yaml";
+import type { GeneratorContext, GeneratorReport } from "../registry.ts";
+import { registerGenerator } from "../registry.ts";
+import type { Spec } from "./gen-contract.ts";
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..", "..", "..");
+const SPECS_DIR = resolve(REPO_ROOT, "specs");
+const DOCS_PAGES_DIR = resolve(REPO_ROOT, "apps", "docs", "src", "pages", "components");
+
+/** Spec fields the docs page reads beyond the shared generator subset. */
+type DocsSpec = Spec & {
+  states?: string[];
+  tokens?: Record<string, { fallback?: string; desc?: string }>;
+  a11y?: { role?: string; keyboard?: Record<string, string> };
+};
+
+function pascalCase(name: string): string {
+  return name
+    .split(/[-_\s]+/)
+    .map((part) => (part.length === 0 ? part : part.charAt(0).toUpperCase() + part.slice(1)))
+    .join("");
+}
+
+/** Escape text for HTML content; `{}` are escaped because Astro reads them as expressions. */
+function esc(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/{/g, "&lbrace;")
+    .replace(/}/g, "&rbrace;");
+}
+
+function formatValue(value: unknown): string {
+  if (value === null || value === undefined) return "null";
+  if (typeof value === "boolean") return value ? "true" : "false";
+  return String(value);
+}
+
+/** A JS-expression rendering of a value — for `prop={expr}` and responsive objects. */
+function jsLiteral(value: unknown): string {
+  if (value === null || value === undefined) return "null";
+  if (typeof value === "string") return JSON.stringify(value);
+  if (typeof value === "boolean" || typeof value === "number") return String(value);
+  if (typeof value === "object") {
+    const entries = Object.entries(value).map(([k, v]) => `${k}: ${jsLiteral(v)}`);
+    return `{ ${entries.join(", ")} }`;
+  }
+  return JSON.stringify(String(value));
+}
+
+/** A JSX attribute for one example prop: `key="str"`, bare `key`, or `key={expr}`. */
+function attr(key: string, value: unknown): string {
+  if (typeof value === "string") return `${key}="${value}"`;
+  if (value === true) return key;
+  return `${key}={${jsLiteral(value)}}`;
+}
+
+function tableRows(rows: string[][]): string {
+  return rows
+    .map((cells) => `        <tr>${cells.map((c) => `<td>${c}</td>`).join("")}</tr>`)
+    .join("\n");
+}
+
+function section(title: string, body: string): string {
+  return `    <section class="t-stack" data-gap="3">\n      <h2>${title}</h2>\n${body}\n    </section>`;
+}
+
+function renderExamples(spec: DocsSpec, Name: string): string {
+  if (!spec.examples || spec.examples.length === 0) return "";
+  const blocks = spec.examples.map((example) => {
+    const props = example.props ?? {};
+    const rendered = Object.entries(props)
+      .filter(([key]) => spec.props?.[key]?.slot !== true && props[key] !== false)
+      .map(([key, value]) => attr(key, value));
+    const open = [Name, ...rendered].join(" ");
+    const code = Object.entries(props)
+      .map(([key, value]) => attr(key, value))
+      .join(" ");
+    return [
+      `      <div class="t-stack" data-gap="2">`,
+      `        <h3>${esc(example.id ?? "example")}</h3>`,
+      `        <div class="t-cluster" data-gap="3">`,
+      `          <${open}>${Name}</${Name}>`,
+      `        </div>`,
+      `        <code>${esc(code)}</code>`,
+      `      </div>`,
+    ].join("\n");
+  });
+  return section("Examples", blocks.join("\n"));
+}
+
+function renderTable(headers: string[], rows: string[][]): string {
+  const head = headers.map((h) => `<th>${h}</th>`).join("");
+  return [
+    `      <table>`,
+    `        <thead><tr>${head}</tr></thead>`,
+    `        <tbody>`,
+    tableRows(rows),
+    `        </tbody>`,
+    `      </table>`,
+  ].join("\n");
+}
+
+function renderProps(spec: DocsSpec): string {
+  if (!spec.props || Object.keys(spec.props).length === 0) return "";
+  const rows = Object.entries(spec.props).map(([name, def]) => {
+    const type = [def.type, def.slot ? "slot" : "", def.responsive ? "responsive" : ""]
+      .filter(Boolean)
+      .join(", ");
+    return [
+      `<code>${esc(name)}</code>`,
+      `<code>${esc(type)}</code>`,
+      `<code>${esc(formatValue(def.default))}</code>`,
+      esc(def.description ?? ""),
+    ];
+  });
+  return section("Props", renderTable(["Prop", "Type", "Default", "Description"], rows));
+}
+
+function renderNamed(
+  title: string,
+  entries: Record<string, { description?: string }> | undefined,
+): string {
+  if (!entries || Object.keys(entries).length === 0) return "";
+  const rows = Object.entries(entries).map(([name, def]) => [
+    `<code>${esc(name)}</code>`,
+    esc(def.description ?? ""),
+  ]);
+  return section(title, renderTable(["Name", "Description"], rows));
+}
+
+function renderStates(spec: DocsSpec): string {
+  if (!spec.states || spec.states.length === 0) return "";
+  const items = spec.states.map((state) => `        <li><code>${esc(state)}</code></li>`);
+  return section("States", `      <ul>\n${items.join("\n")}\n      </ul>`);
+}
+
+function renderTokens(spec: DocsSpec): string {
+  if (!spec.tokens || Object.keys(spec.tokens).length === 0) return "";
+  const rows = Object.entries(spec.tokens).map(([name, def]) => [
+    `<code>--t-${esc(spec.name)}-${esc(name)}</code>`,
+    `<code>${esc(def.fallback ?? "")}</code>`,
+    esc(def.desc ?? ""),
+  ]);
+  return section("Tokens", renderTable(["Token", "Fallback", "Description"], rows));
+}
+
+function renderA11y(spec: DocsSpec): string {
+  if (!spec.a11y) return "";
+  const lines: string[] = [];
+  if (spec.a11y.role) {
+    lines.push(`      <p>Role: <code>${esc(spec.a11y.role)}</code></p>`);
+  }
+  const keyboard = spec.a11y.keyboard ?? {};
+  if (Object.keys(keyboard).length > 0) {
+    const rows = Object.entries(keyboard).map(([key, action]) => [
+      `<code>${esc(key)}</code>`,
+      esc(action),
+    ]);
+    lines.push(renderTable(["Key", "Action"], rows));
+  }
+  if (lines.length === 0) return "";
+  return section("Accessibility", lines.join("\n"));
+}
+
+function renderConstraints(spec: DocsSpec): string {
+  if (!spec.constraints || spec.constraints.length === 0) return "";
+  const items = spec.constraints
+    .filter((c) => typeof c.reason === "string")
+    .map((c) => `        <li>${esc(c.reason ?? "")}</li>`);
+  if (items.length === 0) return "";
+  return section("Constraints", `      <ul>\n${items.join("\n")}\n      </ul>`);
+}
+
+/** Render the full `.astro` docs page for one component spec. */
+function renderDocsPage(spec: DocsSpec): string {
+  const Name = pascalCase(spec.name);
+  const hasExamples = (spec.examples?.length ?? 0) > 0;
+  const sections = [
+    renderExamples(spec, Name),
+    renderProps(spec),
+    renderNamed("Variants", spec.variants),
+    renderNamed("Intents", spec.intents),
+    renderNamed("Sizes", spec.sizes),
+    renderStates(spec),
+    renderTokens(spec),
+    renderA11y(spec),
+    renderConstraints(spec),
+  ].filter((part) => part.length > 0);
+
+  const imports = [
+    ...(hasExamples ? [`import { ${Name} } from "@teseor/react";`] : []),
+    `import Base from "../../layouts/Base.astro";`,
+  ];
+  const intro = spec.description ? `    <p>${esc(spec.description)}</p>\n` : "";
+
+  return [
+    "---",
+    ...imports,
+    "---",
+    "",
+    `<Base title="${Name} — Teseor">`,
+    `  <main class="t-stack" data-gap="6">`,
+    `    <h1>${Name}</h1>`,
+    `${intro}${sections.join("\n")}`,
+    "  </main>",
+    "</Base>",
+    "",
+  ].join("\n");
+}
+
+async function loadSpec(name: string): Promise<DocsSpec> {
+  const raw = await readFile(resolve(SPECS_DIR, `${name}.yaml`), "utf8");
+  const parsed = parseYaml(raw) as DocsSpec;
+  if (parsed.name !== name) {
+    throw new Error(`spec name "${parsed.name}" in ${name}.yaml does not match file basename`);
+  }
+  return parsed;
+}
+
+async function listSpecNames(): Promise<string[]> {
+  const entries = await readdir(SPECS_DIR);
+  return entries
+    .filter((f) => f.endsWith(".yaml") && !f.startsWith("_"))
+    .map((f) => f.slice(0, -5))
+    .sort();
+}
+
+async function docsGenerator(ctx: GeneratorContext): Promise<GeneratorReport> {
+  const requested = ctx.positionals[0];
+  const targets = requested ? [requested] : await listSpecNames();
+  const filesWritten: string[] = [];
+  const notes: string[] = [];
+
+  await mkdir(DOCS_PAGES_DIR, { recursive: true });
+  for (const name of targets) {
+    const spec = await loadSpec(name);
+    const outPath = resolve(DOCS_PAGES_DIR, `${name}.astro`);
+    await writeFile(outPath, renderDocsPage(spec), "utf8");
+    filesWritten.push(outPath);
+    notes.push(`docs: ${name} -> ${outPath.replace(`${REPO_ROOT}/`, "")}`);
+  }
+  return { filesWritten, notes };
+}
+
+registerGenerator("docs", docsGenerator);
+
+export type { DocsSpec };
+export { renderDocsPage };

--- a/scripts/codegen/src/generators/index.ts
+++ b/scripts/codegen/src/generators/index.ts
@@ -1,4 +1,5 @@
 import "./gen-contract.ts";
+import "./gen-docs.ts";
 import "./gen-react.ts";
 import "./gen-tests.ts";
 import "./gen-vue.ts";


### PR DESCRIPTION
## What

A `gen-docs` generator that reads each spec and emits an Astro page per component to `apps/docs/src/pages/components/<name>.astro`.

- Page sections come from spec fields that exist today: live `examples:` previews (the real `@teseor/react` component rendered to static HTML) plus tables for props, variants, intents, sizes, states, tokens, accessibility, and constraints. A section is skipped when its spec field is absent.
- Replaces the hand-coded `button.astro` placeholder; adds generated `stack` and `cluster` pages.
- `pnpm gen docs` generates every component; `pnpm gen docs <name>` generates one.

## Why

A docs page hand-coded against a spec drifts from it — the `button.astro` placeholder already showed examples that didn't match `button.yaml`. Generating the page from the spec keeps it honest, the same contract the wrappers already follow.

## Test plan

- `pnpm gen docs` is byte-identical on re-run (a determinism test plus a snapshot test per component).
- `pnpm build:docs` builds all four pages; the React components render to static HTML.
- `pnpm typecheck`, `pnpm test` (58), `pnpm lint` — green. Generated pages use `t-*` classes only and pass `check-dogfood`.

## Out of scope

- L2 demo blocks (framework tabs, Shiki highlighting, Copy) — need the Tabs and Code components plus `gen-svelte`/`gen-angular`/`gen-webc`.
- The `guidance:` spec field and the When / Variant-choice / Content / Common-mistakes sections.
- Anatomy SVGs and auto-generated navigation.

Closes #560
Closes #603