### PR TITLE
feat(spec): make per-prop responsive a deliberate, enforced decision

### DIFF
--- a/.claude/commands/new-component.md
+++ b/.claude/commands/new-component.md
@@ -6,6 +6,10 @@ Scaffold a new component spec + CSS file + placeholder tests. Argument: the comp
    never rely on a remembered template.
 2. Ask the user: `kind: atomic | composite`, plus any other contextual
    choices the component requires (initial variants, intents, etc.).
+   For every non-slot prop the user lists, ask whether it is responsive
+   (`responsive: true` or `false`) — `docs/rules/responsive.md` requires the
+   decision to be explicit and the validator rejects omission. Slot props
+   (children, `iconStart`, `iconEnd`) are exempt.
 3. Confirm the slugged name (kebab-case) is in the canonical vocabulary
    (`specs/_vocabulary.yaml` `components:` list). If not, ask the user
    whether to add it to vocabulary first — do not silently mint a new name.

--- a/docs/rules/responsive.md
+++ b/docs/rules/responsive.md
@@ -30,7 +30,7 @@ props:
   variant:  { type: enum, values: [solid, outline, ghost, link], responsive: false }
 ```
 
-**Explicit per prop.** Every non-slot prop declares `responsive:` explicitly — `true` or `false`. `validate-spec.ts` rejects omission. Slot props (children, `iconStart`, `iconEnd`) are exempt because they pass through content and have no breakpoint-variant rendering surface. The rule makes the decision deliberate and visible in review; a prop is never non-responsive by accident.
+**Explicit per prop.** Every non-slot prop declares `responsive:` explicitly — `true` or `false`. `validate-spec.ts` rejects omission, on the atomic root and on every composite part (`parts.<name>.props.*`). Slot props (children, `iconStart`, `iconEnd`) are exempt because they pass through content and have no breakpoint-variant rendering surface. The rule makes the decision deliberate and visible in review; a prop is never non-responsive by accident.
 
 Two prop categories:
 

--- a/docs/rules/responsive.md
+++ b/docs/rules/responsive.md
@@ -30,6 +30,8 @@ props:
   variant:  { type: enum, values: [solid, outline, ghost, link], responsive: false }
 ```
 
+**Explicit per prop.** Every non-slot prop declares `responsive:` explicitly — `true` or `false`. `validate-spec.ts` rejects omission. Slot props (children, `iconStart`, `iconEnd`) are exempt because they pass through content and have no breakpoint-variant rendering surface. The rule makes the decision deliberate and visible in review; a prop is never non-responsive by accident.
+
 Two prop categories:
 
 - **Visual props** — `size`, `density`, `layout`, `align`, `padding`. Adapting visual hierarchy across breakpoints is normal. Responsive allowed.

--- a/scripts/codegen/src/semantic-checks.test.ts
+++ b/scripts/codegen/src/semantic-checks.test.ts
@@ -9,6 +9,7 @@ import {
   checkExamplesReferences,
   checkMatrixShape,
   checkMotionSymmetry,
+  checkResponsiveExplicit,
   checkTokenContract,
   checkVariantChoiceKeys,
   checkVocabulary,
@@ -316,6 +317,44 @@ describe("checkCssImportAllowlist", () => {
     const spec = makeButton({ dependencies: ["icon"] });
     const css = `@import "../icon/icon.css";\n.t-button {}`;
     expect(checkCssImportAllowlist(spec, css)).toEqual([]);
+  });
+});
+
+describe("checkResponsiveExplicit", () => {
+  test("flags a non-slot prop that omits `responsive:`", () => {
+    const spec = makeButton({
+      props: { loading: { type: "boolean", description: "Loading." } },
+    });
+    const issues = checkResponsiveExplicit(spec);
+    expect(issues).toHaveLength(1);
+    expect(issues[0]?.path).toBe("props.loading.responsive");
+  });
+
+  test("accepts `responsive: false`", () => {
+    const spec = makeButton({
+      props: {
+        loading: { type: "boolean", responsive: false, description: "Loading." },
+      },
+    });
+    expect(checkResponsiveExplicit(spec)).toEqual([]);
+  });
+
+  test("accepts `responsive: true`", () => {
+    const spec = makeButton({
+      props: {
+        block: { type: "boolean", responsive: true, description: "Block layout." },
+      },
+    });
+    expect(checkResponsiveExplicit(spec)).toEqual([]);
+  });
+
+  test("exempts a slot prop", () => {
+    const spec = makeButton({
+      props: {
+        iconStart: { type: "string", slot: true, description: "Start icon." },
+      },
+    });
+    expect(checkResponsiveExplicit(spec)).toEqual([]);
   });
 });
 

--- a/scripts/codegen/src/semantic-checks.test.ts
+++ b/scripts/codegen/src/semantic-checks.test.ts
@@ -356,6 +356,21 @@ describe("checkResponsiveExplicit", () => {
     });
     expect(checkResponsiveExplicit(spec)).toEqual([]);
   });
+
+  test("walks composite parts", () => {
+    const spec: Spec = {
+      name: "popover",
+      kind: "composite",
+      parts: {
+        content: {
+          props: { open: { type: "boolean", description: "Open." } },
+        },
+      },
+    };
+    const issues = checkResponsiveExplicit(spec);
+    expect(issues).toHaveLength(1);
+    expect(issues[0]?.path).toBe("parts.content.props.open.responsive");
+  });
 });
 
 describe("checkVariantChoiceKeys", () => {

--- a/scripts/codegen/src/semantic-checks.ts
+++ b/scripts/codegen/src/semantic-checks.ts
@@ -557,22 +557,26 @@ export function checkCssImportAllowlist(spec: Spec, css: string | undefined): Is
  * `false`). Omission silently defaults to non-responsive — making the
  * decision invisible in review. Slot props are exempt: they pass through
  * children / VNodes and have no breakpoint-variant rendering surface.
+ * Walks composite parts so `parts.<name>.props.<prop>` is covered too.
  */
 export function checkResponsiveExplicit(spec: Spec): Issue[] {
   const issues: Issue[] = [];
-  if (!isAtomic(spec)) return issues;
-  for (const [propName, propDef] of Object.entries(spec.props ?? {})) {
-    if (propDef.slot === true) continue;
-    if (propDef.responsive === undefined) {
-      issues.push(
-        issue(
-          spec.name,
-          `props.${propName}.responsive`,
-          "non-slot prop must declare `responsive:` explicitly (`true` or `false`)",
-        ),
-      );
+  visitNodes(spec, (node, path) => {
+    for (const [propName, propDef] of Object.entries(node.props ?? {})) {
+      if (propDef.slot === true) continue;
+      if (propDef.responsive === undefined) {
+        const propPath =
+          path === "" ? `props.${propName}.responsive` : `${path}.props.${propName}.responsive`;
+        issues.push(
+          issue(
+            spec.name,
+            propPath,
+            "non-slot prop must declare `responsive:` explicitly (`true` or `false`)",
+          ),
+        );
+      }
     }
-  }
+  });
   return issues;
 }
 

--- a/scripts/codegen/src/semantic-checks.ts
+++ b/scripts/codegen/src/semantic-checks.ts
@@ -550,6 +550,32 @@ export function checkCssImportAllowlist(spec: Spec, css: string | undefined): Is
   return issues;
 }
 
+// ── Responsive: explicit per-prop decision (#594) ───────────────────────────
+
+/**
+ * Every non-slot prop must declare `responsive:` explicitly (`true` or
+ * `false`). Omission silently defaults to non-responsive — making the
+ * decision invisible in review. Slot props are exempt: they pass through
+ * children / VNodes and have no breakpoint-variant rendering surface.
+ */
+export function checkResponsiveExplicit(spec: Spec): Issue[] {
+  const issues: Issue[] = [];
+  if (!isAtomic(spec)) return issues;
+  for (const [propName, propDef] of Object.entries(spec.props ?? {})) {
+    if (propDef.slot === true) continue;
+    if (propDef.responsive === undefined) {
+      issues.push(
+        issue(
+          spec.name,
+          `props.${propName}.responsive`,
+          "non-slot prop must declare `responsive:` explicitly (`true` or `false`)",
+        ),
+      );
+    }
+  }
+  return issues;
+}
+
 // ── `guidance.variantChoice` keys === `spec.variants` exactly ───────────────
 
 export function checkVariantChoiceKeys(spec: Spec): Issue[] {
@@ -599,6 +625,7 @@ export function runSemanticChecks(
     ...checkMotionSymmetry(spec),
     ...checkCssImportAllowlist(spec, ctx.css),
     ...checkVariantChoiceKeys(spec),
+    ...checkResponsiveExplicit(spec),
   ];
 }
 


### PR DESCRIPTION
Closes #594.

## What

`validate-spec.ts` rejects any non-slot prop that omits `responsive:`. Slot props (`slot: true`) stay exempt — they pass through content with no breakpoint-variant rendering surface. `docs/rules/responsive.md` states the rule; the `new-component` scaffold prompts the decision for every non-slot prop.

## Why

`responsive:` was per-prop but optional; omission silently defaulted to non-responsive. The decision was invisible in review — a prop could ship non-responsive because the author forgot, not because they decided. The validator's existence (#636) made the enforcement cheap; this PR is the one-function change that closes the loop.

## Test plan

- 4 unit tests added to `semantic-checks.test.ts` (omission rejected, `true` / `false` accepted, slot exempted).
- `pnpm lint:spec` against the three current specs — `button.yaml` / `stack.yaml` / `cluster.yaml` all already comply (every non-slot prop declares `responsive:` explicitly).
- Full `pnpm lint`, `pnpm typecheck`, `pnpm test` (128 tests), `pnpm gen` drift-clean, pre-push gates green.

## Out of scope

- Changing which existing props are responsive (issue says so explicitly).
- The semantic-prop rejection for `variant` / `intent` carrying `responsive: true` — those live as top-level `variants:` / `intents:` blocks in current specs, not under `props:`. The doc keeps the backstop rule; the validator can enforce it the day a spec puts `variant` under `props:`.
