### PR TITLE
fix(repo): override yaml past the stack-overflow advisory

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  yaml: ^2.8.3
+
 importers:
 
   .:
@@ -202,7 +205,7 @@ importers:
   scripts/codegen:
     dependencies:
       yaml:
-        specifier: ^2.9.0
+        specifier: ^2.8.3
         version: 2.9.0
 
 packages:
@@ -3113,7 +3116,7 @@ packages:
       sugarss: ^5.0.0
       terser: ^5.16.0
       tsx: ^4.8.1
-      yaml: ^2.4.2
+      yaml: ^2.8.3
     peerDependenciesMeta:
       '@types/node':
         optional: true
@@ -3154,7 +3157,7 @@ packages:
       sugarss: ^5.0.0
       terser: ^5.16.0
       tsx: ^4.8.1
-      yaml: ^2.4.2
+      yaml: ^2.8.3
     peerDependenciesMeta:
       '@types/node':
         optional: true
@@ -3377,11 +3380,6 @@ packages:
 
   yaml-language-server@1.20.0:
     resolution: {integrity: sha512-qhjK/bzSRZ6HtTvgeFvjNPJGWdZ0+x5NREV/9XZWFjIGezew2b4r5JPy66IfOhd5OA7KeFwk1JfmEbnTvev0cA==}
-    hasBin: true
-
-  yaml@2.7.1:
-    resolution: {integrity: sha512-10ULxpnOCQXxJvBgxsn9ptjq6uviG/htZKk9veJGhlqn3w/DxQ631zFF+nlQXLwmImeS5amR2dl2U8sg6U9jsQ==}
-    engines: {node: '>= 14'}
     hasBin: true
 
   yaml@2.9.0:
@@ -6769,9 +6767,7 @@ snapshots:
       vscode-languageserver-textdocument: 1.0.12
       vscode-languageserver-types: 3.17.5
       vscode-uri: 3.1.0
-      yaml: 2.7.1
-
-  yaml@2.7.1: {}
+      yaml: 2.9.0
 
   yaml@2.9.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,6 +2,10 @@ packages:
   - 'packages/*'
   - 'apps/*'
   - 'scripts/codegen'
+overrides:
+  # Lifts every `yaml` past the < 2.8.3 stack-overflow advisory — see #625.
+  # Drop this once no transitive dependency resolves `yaml` below 2.8.3.
+  yaml: '^2.8.3'
 allowBuilds:
   esbuild: false
   sharp: false


### PR DESCRIPTION
## What

Adds a pnpm `overrides` entry forcing every `yaml` resolution to `^2.8.3`. This lifts the transitive `yaml@2.7.1` — pulled by `@astrojs/check` through `yaml-language-server` — past the advisory. The lockfile now resolves a single `yaml@2.9.0`.

## Why

Dependabot flagged `yaml < 2.8.3` (medium — stack overflow via deeply nested collections). Direct dependencies were already on 2.9.0; only the deep transitive copy was vulnerable. `pnpm update` cannot reach a transitive of a third-party package, so an override is the fix. pnpm 11 reads `overrides` from `pnpm-workspace.yaml` — the `package.json` `pnpm` field is no longer honored.

Closes #625.

## Test plan

- [ ] `pnpm install` resolves only `yaml@2.9.0`; no `yaml < 2.8.3` remains in `pnpm-lock.yaml`.
- [ ] The pre-push suite (lint, typecheck, test, gen-drift, verify-no-dev-leak, measure) passes.

## Out of scope

Detecting when the override is no longer needed — the inline comment states the removal condition (no transitive resolves `yaml` below 2.8.3); a periodic override audit is a separate proposal.