### PR TITLE
feat(primitives): vanilla portal

### DIFF
--- a/.changeset/654-primitives-portal.md
+++ b/.changeset/654-primitives-portal.md
@@ -1,0 +1,5 @@
+---
+"@teseor/primitives": minor
+---
+
+Add the `portal` primitive — `createPortal({ target, container })` attaches a fresh `<div>` (or a provided container) to `document.body` (or a provided target) and returns an idempotent `unmount`. Vanilla DOM only: React consumers use `createPortal` from `react-dom` directly; Vue consumers use the built-in `<Teleport>`. This vanilla layer exists for `@teseor/webc` and plain-DOM consumers.

--- a/packages/primitives/src/index.ts
+++ b/packages/primitives/src/index.ts
@@ -4,3 +4,4 @@ export {
   type FocusTrapOptions,
   getFocusableElements,
 } from "./focus-trap/index.ts";
+export { createPortal, type Portal, type PortalOptions } from "./portal/index.ts";

--- a/packages/primitives/src/portal/index.test.ts
+++ b/packages/primitives/src/portal/index.test.ts
@@ -1,0 +1,69 @@
+// @vitest-environment happy-dom
+import { afterEach, describe, expect, it } from "vitest";
+import { createPortal } from "./index.ts";
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("createPortal", () => {
+  it("attaches a fresh container to document.body by default", () => {
+    const portal = createPortal();
+    expect(portal.container.parentElement).toBe(document.body);
+    expect(portal.container.tagName).toBe("DIV");
+    expect(portal.container.children.length).toBe(0);
+    portal.unmount();
+  });
+
+  it("attaches the container to a custom target", () => {
+    const target = document.createElement("section");
+    document.body.appendChild(target);
+    const portal = createPortal({ target });
+    expect(portal.container.parentElement).toBe(target);
+    portal.unmount();
+  });
+
+  it("uses the provided container instead of creating a new one", () => {
+    const reused = document.createElement("aside");
+    reused.id = "shared";
+    const portal = createPortal({ container: reused });
+    expect(portal.container).toBe(reused);
+    expect(reused.parentElement).toBe(document.body);
+    portal.unmount();
+  });
+
+  it("hosts arbitrary content appended to the container", () => {
+    const portal = createPortal();
+    const child = document.createElement("p");
+    child.textContent = "hello";
+    portal.container.appendChild(child);
+    expect(portal.container.querySelector("p")?.textContent).toBe("hello");
+    portal.unmount();
+  });
+
+  it("removes the container from the DOM on unmount", () => {
+    const portal = createPortal();
+    portal.unmount();
+    expect(portal.container.parentElement).toBeNull();
+  });
+
+  it("is idempotent — calling unmount twice does not throw", () => {
+    const portal = createPortal();
+    portal.unmount();
+    expect(() => {
+      portal.unmount();
+    }).not.toThrow();
+  });
+
+  it("supports independent stacked portals", () => {
+    const a = createPortal();
+    const b = createPortal();
+    expect(a.container.parentElement).toBe(document.body);
+    expect(b.container.parentElement).toBe(document.body);
+    expect(document.body.children.length).toBe(2);
+    a.unmount();
+    expect(document.body.children.length).toBe(1);
+    expect(b.container.parentElement).toBe(document.body);
+    b.unmount();
+  });
+});

--- a/packages/primitives/src/portal/index.test.ts
+++ b/packages/primitives/src/portal/index.test.ts
@@ -59,6 +59,18 @@ describe("createPortal", () => {
     }
   });
 
+  it("creates the default container in the target's ownerDocument", () => {
+    // A target from a different Document (iframe-like) yields a container
+    // that belongs to that document, not the surrounding one.
+    const otherDoc = document.implementation.createHTMLDocument();
+    const otherBody = otherDoc.body;
+    if (!otherBody) throw new Error("createHTMLDocument did not produce a body");
+    const portal = createPortal({ target: otherBody });
+    expect(portal.container.ownerDocument).toBe(otherDoc);
+    expect(portal.container.parentNode).toBe(otherBody);
+    portal.unmount();
+  });
+
   it("hosts arbitrary content appended to the container", () => {
     const portal = createPortal();
     const child = document.createElement("p");

--- a/packages/primitives/src/portal/index.test.ts
+++ b/packages/primitives/src/portal/index.test.ts
@@ -32,6 +32,33 @@ describe("createPortal", () => {
     portal.unmount();
   });
 
+  it("attaches to a DocumentFragment target", () => {
+    const fragment = document.createDocumentFragment();
+    const portal = createPortal({ target: fragment });
+    expect(portal.container.parentNode).toBe(fragment);
+    portal.unmount();
+  });
+
+  it("attaches to a ShadowRoot target", () => {
+    const host = document.createElement("div");
+    document.body.appendChild(host);
+    const shadow = host.attachShadow({ mode: "open" });
+    const portal = createPortal({ target: shadow });
+    expect(portal.container.parentNode).toBe(shadow);
+    portal.unmount();
+    host.remove();
+  });
+
+  it("throws a clear error when no target is given and document.body is unavailable", () => {
+    const original = document.body;
+    original.remove();
+    try {
+      expect(() => createPortal()).toThrow(/unavailable/);
+    } finally {
+      document.documentElement.appendChild(original);
+    }
+  });
+
   it("hosts arbitrary content appended to the container", () => {
     const portal = createPortal();
     const child = document.createElement("p");

--- a/packages/primitives/src/portal/index.ts
+++ b/packages/primitives/src/portal/index.ts
@@ -1,0 +1,40 @@
+// Appends a container to a target node so content can render outside its
+// natural DOM hierarchy. Vanilla DOM only — React consumers use
+// `createPortal` from `react-dom`; Vue consumers use the built-in
+// `<Teleport>`. This vanilla layer exists for `@teseor/webc` and plain-DOM
+// consumers (Astro islands, server-rendered pages, etc.).
+
+export type PortalOptions = {
+  /** Where to attach the portal container. Default: `document.body`. */
+  target?: HTMLElement;
+  /** Use this element as the portal container instead of creating a fresh `<div>`. */
+  container?: HTMLElement;
+};
+
+export type Portal = {
+  /** The element holding portal contents. Append your nodes here. */
+  container: HTMLElement;
+  /** Detaches and removes the container from the DOM. Idempotent. */
+  unmount: () => void;
+};
+
+/**
+ * Creates a DOM container and attaches it to `target` (default
+ * `document.body`). Returns the container plus an `unmount` cleanup. If
+ * `container` is provided it is used as-is; otherwise a fresh `<div>` is
+ * created. Calling `unmount` more than once is a no-op.
+ */
+export function createPortal(options: PortalOptions = {}): Portal {
+  const target = options.target ?? document.body;
+  const container = options.container ?? document.createElement("div");
+  target.appendChild(container);
+  let mounted = true;
+  return {
+    container,
+    unmount(): void {
+      if (!mounted) return;
+      container.remove();
+      mounted = false;
+    },
+  };
+}

--- a/packages/primitives/src/portal/index.ts
+++ b/packages/primitives/src/portal/index.ts
@@ -5,8 +5,10 @@
 // consumers (Astro islands, server-rendered pages, etc.).
 
 export type PortalOptions = {
-  /** Where to attach the portal container. Default: `document.body`. */
-  target?: HTMLElement;
+  /** Where to attach the portal container. Default: `document.body`.
+   *  Accepts any append-capable parent — `Element`, `ShadowRoot`,
+   *  `DocumentFragment`. */
+  target?: Element | DocumentFragment;
   /** Use this element as the portal container instead of creating a fresh `<div>`. */
   container?: HTMLElement;
 };
@@ -18,14 +20,28 @@ export type Portal = {
   unmount: () => void;
 };
 
+function resolveTarget(
+  explicit: Element | DocumentFragment | undefined,
+): Element | DocumentFragment {
+  if (explicit) return explicit;
+  // `document.body` is typed `HTMLElement` but can be null at runtime — early
+  // scripts loaded before `<body>`, non-browser DOM contexts, certain test
+  // harnesses. Throw a clear message instead of letting `appendChild` blow up.
+  if (typeof document === "undefined" || !document.body) {
+    throw new Error("createPortal: no `target` provided and `document.body` is unavailable");
+  }
+  return document.body;
+}
+
 /**
  * Creates a DOM container and attaches it to `target` (default
  * `document.body`). Returns the container plus an `unmount` cleanup. If
  * `container` is provided it is used as-is; otherwise a fresh `<div>` is
- * created. Calling `unmount` more than once is a no-op.
+ * created. Calling `unmount` more than once is a no-op. Throws if no
+ * explicit target is given and `document.body` is unavailable.
  */
 export function createPortal(options: PortalOptions = {}): Portal {
-  const target = options.target ?? document.body;
+  const target = resolveTarget(options.target);
   const container = options.container ?? document.createElement("div");
   target.appendChild(container);
   let mounted = true;

--- a/packages/primitives/src/portal/index.ts
+++ b/packages/primitives/src/portal/index.ts
@@ -37,12 +37,29 @@ function resolveTarget(
  * Creates a DOM container and attaches it to `target` (default
  * `document.body`). Returns the container plus an `unmount` cleanup. If
  * `container` is provided it is used as-is; otherwise a fresh `<div>` is
- * created. Calling `unmount` more than once is a no-op. Throws if no
- * explicit target is given and `document.body` is unavailable.
+ * created in the target's `ownerDocument` (so a target inside an iframe
+ * yields a container belonging to that iframe's document). Calling
+ * `unmount` more than once is a no-op. Throws when no explicit target is
+ * given and `document.body` is unavailable, or when a default container
+ * is needed but the target has no `ownerDocument`.
  */
 export function createPortal(options: PortalOptions = {}): Portal {
   const target = resolveTarget(options.target);
-  const container = options.container ?? document.createElement("div");
+  let container: HTMLElement;
+  if (options.container) {
+    container = options.container;
+  } else {
+    // Use the target's ownerDocument so a portal placed in an iframe's DOM
+    // gets a container that belongs to that iframe — `document.createElement`
+    // here would silently cross documents.
+    const doc = target.ownerDocument;
+    if (!doc) {
+      throw new Error(
+        "createPortal: target has no `ownerDocument` and no `container` was provided",
+      );
+    }
+    container = doc.createElement("div");
+  }
   target.appendChild(container);
   let mounted = true;
   return {


### PR DESCRIPTION
Closes #654 (portal checkbox).

## What

Adds `createPortal({ target, container })` to `@teseor/primitives` — appends a container to a target node so content can render outside its natural DOM hierarchy. Defaults to a fresh `<div>` inside `document.body`. `target` accepts any append-capable parent (`Element`, `ShadowRoot`, `DocumentFragment`). The default container is created in the target's `ownerDocument` so a target inside an iframe yields a container belonging to that iframe's document. Returns the container plus an idempotent `unmount` cleanup. 10 happy-dom unit cases cover the defaults, custom target and container, ShadowRoot + DocumentFragment targets, cross-document creation, content hosting, unmount removal, double-unmount safety, independent stacked portals, and a clear-error throw when `document.body` is unavailable.

Exported from `@teseor/primitives` (vanilla). No `/react` or `/vue` sub-path export — see "Why" below.

## Why

Tooltip and Popover need to escape parent stacking and overflow contexts, and `@teseor/webc` and plain-DOM consumers don't have a framework `<Teleport>` or `react-dom.createPortal` to lean on. A vanilla helper that just does "append here, give me a cleanup" is the smallest surface that closes that gap.

No React or Vue adapter ships in this PR by design: React's `createPortal` from `react-dom` already covers the entire React side, and Vue's built-in `<Teleport>` is the idiomatic Vue API. Re-exporting either of those from `@teseor/primitives` adds nothing but visual symmetry. The JSDoc on the vanilla function points framework consumers at their built-ins.

## Test plan

- 10 happy-dom unit cases in `portal/index.test.ts`.
- `pnpm lint && pnpm typecheck && pnpm test` green locally; pre-push gates green.

## Out of scope

- Dismissable-layer and anchor positioning — last two boxes on #654, one PR each (dismissable-layer is up in #657).
- React or Vue portal adapters (see "Why").
