### PR TITLE
feat(primitives): scaffold @teseor/primitives with focus-trap

### DIFF
--- a/.changeset/654-primitives-focus-trap.md
+++ b/.changeset/654-primitives-focus-trap.md
@@ -1,0 +1,5 @@
+---
+"@teseor/primitives": minor
+---
+
+Scaffold `@teseor/primitives` — headless behavior package with vanilla functions and per-framework adapters under `/react` and `/vue` sub-paths. First primitive: `focus-trap`. Confines keyboard focus to a container, wraps Tab/Shift+Tab, pulls back focus that escapes the container, restores focus to the previously focused element on deactivate. Vanilla `createFocusTrap` + React `useFocusTrap` hook + Vue `useFocusTrap` composable, all built on the same underlying implementation. Portal, dismissable-layer, and anchor positioning ship in follow-up PRs against the same umbrella issue.

--- a/.github/workflows/pr-discipline.yml
+++ b/.github/workflows/pr-discipline.yml
@@ -40,7 +40,7 @@ jobs:
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
           set -e
-          fixed='token theme codegen showcase css wrapper i18n ci repo claude scripts docs spec'
+          fixed='token theme codegen showcase css wrapper i18n ci repo claude scripts docs spec primitives'
           components=''
           shopt -s nullglob
           for spec in specs/*.yaml; do

--- a/packages/primitives/package.json
+++ b/packages/primitives/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "@teseor/primitives",
+  "version": "3.0.0",
+  "private": true,
+  "description": "Headless behavior primitives for Teseor — focus trap, portal, dismissable layer, anchor positioning. Vanilla functions with React and Vue adapters.",
+  "type": "module",
+  "sideEffects": false,
+  "exports": {
+    ".": "./src/index.ts",
+    "./react": "./src/react.ts",
+    "./vue": "./src/vue.ts",
+    "./*": "./src/*"
+  },
+  "files": [
+    "src"
+  ],
+  "scripts": {
+    "typecheck": "tsc --noEmit"
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/teseor/teseor.git",
+    "directory": "packages/primitives"
+  },
+  "peerDependencies": {
+    "react": ">=18",
+    "vue": ">=3.5"
+  },
+  "peerDependenciesMeta": {
+    "react": {
+      "optional": true
+    },
+    "vue": {
+      "optional": true
+    }
+  },
+  "devDependencies": {
+    "@types/react": "^19.2.15",
+    "@types/react-dom": "^19.2.3",
+    "happy-dom": "^20.9.0",
+    "react": "^19.2.6",
+    "react-dom": "^19.2.6",
+    "vue": "^3.5.34"
+  }
+}

--- a/packages/primitives/src/focus-trap/index.test.ts
+++ b/packages/primitives/src/focus-trap/index.test.ts
@@ -81,6 +81,18 @@ describe("getFocusableElements", () => {
     `);
     expect(getFocusableElements(c).map((el) => el.id)).toEqual(["a", "b"]);
   });
+
+  it("excludes any element whose computed tabIndex is negative", () => {
+    // The CSS selector matches `[tabindex]:not([tabindex="-1"])` so values
+    // like `-2` slip past the selector — the tabIndex filter catches them.
+    const c = makeContainer(`
+      <div id="container">
+        <button id="a">A</button>
+        <div id="b" tabindex="-2">B</div>
+      </div>
+    `);
+    expect(getFocusableElements(c).map((el) => el.id)).toEqual(["a"]);
+  });
 });
 
 describe("createFocusTrap", () => {
@@ -152,6 +164,41 @@ describe("createFocusTrap", () => {
     expect(c.getAttribute("tabindex")).toBe("-1");
     trap.deactivate();
     expect(c.hasAttribute("tabindex")).toBe(false);
+  });
+
+  it("pulls focus back to the container on Tab when there are no focusables and focus escaped", () => {
+    makeContainer(`
+      <div>
+        <button id="outside">O</button>
+        <div id="container"></div>
+      </div>
+    `);
+    const c = getEl("container");
+    const trap = createFocusTrap(c);
+    trap.activate();
+    getEl("outside").focus();
+    pressTab();
+    expect(document.activeElement).toBe(c);
+    expect(c.getAttribute("tabindex")).toBe("-1");
+    trap.deactivate();
+  });
+
+  it("pulls focus back via focusin when an outside element is clicked or focused programmatically", () => {
+    makeContainer(`
+      <div>
+        <button id="outside">O</button>
+        <div id="container">
+          <button id="a">A</button>
+        </div>
+      </div>
+    `);
+    const trap = createFocusTrap(getEl("container"));
+    trap.activate();
+    getEl("outside").focus();
+    // No Tab — just a programmatic focus change. The focusin handler should
+    // pull focus back without us pressing any key.
+    expect(activeId()).toBe("a");
+    trap.deactivate();
   });
 
   it("restores focus to the previously focused element on deactivate", () => {

--- a/packages/primitives/src/focus-trap/index.test.ts
+++ b/packages/primitives/src/focus-trap/index.test.ts
@@ -1,0 +1,229 @@
+// @vitest-environment happy-dom
+import { afterEach, describe, expect, it } from "vitest";
+import { createFocusTrap, getFocusableElements } from "./index.ts";
+
+function makeContainer(html: string): HTMLElement {
+  document.body.innerHTML = html;
+  const container = document.getElementById("container");
+  if (!container) throw new Error("container missing");
+  return container;
+}
+
+function getEl(id: string): HTMLElement {
+  const el = document.getElementById(id);
+  if (!el) throw new Error(`#${id} missing`);
+  return el;
+}
+
+function activeId(): string | null {
+  const el = document.activeElement;
+  return el instanceof HTMLElement ? el.id : null;
+}
+
+function pressTab(shift = false): void {
+  document.dispatchEvent(
+    new KeyboardEvent("keydown", {
+      key: "Tab",
+      bubbles: true,
+      cancelable: true,
+      shiftKey: shift,
+    }),
+  );
+}
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("getFocusableElements", () => {
+  it("returns focusable descendants in DOM order", () => {
+    const c = makeContainer(`
+      <div id="container">
+        <button id="a">A</button>
+        <a id="b" href="#">B</a>
+        <input id="c" />
+      </div>
+    `);
+    expect(getFocusableElements(c).map((el) => el.id)).toEqual(["a", "b", "c"]);
+  });
+
+  it("skips disabled buttons and inputs", () => {
+    const c = makeContainer(`
+      <div id="container">
+        <button id="a">A</button>
+        <button id="b" disabled>B</button>
+        <input id="c" disabled />
+        <button id="d">D</button>
+      </div>
+    `);
+    expect(getFocusableElements(c).map((el) => el.id)).toEqual(["a", "d"]);
+  });
+
+  it("skips elements inside an [inert] subtree", () => {
+    const c = makeContainer(`
+      <div id="container">
+        <div inert>
+          <button id="hidden">H</button>
+        </div>
+        <button id="a">A</button>
+      </div>
+    `);
+    expect(getFocusableElements(c).map((el) => el.id)).toEqual(["a"]);
+  });
+
+  it("includes [tabindex='0'] but excludes [tabindex='-1']", () => {
+    const c = makeContainer(`
+      <div id="container">
+        <button id="a">A</button>
+        <div id="b" tabindex="0">B</div>
+        <div id="c" tabindex="-1">C</div>
+      </div>
+    `);
+    expect(getFocusableElements(c).map((el) => el.id)).toEqual(["a", "b"]);
+  });
+});
+
+describe("createFocusTrap", () => {
+  it("focuses the first focusable on activate", () => {
+    const c = makeContainer(`
+      <div id="container">
+        <button id="a">A</button>
+        <button id="b">B</button>
+      </div>
+    `);
+    const trap = createFocusTrap(c);
+    trap.activate();
+    expect(activeId()).toBe("a");
+    trap.deactivate();
+  });
+
+  it("wraps from last to first on Tab", () => {
+    const c = makeContainer(`
+      <div id="container">
+        <button id="a">A</button>
+        <button id="b">B</button>
+      </div>
+    `);
+    const trap = createFocusTrap(c);
+    trap.activate();
+    getEl("b").focus();
+    pressTab();
+    expect(activeId()).toBe("a");
+    trap.deactivate();
+  });
+
+  it("wraps from first to last on Shift+Tab", () => {
+    const c = makeContainer(`
+      <div id="container">
+        <button id="a">A</button>
+        <button id="b">B</button>
+      </div>
+    `);
+    const trap = createFocusTrap(c);
+    trap.activate();
+    pressTab(true);
+    expect(activeId()).toBe("b");
+    trap.deactivate();
+  });
+
+  it("pulls focus back when it escapes the container", () => {
+    makeContainer(`
+      <div>
+        <button id="outside">O</button>
+        <div id="container">
+          <button id="a">A</button>
+        </div>
+      </div>
+    `);
+    const c = getEl("container");
+    const trap = createFocusTrap(c);
+    trap.activate();
+    getEl("outside").focus();
+    pressTab();
+    expect(activeId()).toBe("a");
+    trap.deactivate();
+  });
+
+  it("focuses the container itself when there are no focusables", () => {
+    const c = makeContainer(`<div id="container"></div>`);
+    const trap = createFocusTrap(c);
+    trap.activate();
+    expect(document.activeElement).toBe(c);
+    expect(c.getAttribute("tabindex")).toBe("-1");
+    trap.deactivate();
+    expect(c.hasAttribute("tabindex")).toBe(false);
+  });
+
+  it("restores focus to the previously focused element on deactivate", () => {
+    document.body.innerHTML = `
+      <button id="trigger">T</button>
+      <div id="container">
+        <button id="a">A</button>
+      </div>
+    `;
+    getEl("trigger").focus();
+    expect(activeId()).toBe("trigger");
+    const trap = createFocusTrap(getEl("container"));
+    trap.activate();
+    expect(activeId()).toBe("a");
+    trap.deactivate();
+    expect(activeId()).toBe("trigger");
+  });
+
+  it("honors `initialFocus` as an HTMLElement", () => {
+    const c = makeContainer(`
+      <div id="container">
+        <button id="a">A</button>
+        <button id="b">B</button>
+      </div>
+    `);
+    const trap = createFocusTrap(c, { initialFocus: getEl("b") });
+    trap.activate();
+    expect(activeId()).toBe("b");
+    trap.deactivate();
+  });
+
+  it("skips initial focus when `initialFocus` is false", () => {
+    const c = makeContainer(`
+      <div id="container">
+        <button id="a">A</button>
+      </div>
+    `);
+    document.body.tabIndex = -1;
+    document.body.focus();
+    const before = document.activeElement;
+    const trap = createFocusTrap(c, { initialFocus: false });
+    trap.activate();
+    expect(document.activeElement).toBe(before);
+    trap.deactivate();
+  });
+
+  it("honors `returnFocus` as an HTMLElement", () => {
+    document.body.innerHTML = `
+      <button id="trigger">T</button>
+      <button id="elsewhere">E</button>
+      <div id="container">
+        <button id="a">A</button>
+      </div>
+    `;
+    getEl("trigger").focus();
+    const trap = createFocusTrap(getEl("container"), {
+      returnFocus: getEl("elsewhere"),
+    });
+    trap.activate();
+    trap.deactivate();
+    expect(activeId()).toBe("elsewhere");
+  });
+
+  it("ignores repeated activate / deactivate calls", () => {
+    const c = makeContainer(`
+      <div id="container"><button id="a">A</button></div>
+    `);
+    const trap = createFocusTrap(c);
+    trap.activate();
+    trap.activate(); // no-op
+    expect(activeId()).toBe("a");
+    trap.deactivate();
+    trap.deactivate(); // no-op
+  });
+});

--- a/packages/primitives/src/focus-trap/index.ts
+++ b/packages/primitives/src/focus-trap/index.ts
@@ -28,10 +28,11 @@ function isHTMLElement(value: unknown): value is HTMLElement {
 }
 
 /** Returns focusable descendants of `container` in DOM order, skipping
- *  disabled inputs and anything inside an `[inert]` subtree. */
+ *  disabled inputs, anything inside an `[inert]` subtree, and elements
+ *  whose computed `tabIndex` is negative (e.g. `tabindex="-2"`). */
 export function getFocusableElements(container: HTMLElement): HTMLElement[] {
   return Array.from(container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)).filter(
-    (el) => !el.closest("[inert]"),
+    (el) => el.tabIndex >= 0 && !el.closest("[inert]"),
   );
 }
 
@@ -50,11 +51,34 @@ export function createFocusTrap(container: HTMLElement, options: FocusTrapOption
   let active = false;
   let temporaryTabindex = false;
 
+  function ensureContainerFocusable(): void {
+    if (!container.hasAttribute("tabindex")) {
+      container.setAttribute("tabindex", "-1");
+      temporaryTabindex = true;
+    }
+  }
+
+  function focusFallback(): void {
+    const focusables = getFocusableElements(container);
+    const next = focusables[0];
+    if (next) {
+      next.focus();
+      return;
+    }
+    ensureContainerFocusable();
+    container.focus();
+  }
+
   function handleKeyDown(event: KeyboardEvent): void {
     if (event.key !== "Tab") return;
     const focusables = getFocusableElements(container);
     if (focusables.length === 0) {
+      // No tabbable children — block Tab and keep focus inside the container.
       event.preventDefault();
+      if (!container.contains(document.activeElement)) {
+        ensureContainerFocusable();
+        container.focus();
+      }
       return;
     }
     const first = focusables[0];
@@ -73,6 +97,16 @@ export function createFocusTrap(container: HTMLElement, options: FocusTrapOption
       event.preventDefault();
       first.focus();
     }
+  }
+
+  function handleFocusIn(event: FocusEvent): void {
+    const target = event.target;
+    if (!(target instanceof Node)) return;
+    if (container.contains(target)) return;
+    // Focus escaped via click, programmatic focus, or browser-native Tab —
+    // pull it back. Tab keydown's handler runs first and already redirects,
+    // so this is a no-op on that path.
+    focusFallback();
   }
 
   function resolveInitial(): HTMLElement | null {
@@ -96,13 +130,13 @@ export function createFocusTrap(container: HTMLElement, options: FocusTrapOption
     active = true;
     previouslyFocused = isHTMLElement(document.activeElement) ? document.activeElement : null;
     document.addEventListener("keydown", handleKeyDown, true);
+    document.addEventListener("focusin", handleFocusIn, true);
     const initial = resolveInitial();
     if (initial) {
-      // Make the container itself focusable when we're falling back to it,
-      // and remember to clean the attribute up on deactivate.
-      if (initial === container && !container.hasAttribute("tabindex")) {
-        container.setAttribute("tabindex", "-1");
-        temporaryTabindex = true;
+      // Fall back to focusing the container itself when there's no other
+      // candidate; ensureContainerFocusable cleans up the tabindex on deactivate.
+      if (initial === container) {
+        ensureContainerFocusable();
       }
       initial.focus();
     }
@@ -112,6 +146,7 @@ export function createFocusTrap(container: HTMLElement, options: FocusTrapOption
     if (!active) return;
     active = false;
     document.removeEventListener("keydown", handleKeyDown, true);
+    document.removeEventListener("focusin", handleFocusIn, true);
     if (temporaryTabindex) {
       container.removeAttribute("tabindex");
       temporaryTabindex = false;

--- a/packages/primitives/src/focus-trap/index.ts
+++ b/packages/primitives/src/focus-trap/index.ts
@@ -1,0 +1,125 @@
+// Confines keyboard focus to a container. Vanilla DOM; framework adapters
+// under ./react and ./vue wrap this for component lifecycles.
+
+const FOCUSABLE_SELECTOR = [
+  "a[href]",
+  "button:not([disabled])",
+  'input:not([disabled]):not([type="hidden"])',
+  "select:not([disabled])",
+  "textarea:not([disabled])",
+  '[tabindex]:not([tabindex="-1"])',
+  '[contenteditable]:not([contenteditable="false"])',
+].join(",");
+
+export type FocusTrapOptions = {
+  /** Where to send focus on activate. Default: first focusable inside the container, falling back to the container itself. `false` skips initial focus. */
+  initialFocus?: HTMLElement | (() => HTMLElement | null) | false;
+  /** Where to send focus on deactivate. Default: the element focused before activate. `false` skips restoration. */
+  returnFocus?: HTMLElement | (() => HTMLElement | null) | false;
+};
+
+export type FocusTrap = {
+  activate: () => void;
+  deactivate: () => void;
+};
+
+function isHTMLElement(value: unknown): value is HTMLElement {
+  return value instanceof HTMLElement;
+}
+
+/** Returns focusable descendants of `container` in DOM order, skipping
+ *  disabled inputs and anything inside an `[inert]` subtree. */
+export function getFocusableElements(container: HTMLElement): HTMLElement[] {
+  return Array.from(container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)).filter(
+    (el) => !el.closest("[inert]"),
+  );
+}
+
+/**
+ * Cycles Tab/Shift+Tab inside `container`. Tab from the last focusable wraps
+ * to the first; Shift+Tab from the first wraps to the last. Focus escaping
+ * the container is pulled back to the first focusable. On deactivate, focus
+ * returns to wherever it came from (overridable via `returnFocus`).
+ *
+ * The trap does not handle ESC, click-outside, or portal placement — those
+ * are separate primitives. Composing a Popover means activating a focus trap
+ * inside a portal with a dismissable layer wrapping both.
+ */
+export function createFocusTrap(container: HTMLElement, options: FocusTrapOptions = {}): FocusTrap {
+  let previouslyFocused: HTMLElement | null = null;
+  let active = false;
+  let temporaryTabindex = false;
+
+  function handleKeyDown(event: KeyboardEvent): void {
+    if (event.key !== "Tab") return;
+    const focusables = getFocusableElements(container);
+    if (focusables.length === 0) {
+      event.preventDefault();
+      return;
+    }
+    const first = focusables[0];
+    const last = focusables[focusables.length - 1];
+    if (!first || !last) return;
+    const activeEl = document.activeElement;
+    if (!container.contains(activeEl)) {
+      event.preventDefault();
+      first.focus();
+      return;
+    }
+    if (event.shiftKey && activeEl === first) {
+      event.preventDefault();
+      last.focus();
+    } else if (!event.shiftKey && activeEl === last) {
+      event.preventDefault();
+      first.focus();
+    }
+  }
+
+  function resolveInitial(): HTMLElement | null {
+    const { initialFocus } = options;
+    if (initialFocus === false) return null;
+    if (typeof initialFocus === "function") return initialFocus();
+    if (isHTMLElement(initialFocus)) return initialFocus;
+    return getFocusableElements(container)[0] ?? container;
+  }
+
+  function resolveReturn(): HTMLElement | null {
+    const { returnFocus } = options;
+    if (returnFocus === false) return null;
+    if (typeof returnFocus === "function") return returnFocus();
+    if (isHTMLElement(returnFocus)) return returnFocus;
+    return previouslyFocused;
+  }
+
+  function activate(): void {
+    if (active) return;
+    active = true;
+    previouslyFocused = isHTMLElement(document.activeElement) ? document.activeElement : null;
+    document.addEventListener("keydown", handleKeyDown, true);
+    const initial = resolveInitial();
+    if (initial) {
+      // Make the container itself focusable when we're falling back to it,
+      // and remember to clean the attribute up on deactivate.
+      if (initial === container && !container.hasAttribute("tabindex")) {
+        container.setAttribute("tabindex", "-1");
+        temporaryTabindex = true;
+      }
+      initial.focus();
+    }
+  }
+
+  function deactivate(): void {
+    if (!active) return;
+    active = false;
+    document.removeEventListener("keydown", handleKeyDown, true);
+    if (temporaryTabindex) {
+      container.removeAttribute("tabindex");
+      temporaryTabindex = false;
+    }
+    const ret = resolveReturn();
+    ret?.focus();
+    previouslyFocused = null;
+  }
+
+  return { activate, deactivate };
+}

--- a/packages/primitives/src/focus-trap/react.test.tsx
+++ b/packages/primitives/src/focus-trap/react.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment happy-dom
-import { act, useRef } from "react";
+import { act, useState } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { useFocusTrap } from "./react.ts";
@@ -8,10 +8,10 @@ let mountTarget: HTMLDivElement;
 let root: Root;
 
 function Trap(props: { active: boolean }) {
-  const ref = useRef<HTMLDivElement>(null);
-  useFocusTrap(ref, props.active);
+  const [container, setContainer] = useState<HTMLElement | null>(null);
+  useFocusTrap(container, props.active);
   return (
-    <div ref={ref} id="trap">
+    <div ref={setContainer} id="trap">
       <button type="button" id="first">
         First
       </button>

--- a/packages/primitives/src/focus-trap/react.test.tsx
+++ b/packages/primitives/src/focus-trap/react.test.tsx
@@ -1,0 +1,71 @@
+// @vitest-environment happy-dom
+import { act, useRef } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { useFocusTrap } from "./react.ts";
+
+let mountTarget: HTMLDivElement;
+let root: Root;
+
+function Trap(props: { active: boolean }) {
+  const ref = useRef<HTMLDivElement>(null);
+  useFocusTrap(ref, props.active);
+  return (
+    <div ref={ref} id="trap">
+      <button type="button" id="first">
+        First
+      </button>
+      <button type="button" id="last">
+        Last
+      </button>
+    </div>
+  );
+}
+
+function render(active: boolean): void {
+  act(() => {
+    root.render(<Trap active={active} />);
+  });
+}
+
+function activeId(): string | null {
+  const el = document.activeElement;
+  return el instanceof HTMLElement ? el.id : null;
+}
+
+beforeEach(() => {
+  mountTarget = document.createElement("div");
+  document.body.appendChild(mountTarget);
+  root = createRoot(mountTarget);
+});
+
+afterEach(() => {
+  act(() => {
+    root.unmount();
+  });
+  mountTarget.remove();
+  document.body.innerHTML = "";
+});
+
+describe("useFocusTrap (react)", () => {
+  it("focuses the first focusable on mount when active is true", () => {
+    render(true);
+    expect(activeId()).toBe("first");
+  });
+
+  it("does not move focus when active is false", () => {
+    document.body.tabIndex = -1;
+    document.body.focus();
+    render(false);
+    expect(document.activeElement).toBe(document.body);
+  });
+
+  it("deactivates and restores focus when active flips to false", () => {
+    document.body.tabIndex = -1;
+    document.body.focus();
+    render(true);
+    expect(activeId()).toBe("first");
+    render(false);
+    expect(document.activeElement).toBe(document.body);
+  });
+});

--- a/packages/primitives/src/focus-trap/react.ts
+++ b/packages/primitives/src/focus-trap/react.ts
@@ -1,0 +1,35 @@
+import { type RefObject, useEffect, useRef } from "react";
+import { createFocusTrap, type FocusTrapOptions } from "./index.ts";
+
+/**
+ * React adapter for {@link createFocusTrap}.
+ *
+ * While `active` is true, focus is confined to `containerRef.current`. The
+ * trap activates on mount (or when `active` flips to true), deactivates on
+ * unmount (or when `active` flips to false), and restores focus to wherever
+ * it came from.
+ *
+ * Options are captured at activation time. Pass a new object to re-configure
+ * on the next activation cycle; mid-cycle changes are not reread.
+ */
+export function useFocusTrap(
+  containerRef: RefObject<HTMLElement | null>,
+  active: boolean,
+  options?: FocusTrapOptions,
+): void {
+  // Stable ref so a fresh-object-literal options on every render does not
+  // re-run the effect; the trap reads options lazily at activate/deactivate.
+  const optionsRef = useRef(options);
+  optionsRef.current = options;
+
+  useEffect(() => {
+    if (!active) return;
+    const container = containerRef.current;
+    if (!container) return;
+    const trap = createFocusTrap(container, optionsRef.current);
+    trap.activate();
+    return () => {
+      trap.deactivate();
+    };
+  }, [active, containerRef]);
+}

--- a/packages/primitives/src/focus-trap/react.ts
+++ b/packages/primitives/src/focus-trap/react.ts
@@ -1,19 +1,20 @@
-import { type RefObject, useEffect, useRef } from "react";
+import { useEffect, useRef } from "react";
 import { createFocusTrap, type FocusTrapOptions } from "./index.ts";
 
 /**
  * React adapter for {@link createFocusTrap}.
  *
- * While `active` is true, focus is confined to `containerRef.current`. The
- * trap activates on mount (or when `active` flips to true), deactivates on
- * unmount (or when `active` flips to false), and restores focus to wherever
- * it came from.
+ * While `active` is true and `container` is non-null, focus is confined to
+ * the element. Pass the element directly (typically from a state-driven
+ * callback ref, e.g. `useState<HTMLElement | null>(null)` plus `ref={setEl}`)
+ * so the effect re-runs when the element itself changes — a `RefObject` is
+ * stable across renders and silently skips element swaps.
  *
- * Options are captured at activation time. Pass a new object to re-configure
- * on the next activation cycle; mid-cycle changes are not reread.
+ * Options are captured at activation time; pass a new object to re-configure
+ * on the next activation cycle.
  */
 export function useFocusTrap(
-  containerRef: RefObject<HTMLElement | null>,
+  container: HTMLElement | null,
   active: boolean,
   options?: FocusTrapOptions,
 ): void {
@@ -23,13 +24,11 @@ export function useFocusTrap(
   optionsRef.current = options;
 
   useEffect(() => {
-    if (!active) return;
-    const container = containerRef.current;
-    if (!container) return;
+    if (!active || !container) return;
     const trap = createFocusTrap(container, optionsRef.current);
     trap.activate();
     return () => {
       trap.deactivate();
     };
-  }, [active, containerRef]);
+  }, [active, container]);
 }

--- a/packages/primitives/src/focus-trap/vue.test.ts
+++ b/packages/primitives/src/focus-trap/vue.test.ts
@@ -1,0 +1,76 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { type App, createApp, defineComponent, h, nextTick, type Ref, ref } from "vue";
+import { useFocusTrap } from "./vue.ts";
+
+let mountTarget: HTMLDivElement;
+let app: App | null = null;
+
+function mountTrap(initial: boolean): Ref<boolean> {
+  const active = ref(initial);
+  const containerRef = ref<HTMLElement | null>(null);
+  const Trap = defineComponent({
+    setup() {
+      // biome-ignore lint/correctness/useHookAtTopLevel: vue composable inside setup(), not a react hook
+      useFocusTrap(containerRef, active);
+      return () =>
+        h(
+          "div",
+          {
+            id: "trap",
+            ref: (el: unknown) => {
+              containerRef.value = el instanceof HTMLElement ? el : null;
+            },
+          },
+          [h("button", { id: "first" }, "First"), h("button", { id: "last" }, "Last")],
+        );
+    },
+  });
+  app = createApp(Trap);
+  app.mount(mountTarget);
+  return active;
+}
+
+function activeId(): string | null {
+  const el = document.activeElement;
+  return el instanceof HTMLElement ? el.id : null;
+}
+
+beforeEach(() => {
+  mountTarget = document.createElement("div");
+  document.body.appendChild(mountTarget);
+});
+
+afterEach(() => {
+  app?.unmount();
+  app = null;
+  mountTarget.remove();
+  document.body.innerHTML = "";
+});
+
+describe("useFocusTrap (vue)", () => {
+  it("focuses the first focusable on mount when active is true", async () => {
+    mountTrap(true);
+    await nextTick();
+    expect(activeId()).toBe("first");
+  });
+
+  it("does not move focus when active is false", async () => {
+    document.body.tabIndex = -1;
+    document.body.focus();
+    mountTrap(false);
+    await nextTick();
+    expect(document.activeElement).toBe(document.body);
+  });
+
+  it("deactivates and restores focus when active flips to false", async () => {
+    document.body.tabIndex = -1;
+    document.body.focus();
+    const active = mountTrap(true);
+    await nextTick();
+    expect(activeId()).toBe("first");
+    active.value = false;
+    await nextTick();
+    expect(document.activeElement).toBe(document.body);
+  });
+});

--- a/packages/primitives/src/focus-trap/vue.ts
+++ b/packages/primitives/src/focus-trap/vue.ts
@@ -1,0 +1,41 @@
+import { onBeforeUnmount, type Ref, watch } from "vue";
+import { createFocusTrap, type FocusTrap, type FocusTrapOptions } from "./index.ts";
+
+/**
+ * Vue adapter for {@link createFocusTrap}.
+ *
+ * While `active` is true and `containerRef` is non-null, focus is confined
+ * to the referenced element. The trap activates/deactivates as the inputs
+ * change and deactivates on component unmount.
+ *
+ * Options are captured at activation time; pass a new object to re-configure
+ * on the next activation cycle.
+ */
+export function useFocusTrap(
+  containerRef: Ref<HTMLElement | null>,
+  active: Ref<boolean>,
+  options?: FocusTrapOptions,
+): void {
+  let trap: FocusTrap | null = null;
+
+  function teardown(): void {
+    if (trap) {
+      trap.deactivate();
+      trap = null;
+    }
+  }
+
+  watch(
+    [containerRef, active],
+    ([container, isActive]) => {
+      teardown();
+      if (isActive && container) {
+        trap = createFocusTrap(container, options);
+        trap.activate();
+      }
+    },
+    { immediate: true, flush: "post" },
+  );
+
+  onBeforeUnmount(teardown);
+}

--- a/packages/primitives/src/index.ts
+++ b/packages/primitives/src/index.ts
@@ -1,0 +1,6 @@
+export {
+  createFocusTrap,
+  type FocusTrap,
+  type FocusTrapOptions,
+  getFocusableElements,
+} from "./focus-trap/index.ts";

--- a/packages/primitives/src/react.ts
+++ b/packages/primitives/src/react.ts
@@ -1,0 +1,1 @@
+export { useFocusTrap } from "./focus-trap/react.ts";

--- a/packages/primitives/src/vue.ts
+++ b/packages/primitives/src/vue.ts
@@ -1,0 +1,1 @@
+export { useFocusTrap } from "./focus-trap/vue.ts";

--- a/packages/primitives/tsconfig.json
+++ b/packages/primitives/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "lib": ["es2022", "dom", "dom.iterable"]
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -58,7 +58,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4.1.7
-        version: 4.1.7(@types/node@24.12.4)(vite@8.0.14(@types/node@24.12.4)(esbuild@0.27.7)(yaml@2.9.0))
+        version: 4.1.7(@types/node@24.12.4)(happy-dom@20.9.0)(vite@8.0.14(@types/node@24.12.4)(esbuild@0.27.7)(yaml@2.9.0))
 
   apps/docs:
     dependencies:
@@ -178,6 +178,27 @@ importers:
       postcss-value-parser:
         specifier: ^4.2.0
         version: 4.2.0
+
+  packages/primitives:
+    devDependencies:
+      '@types/react':
+        specifier: ^19.2.15
+        version: 19.2.15
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.15)
+      happy-dom:
+        specifier: ^20.9.0
+        version: 20.9.0
+      react:
+        specifier: ^19.2.6
+        version: 19.2.6
+      react-dom:
+        specifier: ^19.2.6
+        version: 19.2.6(react@19.2.6)
+      vue:
+        specifier: ^3.5.34
+        version: 3.5.34(typescript@6.0.3)
 
   packages/react:
     dependencies:
@@ -1299,6 +1320,12 @@ packages:
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
+  '@types/whatwg-mimetype@3.0.2':
+    resolution: {integrity: sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==}
+
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
+
   '@ungap/structured-clone@1.3.1':
     resolution: {integrity: sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==}
 
@@ -1913,6 +1940,10 @@ packages:
 
   h3@1.15.11:
     resolution: {integrity: sha512-L3THSe2MPeBwgIZVSH5zLdBBU90TOxarvhK9d04IDY2AmVS8j2Jz2LIWtwsGOU3lu2I5jCN7FNvVfY2+XyF+mg==}
+
+  happy-dom@20.9.0:
+    resolution: {integrity: sha512-GZZ9mKe8r646NUAf/zemnGbjYh4Bt8/MqASJY+pSm5ZDtc3YQox+4gsLI7yi1hba6o+eCsGxpHn5+iEVn31/FQ==}
+    engines: {node: '>=20.0.0'}
 
   has-flag@5.0.1:
     resolution: {integrity: sha512-CsNUt5x9LUdx6hnk/E2SZLsDyvfqANZSUq4+D3D8RzDJ2M+HDTIkF60ibS1vHaK55vzgiZw1bEPFG9yH7l33wA==}
@@ -3425,6 +3456,10 @@ packages:
   web-namespaces@2.0.1:
     resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
 
+  whatwg-mimetype@3.0.0:
+    resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
+    engines: {node: '>=12'}
+
   which-pm-runs@1.1.0:
     resolution: {integrity: sha512-n1brCuqClxfFfq/Rb0ICg9giSZqCS+pLtccdag6C2HyufBrh3fBOiy9nb6ggRMvWOVH5GrdJskj5iGTZNxd7SA==}
     engines: {node: '>=4'}
@@ -3450,6 +3485,18 @@ packages:
   write-file-atomic@7.0.1:
     resolution: {integrity: sha512-OTIk8iR8/aCRWBqvxrzxR0hgxWpnYBblY1S5hDWBQfk/VFmJwzmJgQFN3WsoUKHISv2eAwe+PpbUzyL1CKTLXg==}
     engines: {node: ^20.17.0 || >=22.9.0}
+
+  ws@8.20.1:
+    resolution: {integrity: sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
 
   xxhash-wasm@1.1.0:
     resolution: {integrity: sha512-147y/6YNh+tlp6nd/2pWq38i9h6mz/EuQ6njIrmW8D1BS5nCqs0P6DG+m6zTGnNz5I+uhZ0SHxBs9BsPrwcKDA==}
@@ -4508,6 +4555,12 @@ snapshots:
 
   '@types/unist@3.0.3': {}
 
+  '@types/whatwg-mimetype@3.0.2': {}
+
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 24.12.4
+
   '@ungap/structured-clone@1.3.1': {}
 
   '@vitejs/plugin-react@5.2.0(vite@7.3.3(@types/node@24.12.4)(lightningcss@1.32.0)(yaml@2.9.0))':
@@ -5237,6 +5290,18 @@ snapshots:
       radix3: 1.1.2
       ufo: 1.6.4
       uncrypto: 0.1.3
+
+  happy-dom@20.9.0:
+    dependencies:
+      '@types/node': 24.12.4
+      '@types/whatwg-mimetype': 3.0.2
+      '@types/ws': 8.18.1
+      entities: 7.0.1
+      whatwg-mimetype: 3.0.0
+      ws: 8.20.1
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   has-flag@5.0.1: {}
 
@@ -6776,7 +6841,7 @@ snapshots:
     optionalDependencies:
       vite: 7.3.3(@types/node@24.12.4)(lightningcss@1.32.0)(yaml@2.9.0)
 
-  vitest@4.1.7(@types/node@24.12.4)(vite@8.0.14(@types/node@24.12.4)(esbuild@0.27.7)(yaml@2.9.0)):
+  vitest@4.1.7(@types/node@24.12.4)(happy-dom@20.9.0)(vite@8.0.14(@types/node@24.12.4)(esbuild@0.27.7)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.7
       '@vitest/mocker': 4.1.7(vite@8.0.14(@types/node@24.12.4)(esbuild@0.27.7)(yaml@2.9.0))
@@ -6800,6 +6865,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.12.4
+      happy-dom: 20.9.0
     transitivePeerDependencies:
       - msw
 
@@ -6918,6 +6984,8 @@ snapshots:
 
   web-namespaces@2.0.1: {}
 
+  whatwg-mimetype@3.0.0: {}
+
   which-pm-runs@1.1.0: {}
 
   which@1.3.1:
@@ -6942,6 +7010,8 @@ snapshots:
   write-file-atomic@7.0.1:
     dependencies:
       signal-exit: 4.1.0
+
+  ws@8.20.1: {}
 
   xxhash-wasm@1.1.0: {}
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
-    include: ["packages/**/*.{test,spec}.ts", "scripts/**/*.{test,spec}.ts"],
+    include: ["packages/**/*.{test,spec}.{ts,tsx}", "scripts/**/*.{test,spec}.{ts,tsx}"],
     exclude: ["**/node_modules/**", "**/dist/**", "tests/**"],
     passWithNoTests: true,
   },


### PR DESCRIPTION
Closes #654 (scaffold + focus-trap checkbox).

## What

Stand up `@teseor/primitives` — a new headless behavior package — and ship the first primitive end-to-end: `focus-trap`, with vanilla, React, and Vue surfaces all built on the same underlying implementation.

Package layout:

```
packages/primitives/
├── package.json          # exports ".", "./react", "./vue"
└── src/
    ├── index.ts          # vanilla barrel
    ├── react.ts          # framework barrel
    ├── vue.ts            # framework barrel
    └── focus-trap/
        ├── index.ts      # createFocusTrap, getFocusableElements
        ├── index.test.ts # happy-dom; 14 cases
        ├── react.ts      # useFocusTrap hook
        ├── react.test.tsx# react-dom/client + happy-dom; 3 cases
        ├── vue.ts        # useFocusTrap composable
        └── vue.test.ts   # createApp + happy-dom; 3 cases
```

Behavior: Tab/Shift+Tab cycles inside the container, focus that escapes is pulled back to the first focusable, deactivate restores focus to wherever it came from. Containers with no focusables fall back to focusing the container itself with a temporary `tabindex="-1"`. `initialFocus` and `returnFocus` options accept an element, a getter, or `false` to skip.

Also tweaks `vitest.config.ts` to include `.tsx` files in the test glob — required for the React adapter test.

## Why

Tooltip and Popover (the first v0.3 overlays per the roadmap) need focus-trap, portal, dismissable-layer, and anchor positioning. Without a shared vanilla layer, each Teseor wrapper package (`@teseor/react`, `@teseor/vue`, eventually `@teseor/webc`) would re-implement the algorithms. One implementation underneath thin framework adapters means one bug surface, one set of edge-case fixes.

One package with sub-paths instead of three packages keeps the vanilla function and its adapters version-locked and co-located, and matches the Floating UI shape. Adapters are thin wrappers — about ten lines each — that handle the React/Vue lifecycle.

## Test plan

- `pnpm lint && pnpm typecheck && pnpm test` green locally; full pre-push suite (changeset, gen-drift, lint, measure, test, typecheck, verify-no-dev-leak) green.
- 20 new vitest cases (14 vanilla, 3 React, 3 Vue), all under happy-dom.
- Bundle-size report unchanged — primitives is a new package with `"private": true`; only ships when consumers import it.

## Out of scope

- Portal, dismissable-layer, anchor positioning — three more boxes on #654, one PR each.
- Tooltip / Popover wrappers — separate issues; will be the first consumers of these primitives.
- Floating-UI-style middleware framework — out of scope for v0.3.
