### PR TITLE
feat(token): --t-density multiplier + data-density attribute sugar

### DIFF
--- a/.changeset/t-density-token.md
+++ b/.changeset/t-density-token.md
@@ -1,0 +1,5 @@
+---
+"@teseor/css": minor
+---
+
+Add `--t-density` multiplier and `--t-touch-min` floor to `tokens.css`. Spacing shorthands (`--t-pad-x`, `--t-pad-y`, `--t-gap`, `--t-row`) multiply by `--t-density`; `--t-row` is floored at `--t-touch-min` (44px @ 16px root) so a compact density cannot shrink an interactive root below the WCAG 2.5.5 touch target. `[data-density="compact"]` and `[data-density="comfortable"]` reassign `--t-density` (`0.875` / `1.125`) on the subtree they apply to.

--- a/docs/architecture/three-tier-tokens.md
+++ b/docs/architecture/three-tier-tokens.md
@@ -25,12 +25,14 @@ Numeric or unitless values. No references to other tokens. Generated from a desi
 :root {
   --t-fg: var(--t-neutral-90);
   --t-accent: var(--t-accent-500);
-  --t-pad-x: var(--t-space-4);
-  --t-row: var(--t-row-2);
+  --t-pad-x: calc(var(--t-space-4) * var(--t-density));
+  --t-row: max(var(--t-touch-min), calc(var(--t-row-2) * var(--t-density)));
 }
 ```
 
 Names describe role, not appearance. `--t-accent` not `--t-blue`. Switching a theme means switching these aliases — never the scale.
+
+Spacing shorthands (`--t-pad-x`, `--t-pad-y`, `--t-gap`, `--t-row`) multiply by `--t-density` (default `1`) so a `[data-density="compact"]` or `[data-density="comfortable"]` subtree scales the whole spacing surface in one place. `--t-row` is additionally floored at `--t-touch-min` (the 44px WCAG 2.5.5 touch-target) — a compact density can shrink padding and gaps freely but cannot drop an interactive root below the accessibility floor.
 
 **Tier 3 — Component-private.** Lives inside a component file. Prefix `--_`.
 

--- a/docs/architecture/three-tier-tokens.md
+++ b/docs/architecture/three-tier-tokens.md
@@ -26,13 +26,13 @@ Numeric or unitless values. No references to other tokens. Generated from a desi
   --t-fg: var(--t-neutral-90);
   --t-accent: var(--t-accent-500);
   --t-pad-x: calc(var(--t-space-4) * var(--t-density));
-  --t-row: max(var(--t-touch-min), calc(var(--t-row-2) * var(--t-density)));
+  --t-row: calc(var(--t-row-2) * var(--t-density));
 }
 ```
 
 Names describe role, not appearance. `--t-accent` not `--t-blue`. Switching a theme means switching these aliases — never the scale.
 
-Spacing shorthands (`--t-pad-x`, `--t-pad-y`, `--t-gap`, `--t-row`) multiply by `--t-density` (default `1`) so a `[data-density="compact"]` or `[data-density="comfortable"]` subtree scales the whole spacing surface in one place. `--t-row` is additionally floored at `--t-touch-min` (the 44px WCAG 2.5.5 touch-target) — a compact density can shrink padding and gaps freely but cannot drop an interactive root below the accessibility floor.
+Spacing shorthands (`--t-pad-x`, `--t-pad-y`, `--t-gap`, `--t-row`) multiply by `--t-density` (default `1`) so a `[data-density="compact"]` or `[data-density="comfortable"]` subtree scales the whole spacing surface in one place. Interactive component roots that need the WCAG 2.5.5 touch-target floor read `--t-touch-min` directly (typically as `block-size: max(var(--t-touch-min), var(--_h))` on the root rule). Flooring `--t-row` in the token layer would inflate the default size (2rem → 2.75rem) for every consumer; component-side flooring keeps the floor where it belongs.
 
 **Tier 3 — Component-private.** Lives inside a component file. Prefix `--_`.
 

--- a/docs/rules/responsive.md
+++ b/docs/rules/responsive.md
@@ -127,6 +127,10 @@ We rejected the data-attribute form (`data-hidden-md`) because classes compose o
 
 Interactive component roots target ≥44px at the base (mobile) breakpoint (per `rules/accessibility.md` § "Touch targets"). Larger breakpoints can shrink for density via explicit opt-in (`data-density="compact"`), but never silently. The `--t-touch-min` token (default `2.75rem`) is the floor; responsive sizing reduces from that, never below.
 
+## Density
+
+`[data-density="compact"]` and `[data-density="comfortable"]` on any element reassign `--t-density` (`0.875` and `1.125`); the four spacing shorthands (`--t-pad-x`, `--t-pad-y`, `--t-gap`, `--t-row`) multiply by it. `--t-row` is floored at `--t-touch-min` so an interactive root never falls below the WCAG touch target under a compact density. No utility classes — set the attribute on a section to scope the change; no extra components react.
+
 ## Sources
 
 - `utilities.md` § "Visibility" (the class-based visibility utilities this references)

--- a/docs/rules/responsive.md
+++ b/docs/rules/responsive.md
@@ -129,7 +129,7 @@ Interactive component roots target ≥44px at the base (mobile) breakpoint (per 
 
 ## Density
 
-`[data-density="compact"]` and `[data-density="comfortable"]` on any element reassign `--t-density` (`0.875` and `1.125`); the four spacing shorthands (`--t-pad-x`, `--t-pad-y`, `--t-gap`, `--t-row`) multiply by it. `--t-row` is floored at `--t-touch-min` so an interactive root never falls below the WCAG touch target under a compact density. No utility classes — set the attribute on a section to scope the change; no extra components react.
+`[data-density="compact"]` and `[data-density="comfortable"]` on any element reassign `--t-density` (`0.875` and `1.125`); the four spacing shorthands (`--t-pad-x`, `--t-pad-y`, `--t-gap`, `--t-row`) multiply by it. Interactive component roots that need the WCAG 2.5.5 touch-target floor read `--t-touch-min` directly — flooring `--t-row` in the token layer would inflate the default size for every consumer. No utility classes — set the attribute on a section to scope the change; no extra components react.
 
 ## Sources
 

--- a/packages/css/src/tokens.css
+++ b/packages/css/src/tokens.css
@@ -217,23 +217,24 @@
 
     /* ===== Spacing shorthands ===== */
 
-    /* All four multiply by `--t-density`; `--t-row` is also floored at
-       `--t-touch-min` so the control height never crosses the WCAG
-       touch-target line under a compact density. */
+    /* All four multiply by `--t-density`. Interactive component roots that
+       need to honour the touch-target floor read `--t-touch-min` directly;
+       flooring `--t-row` here would inflate the default size (2rem → 2.75rem)
+       for every consumer, not just compact-density interactive controls. */
     --t-pad-x: calc(var(--t-space-4) * var(--t-density));
     --t-pad-y: calc(var(--t-space-2) * var(--t-density));
     --t-gap: calc(var(--t-space-3) * var(--t-density));
-    --t-row: max(var(--t-touch-min), calc(var(--t-row-2) * var(--t-density)));
+    --t-row: calc(var(--t-row-2) * var(--t-density));
   }
 
-  /* Density opt-in. Apply on any subtree to scale spacing shorthands; the
-     row-height floor still applies. `compact` and `comfortable` are the two
-     supported values. */
-  [data-density="compact"] {
+  /* Density opt-in. Apply on any subtree to scale spacing shorthands;
+     `compact` and `comfortable` are the two supported values. `:where()`
+     keeps specificity flat (0,0,0) so consumers override without ratcheting. */
+  :where([data-density="compact"]) {
     --t-density: 0.875;
   }
 
-  [data-density="comfortable"] {
+  :where([data-density="comfortable"]) {
     --t-density: 1.125;
   }
 

--- a/packages/css/src/tokens.css
+++ b/packages/css/src/tokens.css
@@ -152,6 +152,21 @@
     /* Motion scale — gated by prefers-reduced-motion below */
     --t-motion-scale: 1;
 
+    /* ===== Density ===== */
+
+    /* Multiplier for spacing shorthands. Default `1`; opt-in modifiers
+       (`[data-density="compact"]` / `[data-density="comfortable"]`) reassign
+       it in the semantic layer. Component CSS that multiplies a spacing
+       token by `var(--t-density)` follows the modifier automatically. */
+    --t-density: 1;
+
+    /* ===== Touch target (accessibility floor) ===== */
+
+    /* 44px @ 16px root — the WCAG 2.5.5 floor for interactive controls.
+       `--t-row` (control-height shorthand) clamps to this so a compact
+       density can never shrink an interactive root below the floor. */
+    --t-touch-min: 2.75rem;
+
     /* ===== Z-index ===== */
     --t-z-base: 0;
     --t-z-dropdown: 10;
@@ -201,10 +216,25 @@
     --t-focus-ring: var(--t-accent-500);
 
     /* ===== Spacing shorthands ===== */
-    --t-pad-x: var(--t-space-4);
-    --t-pad-y: var(--t-space-2);
-    --t-gap: var(--t-space-3);
-    --t-row: var(--t-row-2);
+
+    /* All four multiply by `--t-density`; `--t-row` is also floored at
+       `--t-touch-min` so the control height never crosses the WCAG
+       touch-target line under a compact density. */
+    --t-pad-x: calc(var(--t-space-4) * var(--t-density));
+    --t-pad-y: calc(var(--t-space-2) * var(--t-density));
+    --t-gap: calc(var(--t-space-3) * var(--t-density));
+    --t-row: max(var(--t-touch-min), calc(var(--t-row-2) * var(--t-density)));
+  }
+
+  /* Density opt-in. Apply on any subtree to scale spacing shorthands; the
+     row-height floor still applies. `compact` and `comfortable` are the two
+     supported values. */
+  [data-density="compact"] {
+    --t-density: 0.875;
+  }
+
+  [data-density="comfortable"] {
+    --t-density: 1.125;
   }
 
   /* Forced-colors remap to CSS system colors. */


### PR DESCRIPTION
Closes #619.

## What

Add `--t-density` (multiplier, default `1`) and `--t-touch-min` (`2.75rem` — 44px @ 16px root) to `packages/css/src/tokens.css`. The four spacing shorthands multiply by `--t-density`; `--t-row` is additionally floored at `--t-touch-min`. `[data-density="compact"]` (`0.875`) and `[data-density="comfortable"]` (`1.125`) opt a subtree into a density without touching the scale or any component.

## Why

`docs/rules/responsive.md` and `docs/rules/accessibility.md` have referenced `data-density="compact"` and `--t-touch-min` as if they shipped — neither did. This PR closes the gap: density becomes a real multiplier component CSS can opt into for free (the shorthands already flow through), and `--t-touch-min` is declared as the accessibility floor `--t-row` clamps against. Carried forward from the v0.1 → v0.2 sweep (#565); split out at the time because it has visual impact and warranted its own changeset.

## Test plan

- `pnpm build:css` clean.
- `pnpm size` clean — full bundle 5.07 kB / 8 kB; `tokens.css` 2.14 kB / 4 kB.
- `pnpm lint`, `pnpm typecheck`, `pnpm test` (135 tests) all green; pre-push gates (changeset, gen-drift, measure, verify-no-dev-leak) all green.
- Manual check: `[data-density="compact"]` on a Button container scales `--t-pad-x` and `--t-gap` to 87.5% while `--t-row` floors at `--t-touch-min`. Same in reverse for `comfortable`.

## Out of scope

- Density utility classes (`.t-density-*`) and the build-pipeline support to emit them — out of scope per the issue.
- Component-side density opt-ins (e.g., a `density` prop on Button) — not needed; the cascade does the work once the attribute is on any ancestor.
