### PR TITLE
feat(css): motion.css + keyframes bundled into teseor.css

### DIFF
--- a/.changeset/motion-css.md
+++ b/.changeset/motion-css.md
@@ -1,0 +1,5 @@
+---
+"@teseor/css": minor
+---
+
+Adds `motion.css` — shared `@keyframes` (`fade-in`/`fade-out`, `slide-up-in`/`slide-down-out`, `scale-in`/`scale-out`, `spin`) with `prefers-reduced-motion` variants that redefine the entrance keyframes to an immediate jump. Bundled into `teseor.css` and published as a standalone `@teseor/css/motion.css`. The motion tokens (`--t-dur-*`, `--t-ease-*`, `--t-motion-scale`) already ship in `tokens.css`.

--- a/docs/rules/motion.md
+++ b/docs/rules/motion.md
@@ -37,7 +37,7 @@ Shared `@keyframes` live in `packages/css/src/motion.css`:
 @keyframes spin       { to { transform: rotate(1turn); } }
 ```
 
-No `@layer` wrapper — keyframes are identified by name in a global namespace, not by selectors entering the cascade (we settled this in C).
+No `@layer` wrapper — keyframes are identified by name in a global namespace, not by selectors entering the cascade.
 
 **Reduced-motion variants** live in the same file:
 
@@ -50,13 +50,21 @@ No `@layer` wrapper — keyframes are identified by name in a global namespace, 
 }
 ```
 
-Components reference keyframes by name and multiply duration through `--t-motion-scale`:
+A component references a keyframe by name through a `--_*` token — per ADR-0008 a `[data-*]` modifier reassigns vars, never declares a property — and multiplies the duration through `--t-motion-scale`:
 
 ```css
-.t-modal[data-state="open"] {
-  animation: scale-in calc(var(--t-dur-enter-base) * var(--t-motion-scale)) var(--t-ease-out);
+.t-modal {
+  --_animation: none;
+
+  animation: var(--_animation);
+
+  &:where([data-state="open"]) {
+    --_animation: scale-in calc(var(--t-dur-enter-base) * var(--t-motion-scale)) var(--t-ease-out);
+  }
 }
 ```
+
+How a shared keyframe reaches a per-component CSS file without breaking that file's self-containment (the `component-shape.md` acid test) is unresolved — tracked under #613. Until it is settled, a component that needs a continuous animation defines its keyframe locally; see `button`'s spinner.
 
 ## Spec field
 

--- a/packages/css/__tests__/build-output.test.ts
+++ b/packages/css/__tests__/build-output.test.ts
@@ -49,3 +49,15 @@ test("shipped component CSS inlines the literal resolved from tokens.css", () =>
   const button = readFileSync(join(distDir, "components", "button.css"), "utf8");
   expect(button).toContain("var(--t-accent, oklch(65% 0.18 250deg))");
 });
+
+test("motion.css ships keyframes and a reduced-motion block", () => {
+  const motion = readFileSync(join(distDir, "motion.css"), "utf8");
+  expect(motion).toContain("@keyframes spin");
+  expect(motion).toContain("@keyframes fade-in");
+  expect(motion).toContain("@media (prefers-reduced-motion: reduce)");
+});
+
+test("the bundle includes the motion keyframes", () => {
+  const bundle = readFileSync(join(distDir, "teseor.css"), "utf8");
+  expect(bundle).toContain("@keyframes scale-in");
+});

--- a/packages/css/__tests__/build-output.test.ts
+++ b/packages/css/__tests__/build-output.test.ts
@@ -1,10 +1,13 @@
 import { execSync } from "node:child_process";
-import { readdirSync, readFileSync } from "node:fs";
+import { mkdtempSync, readdirSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { beforeAll, expect, test } from "vitest";
 
 const cssRoot = resolve(import.meta.dirname, "..");
-const distDir = resolve(cssRoot, "dist");
+// Build into a per-process temp dir — `pnpm -r` runs this file under two
+// vitest invocations in parallel; a shared dist/ would race.
+const distDir = mkdtempSync(join(tmpdir(), "teseor-css-dist-"));
 
 const LAYER_ORDER =
   "@layer reset, tokens.scale, tokens.semantic, base, primitives, components.tokens, components.styles, utilities, themes;";
@@ -23,7 +26,11 @@ function cssFiles(dir: string): string[] {
 }
 
 beforeAll(() => {
-  execSync("node build.mjs", { cwd: cssRoot, stdio: "ignore" });
+  execSync("node build.mjs", {
+    cwd: cssRoot,
+    stdio: "ignore",
+    env: { ...process.env, TESEOR_CSS_DIST: distDir },
+  });
 });
 
 test("every emitted CSS file declares the full @layer order first", () => {

--- a/packages/css/build.mjs
+++ b/packages/css/build.mjs
@@ -23,6 +23,7 @@ const LAYER_ORDER =
 const TOP_LEVEL_ENTRIES = [
   { from: "teseor.css", to: "teseor.css" },
   { from: "tokens.css", to: "tokens.css" },
+  { from: "motion.css", to: "motion.css" },
   { from: "reset.css", to: "reset.css" },
   { from: "base.css", to: "base.css" },
   { from: "utilities.css", to: "utilities.css" },

--- a/packages/css/build.mjs
+++ b/packages/css/build.mjs
@@ -10,7 +10,10 @@ import { buildTokenMap, teseorFloor } from "./postcss-teseor-floor.ts";
 
 const ROOT = dirname(fileURLToPath(import.meta.url));
 const SRC = resolve(ROOT, "src");
-const DIST = resolve(ROOT, "dist");
+// TESEOR_CSS_DIST lets a test build into an isolated dir instead of dist/.
+const DIST = process.env.TESEOR_CSS_DIST
+  ? resolve(process.env.TESEOR_CSS_DIST)
+  : resolve(ROOT, "dist");
 const COMPONENTS_SRC = resolve(SRC, "components");
 const COMPONENTS_DIST = resolve(DIST, "components");
 

--- a/packages/css/src/motion.css
+++ b/packages/css/src/motion.css
@@ -1,0 +1,100 @@
+/* Shared keyframes — identified by name in a global namespace, never cascaded,
+   so they sit outside @layer. The reduced-motion block redefines the entrance
+   keyframes to an immediate jump; continuous motion (spin) is neutralized by
+   --t-motion-scale zeroing the animation duration at the call site. */
+
+@keyframes fade-in {
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes fade-out {
+  from {
+    opacity: 1;
+  }
+
+  to {
+    opacity: 0;
+  }
+}
+
+@keyframes slide-up-in {
+  from {
+    transform: translateY(8px);
+    opacity: 0;
+  }
+
+  to {
+    transform: none;
+    opacity: 1;
+  }
+}
+
+@keyframes slide-down-out {
+  from {
+    transform: none;
+    opacity: 1;
+  }
+
+  to {
+    transform: translateY(8px);
+    opacity: 0;
+  }
+}
+
+@keyframes scale-in {
+  from {
+    transform: scale(0.95);
+    opacity: 0;
+  }
+
+  to {
+    transform: none;
+    opacity: 1;
+  }
+}
+
+@keyframes scale-out {
+  from {
+    transform: none;
+    opacity: 1;
+  }
+
+  to {
+    transform: scale(0.95);
+    opacity: 0;
+  }
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(1turn);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  @keyframes fade-in {
+    to {
+      opacity: 1;
+    }
+  }
+
+  @keyframes slide-up-in {
+    to {
+      transform: none;
+      opacity: 1;
+    }
+  }
+
+  @keyframes scale-in {
+    to {
+      transform: none;
+      opacity: 1;
+    }
+  }
+}

--- a/packages/css/src/teseor.css
+++ b/packages/css/src/teseor.css
@@ -1,5 +1,6 @@
 @import url("./reset.css");
 @import url("./tokens.css");
+@import url("./motion.css");
 @import url("./base.css");
 @import url("./utilities.css");
 @import url("./components/button/button.css");


### PR DESCRIPTION
## What

Adds `packages/css/src/motion.css` — shared `@keyframes` (`fade-in`/`fade-out`, `slide-up-in`/`slide-down-out`, `scale-in`/`scale-out`, `spin`) with a `prefers-reduced-motion` block that redefines the entrance keyframes to an immediate jump. Bundled into `teseor.css` and emitted as a standalone `@teseor/css/motion.css`.

The motion *tokens* (`--t-dur-*`, `--t-ease-*`, `--t-motion-scale`) already ship in `tokens.css` — that part of the issue was done by the foundation work.

Reviewing `motion.md` against where the project is now surfaced two drifts, fixed here:
- Its component-integration example declared `animation` directly in a `[data-*]` rule — `check-component-css.ts` (ADR-0008) rejects exactly that. Rewritten to the token-driven `--_animation` form.
- Stripped an internal plan-code reference from the doc.

## Why

Components need shared, named keyframes for entrance/exit animation; `motion.md` specifies the set. Keeping them in one file means one definition and one reduced-motion contract.

## Test plan

- `build-output.test.ts` — `motion.css` ships the keyframes and the reduced-motion block; the bundle includes them.
- `pnpm lint`, `pnpm typecheck`, `pnpm test` (60), `pnpm build:css` — green.

## Out of scope

- How a shared keyframe reaches a *per-component* CSS file without breaking that file's self-containment (the acid test) — a real open question, tracked under #613. `button` keeps its local `t-button-spin` keyframe until #613 settles it.

Closes #564