### PR TITLE
chore(repo): pre-push hook mirrors CI's local-runnable checks

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -32,9 +32,24 @@ pre-commit:
 
 pre-push:
   commands:
+    lint:
+      run: pnpm lint
     typecheck:
       run: pnpm typecheck
     test:
-      run: pnpm test:unit
+      run: pnpm test
+    gen-drift:
+      run: |
+        before=$(git status --porcelain)
+        pnpm gen
+        if [ "$before" != "$(git status --porcelain)" ]; then
+          echo "pnpm gen changed generated output — commit the regenerated files."
+          git --no-pager diff
+          exit 1
+        fi
+    verify-no-dev-leak:
+      run: pnpm -r --if-present run build && pnpm verify:no-dev-leak
+    measure:
+      run: pnpm build:css && pnpm size
     changeset:
       run: node scripts/check-changeset.js

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -40,9 +40,10 @@ pre-push:
       run: pnpm test
     gen-drift:
       run: |
-        before=$(git status --porcelain)
+        set -e
+        before="$(git status --porcelain)$(git diff HEAD)"
         pnpm gen
-        if [ "$before" != "$(git status --porcelain)" ]; then
+        if [ "$before" != "$(git status --porcelain)$(git diff HEAD)" ]; then
           echo "pnpm gen changed generated output — commit the regenerated files."
           git --no-pager diff
           exit 1


### PR DESCRIPTION
## What

`pre-push` now runs every CI job that can run locally: `lint`, `typecheck`, `test`, `gen-drift`, `verify-no-dev-leak`, `measure`, and `changeset`.

It also fixes a real bug — the hook's `test` step ran `pnpm test:unit`, and no package implements a `test:unit` script, so `--if-present` skipped everything. **The hook never ran tests.** It now runs `pnpm test`, matching CI.

`gen-drift` compares `git status` before and after `pnpm gen` rather than CI's `git diff --quiet`. CI runs against a clean checkout; a pre-push hook can run against a dirty tree, so the check must flag only what `pnpm gen` itself changes, not unrelated uncommitted work.

## Why

The hook ran only `typecheck`, a no-op `test`, and the changeset check — so lint, gen-drift, size, and dev-leak failures were discovered on CI after a push instead of before it.

## Test plan

- `lefthook run pre-push --all-files --force` — all seven commands pass.
- Pushing this branch exercised the hook for real — green.

## Out of scope

- `test-e2e` stays CI-only — it needs `playwright install --with-deps` (a heavy browser download) and is the slowest job.
- PR-metadata checks (`title-format`, `body-sections`, `labeler`, `linked-issue`) cannot run at push time — there is no PR yet.

Closes #615