### PR TITLE
feat(primitives): dismissable-layer

### DIFF
--- a/.changeset/654-primitives-dismissable.md
+++ b/.changeset/654-primitives-dismissable.md
@@ -1,0 +1,5 @@
+---
+"@teseor/primitives": minor
+---
+
+Add the `dismissable-layer` primitive — fires `onEscapeKeyDown` and `onPointerDownOutside` callbacks so an overlay's owner can dismiss it. Layers stack: Escape fires on the topmost layer only (one tap closes one layer); pointer-down-outside fires on every layer whose element does not contain the click target (a click outside a Popover-inside-a-Modal closes both). Vanilla `createDismissableLayer` + React `useDismissableLayer` + Vue `useDismissableLayer`, all built on a shared stack. The primitive only notifies — the consumer owns the `open` state.

--- a/packages/primitives/src/dismissable-layer/index.test.ts
+++ b/packages/primitives/src/dismissable-layer/index.test.ts
@@ -1,0 +1,200 @@
+// @vitest-environment happy-dom
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createDismissableLayer } from "./index.ts";
+
+function makeContainer(html: string): HTMLElement {
+  document.body.innerHTML = html;
+  const container = document.getElementById("container");
+  if (!container) throw new Error("container missing");
+  return container;
+}
+
+function getEl(id: string): HTMLElement {
+  const el = document.getElementById(id);
+  if (!el) throw new Error(`#${id} missing`);
+  return el;
+}
+
+function pressEscape(): void {
+  document.dispatchEvent(
+    new KeyboardEvent("keydown", { key: "Escape", bubbles: true, cancelable: true }),
+  );
+}
+
+function pointerDownOn(target: HTMLElement): void {
+  target.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true, cancelable: true }));
+}
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("createDismissableLayer", () => {
+  it("fires onEscapeKeyDown when Escape is pressed", () => {
+    const c = makeContainer(`<div id="container"></div>`);
+    const onEscapeKeyDown = vi.fn();
+    const layer = createDismissableLayer(c, { onEscapeKeyDown });
+    pressEscape();
+    expect(onEscapeKeyDown).toHaveBeenCalledTimes(1);
+    layer.destroy();
+  });
+
+  it("ignores keys other than Escape", () => {
+    const c = makeContainer(`<div id="container"></div>`);
+    const onEscapeKeyDown = vi.fn();
+    const layer = createDismissableLayer(c, { onEscapeKeyDown });
+    document.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+    expect(onEscapeKeyDown).not.toHaveBeenCalled();
+    layer.destroy();
+  });
+
+  it("fires onPointerDownOutside when a pointerdown lands outside the layer", () => {
+    makeContainer(`
+      <div>
+        <button id="outside">O</button>
+        <div id="container">
+          <button id="inside">I</button>
+        </div>
+      </div>
+    `);
+    const onPointerDownOutside = vi.fn();
+    const layer = createDismissableLayer(getEl("container"), { onPointerDownOutside });
+    pointerDownOn(getEl("outside"));
+    expect(onPointerDownOutside).toHaveBeenCalledTimes(1);
+    layer.destroy();
+  });
+
+  it("does not fire onPointerDownOutside for pointerdowns inside the layer", () => {
+    makeContainer(`
+      <div id="container">
+        <button id="inside">I</button>
+      </div>
+    `);
+    const onPointerDownOutside = vi.fn();
+    const layer = createDismissableLayer(getEl("container"), { onPointerDownOutside });
+    pointerDownOn(getEl("inside"));
+    expect(onPointerDownOutside).not.toHaveBeenCalled();
+    layer.destroy();
+  });
+
+  it("fires onInteractOutside alongside onPointerDownOutside", () => {
+    makeContainer(`
+      <div>
+        <button id="outside">O</button>
+        <div id="container"></div>
+      </div>
+    `);
+    const onPointerDownOutside = vi.fn();
+    const onInteractOutside = vi.fn();
+    const layer = createDismissableLayer(getEl("container"), {
+      onPointerDownOutside,
+      onInteractOutside,
+    });
+    pointerDownOn(getEl("outside"));
+    expect(onPointerDownOutside).toHaveBeenCalledTimes(1);
+    expect(onInteractOutside).toHaveBeenCalledTimes(1);
+    layer.destroy();
+  });
+
+  it("routes Escape to the topmost layer only", () => {
+    document.body.innerHTML = `
+      <div id="outer"></div>
+      <div id="inner"></div>
+    `;
+    const onOuter = vi.fn();
+    const onInner = vi.fn();
+    const outer = createDismissableLayer(getEl("outer"), { onEscapeKeyDown: onOuter });
+    const inner = createDismissableLayer(getEl("inner"), { onEscapeKeyDown: onInner });
+    pressEscape();
+    expect(onInner).toHaveBeenCalledTimes(1);
+    expect(onOuter).not.toHaveBeenCalled();
+    inner.destroy();
+    pressEscape();
+    expect(onOuter).toHaveBeenCalledTimes(1);
+    outer.destroy();
+  });
+
+  it("fires onPointerDownOutside on every layer whose element does not contain the target", () => {
+    // Click outside both stacked layers → both fire.
+    document.body.innerHTML = `
+      <button id="outside">O</button>
+      <div id="outer"></div>
+      <div id="inner"></div>
+    `;
+    const onOuter = vi.fn();
+    const onInner = vi.fn();
+    const outer = createDismissableLayer(getEl("outer"), { onPointerDownOutside: onOuter });
+    const inner = createDismissableLayer(getEl("inner"), { onPointerDownOutside: onInner });
+    pointerDownOn(getEl("outside"));
+    expect(onOuter).toHaveBeenCalledTimes(1);
+    expect(onInner).toHaveBeenCalledTimes(1);
+    outer.destroy();
+    inner.destroy();
+  });
+
+  it("fires only on the inner layer when the click lands inside the outer but outside the inner", () => {
+    document.body.innerHTML = `
+      <div id="outer">
+        <button id="inside-outer">X</button>
+        <div id="inner"></div>
+      </div>
+    `;
+    const onOuter = vi.fn();
+    const onInner = vi.fn();
+    const outer = createDismissableLayer(getEl("outer"), { onPointerDownOutside: onOuter });
+    const inner = createDismissableLayer(getEl("inner"), { onPointerDownOutside: onInner });
+    pointerDownOn(getEl("inside-outer"));
+    expect(onInner).toHaveBeenCalledTimes(1);
+    expect(onOuter).not.toHaveBeenCalled();
+    outer.destroy();
+    inner.destroy();
+  });
+
+  it("survives a callback that destroys a layer mid-iteration", () => {
+    document.body.innerHTML = `
+      <button id="outside">O</button>
+      <div id="a"></div>
+      <div id="b"></div>
+    `;
+    const onA = vi.fn();
+    const aLayer = createDismissableLayer(getEl("a"), {
+      onPointerDownOutside: () => {
+        onA();
+        aLayer.destroy();
+      },
+    });
+    const onB = vi.fn();
+    const bLayer = createDismissableLayer(getEl("b"), { onPointerDownOutside: onB });
+    pointerDownOn(getEl("outside"));
+    expect(onA).toHaveBeenCalledTimes(1);
+    expect(onB).toHaveBeenCalledTimes(1);
+    bLayer.destroy();
+  });
+
+  it("destroy is idempotent", () => {
+    const c = makeContainer(`<div id="container"></div>`);
+    const onEscapeKeyDown = vi.fn();
+    const layer = createDismissableLayer(c, { onEscapeKeyDown });
+    layer.destroy();
+    expect(() => {
+      layer.destroy();
+    }).not.toThrow();
+    pressEscape();
+    expect(onEscapeKeyDown).not.toHaveBeenCalled();
+  });
+
+  it("detaches global listeners when the stack empties", () => {
+    const c = makeContainer(`<div id="container"></div>`);
+    const onEscapeKeyDown = vi.fn();
+    const layer = createDismissableLayer(c, { onEscapeKeyDown });
+    layer.destroy();
+    // After destroy, no live layer should receive events.
+    pressEscape();
+    expect(onEscapeKeyDown).not.toHaveBeenCalled();
+    // And a fresh layer starts clean.
+    const layer2 = createDismissableLayer(c, { onEscapeKeyDown });
+    pressEscape();
+    expect(onEscapeKeyDown).toHaveBeenCalledTimes(1);
+    layer2.destroy();
+  });
+});

--- a/packages/primitives/src/dismissable-layer/index.test.ts
+++ b/packages/primitives/src/dismissable-layer/index.test.ts
@@ -77,6 +77,28 @@ describe("createDismissableLayer", () => {
     layer.destroy();
   });
 
+  it("does not misclassify Shadow DOM clicks as outside (uses composedPath)", () => {
+    // A layer rendered inside a shadow root receives clicks whose event.target
+    // is retargeted to the shadow host at document level. composedPath()
+    // exposes the real path; element.contains(retargetedTarget) would lie.
+    const host = document.createElement("div");
+    document.body.appendChild(host);
+    const shadow = host.attachShadow({ mode: "open" });
+    const layer = document.createElement("div");
+    const inside = document.createElement("button");
+    inside.id = "shadow-inside";
+    layer.appendChild(inside);
+    shadow.appendChild(layer);
+    const onPointerDownOutside = vi.fn();
+    const subscription = createDismissableLayer(layer, { onPointerDownOutside });
+    inside.dispatchEvent(
+      new PointerEvent("pointerdown", { bubbles: true, composed: true, cancelable: true }),
+    );
+    expect(onPointerDownOutside).not.toHaveBeenCalled();
+    subscription.destroy();
+    host.remove();
+  });
+
   it("fires onInteractOutside alongside onPointerDownOutside", () => {
     makeContainer(`
       <div>

--- a/packages/primitives/src/dismissable-layer/index.test.ts
+++ b/packages/primitives/src/dismissable-layer/index.test.ts
@@ -219,4 +219,36 @@ describe("createDismissableLayer", () => {
     expect(onEscapeKeyDown).toHaveBeenCalledTimes(1);
     layer2.destroy();
   });
+
+  it("scopes stack and listeners per ownerDocument", () => {
+    // A layer in another document (iframe-like) is isolated: events in the
+    // main document don't fire its callbacks, and events in its own document
+    // don't fire callbacks for layers in the main document.
+    const otherDoc = document.implementation.createHTMLDocument();
+    if (!otherDoc.body) throw new Error("createHTMLDocument did not produce a body");
+    const otherEl = otherDoc.createElement("div");
+    otherDoc.body.appendChild(otherEl);
+
+    const mainEl = document.createElement("div");
+    document.body.appendChild(mainEl);
+
+    const onMain = vi.fn();
+    const onOther = vi.fn();
+    const mainLayer = createDismissableLayer(mainEl, { onEscapeKeyDown: onMain });
+    const otherLayer = createDismissableLayer(otherEl, { onEscapeKeyDown: onOther });
+
+    // Escape in the main document → only main fires.
+    document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    expect(onMain).toHaveBeenCalledTimes(1);
+    expect(onOther).not.toHaveBeenCalled();
+
+    // Escape in the other document → only other fires.
+    otherDoc.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    expect(onMain).toHaveBeenCalledTimes(1);
+    expect(onOther).toHaveBeenCalledTimes(1);
+
+    mainLayer.destroy();
+    otherLayer.destroy();
+    mainEl.remove();
+  });
 });

--- a/packages/primitives/src/dismissable-layer/index.ts
+++ b/packages/primitives/src/dismissable-layer/index.ts
@@ -7,13 +7,19 @@
 // This primitive only notifies. State management is the consumer's job —
 // the callback is where the consumer sets `open = false` or equivalent.
 
+/** Event seen by `onInteractOutside`. Currently a `PointerEvent`; widens to
+ *  a union as additional outside-channels (focus, etc.) ship. Exported so
+ *  consumers can name the type without binding to today's narrow shape. */
+export type InteractOutsideEvent = PointerEvent;
+
 export type DismissableLayerOptions = {
   /** Fires when Escape is pressed while this is the topmost layer. */
   onEscapeKeyDown?: (event: KeyboardEvent) => void;
   /** Fires when a pointer-down lands outside this layer's element. */
   onPointerDownOutside?: (event: PointerEvent) => void;
-  /** Convenience: fires alongside any outside-pointer event. */
-  onInteractOutside?: (event: PointerEvent) => void;
+  /** Convenience: fires alongside every outside-pointer event today; will
+   *  also cover focus-outside and any future channels as they're added. */
+  onInteractOutside?: (event: InteractOutsideEvent) => void;
 };
 
 export type DismissableLayer = {

--- a/packages/primitives/src/dismissable-layer/index.ts
+++ b/packages/primitives/src/dismissable-layer/index.ts
@@ -42,13 +42,16 @@ function handleKeyDown(event: KeyboardEvent): void {
 }
 
 function handlePointerDown(event: PointerEvent): void {
-  const target = event.target;
-  if (!(target instanceof Node)) return;
+  // composedPath() crosses Shadow DOM boundaries — event.target is retargeted
+  // to the shadow host for listeners on document, so contains() would
+  // misclassify a click inside a shadow-rooted layer as outside.
+  const path = event.composedPath();
+  if (path.length === 0) return;
   // Snapshot so a callback that destroys a layer doesn't perturb iteration.
   const snapshot = [...stack];
   for (const layer of snapshot) {
     if (layer.destroyed) continue;
-    if (layer.element.contains(target)) continue;
+    if (path.includes(layer.element)) continue;
     layer.options.onPointerDownOutside?.(event);
     layer.options.onInteractOutside?.(event);
   }

--- a/packages/primitives/src/dismissable-layer/index.ts
+++ b/packages/primitives/src/dismissable-layer/index.ts
@@ -4,6 +4,9 @@
 // fires on every layer whose element does not contain the click target
 // (one click outside a Popover-in-a-Modal closes both).
 //
+// Stacks and global listeners are scoped per `element.ownerDocument`, so an
+// iframe-rendered layer is isolated from layers in the host document.
+//
 // This primitive only notifies. State management is the consumer's job —
 // the callback is where the consumer sets `open = false` or equivalent.
 
@@ -32,50 +35,76 @@ type LayerInstance = {
   destroyed: boolean;
 };
 
-const stack: LayerInstance[] = [];
+type DocStack = {
+  layers: LayerInstance[];
+  keyDown: (event: KeyboardEvent) => void;
+  pointerDown: (event: PointerEvent) => void;
+};
 
-function handleKeyDown(event: KeyboardEvent): void {
-  if (event.key !== "Escape") return;
-  const top = stack[stack.length - 1];
-  if (!top) return;
-  top.options.onEscapeKeyDown?.(event);
+// One stack + listener pair per document. A consumer rendering layers in an
+// iframe gets a separate stack from the host page; events don't cross.
+const stacks: Map<Document, DocStack> = new Map();
+
+function getOrCreateStack(doc: Document): DocStack {
+  const existing = stacks.get(doc);
+  if (existing) return existing;
+
+  const keyDown = (event: KeyboardEvent): void => {
+    if (event.key !== "Escape") return;
+    const s = stacks.get(doc);
+    if (!s) return;
+    const top = s.layers[s.layers.length - 1];
+    if (!top) return;
+    top.options.onEscapeKeyDown?.(event);
+  };
+
+  const pointerDown = (event: PointerEvent): void => {
+    // composedPath() crosses Shadow DOM boundaries — event.target is retargeted
+    // to the shadow host for listeners on document, so contains() would
+    // misclassify a click inside a shadow-rooted layer as outside.
+    const path = event.composedPath();
+    if (path.length === 0) return;
+    const s = stacks.get(doc);
+    if (!s) return;
+    // Snapshot so a callback that destroys a layer doesn't perturb iteration.
+    const snapshot = [...s.layers];
+    for (const layer of snapshot) {
+      if (layer.destroyed) continue;
+      if (path.includes(layer.element)) continue;
+      layer.options.onPointerDownOutside?.(event);
+      layer.options.onInteractOutside?.(event);
+    }
+  };
+
+  const stack: DocStack = { layers: [], keyDown, pointerDown };
+  stacks.set(doc, stack);
+  return stack;
 }
 
-function handlePointerDown(event: PointerEvent): void {
-  // composedPath() crosses Shadow DOM boundaries — event.target is retargeted
-  // to the shadow host for listeners on document, so contains() would
-  // misclassify a click inside a shadow-rooted layer as outside.
-  const path = event.composedPath();
-  if (path.length === 0) return;
-  // Snapshot so a callback that destroys a layer doesn't perturb iteration.
-  const snapshot = [...stack];
-  for (const layer of snapshot) {
-    if (layer.destroyed) continue;
-    if (path.includes(layer.element)) continue;
-    layer.options.onPointerDownOutside?.(event);
-    layer.options.onInteractOutside?.(event);
-  }
-}
-
-function ensureGlobalListeners(): void {
-  if (stack.length !== 1) return;
+function attachListenersIfFirst(doc: Document, stack: DocStack): void {
+  if (stack.layers.length !== 1) return;
   // Capture phase on both: a component inside the layer that calls
   // `stopPropagation()` on Escape or pointerdown must not suppress dismissal.
   // Matches focus-trap's capture-phase listener pattern.
-  document.addEventListener("keydown", handleKeyDown, true);
-  document.addEventListener("pointerdown", handlePointerDown, true);
+  doc.addEventListener("keydown", stack.keyDown, true);
+  doc.addEventListener("pointerdown", stack.pointerDown, true);
 }
 
-function teardownGlobalListenersIfEmpty(): void {
-  if (stack.length !== 0) return;
-  document.removeEventListener("keydown", handleKeyDown, true);
-  document.removeEventListener("pointerdown", handlePointerDown, true);
+function detachListenersIfEmpty(doc: Document, stack: DocStack): void {
+  if (stack.layers.length !== 0) return;
+  doc.removeEventListener("keydown", stack.keyDown, true);
+  doc.removeEventListener("pointerdown", stack.pointerDown, true);
+  stacks.delete(doc);
 }
 
 /**
  * Subscribes a dismiss-notifying layer for `element`. Returns `{ destroy }`
- * which removes the layer from the stack and detaches global listeners when
- * the stack empties. `destroy` is idempotent.
+ * which removes the layer from its document's stack and detaches that
+ * document's listeners when the stack empties. `destroy` is idempotent.
+ *
+ * Throws when `element.ownerDocument` is unavailable (SSR / non-browser /
+ * detached element) so consumers get a deterministic error instead of a
+ * bare `ReferenceError`.
  *
  * The layer does not close itself — wire the callbacks to whatever state
  * controls the overlay's visibility.
@@ -84,17 +113,24 @@ export function createDismissableLayer(
   element: HTMLElement,
   options: DismissableLayerOptions = {},
 ): DismissableLayer {
+  const doc = element.ownerDocument;
+  if (!doc) {
+    throw new Error(
+      "createDismissableLayer: `element.ownerDocument` is unavailable — primitives need a live DOM",
+    );
+  }
+  const stack = getOrCreateStack(doc);
   const instance: LayerInstance = { element, options, destroyed: false };
-  stack.push(instance);
-  ensureGlobalListeners();
+  stack.layers.push(instance);
+  attachListenersIfFirst(doc, stack);
 
   return {
     destroy(): void {
       if (instance.destroyed) return;
       instance.destroyed = true;
-      const index = stack.indexOf(instance);
-      if (index !== -1) stack.splice(index, 1);
-      teardownGlobalListenersIfEmpty();
+      const index = stack.layers.indexOf(instance);
+      if (index !== -1) stack.layers.splice(index, 1);
+      detachListenersIfEmpty(doc, stack);
     },
   };
 }

--- a/packages/primitives/src/dismissable-layer/index.ts
+++ b/packages/primitives/src/dismissable-layer/index.ts
@@ -50,13 +50,16 @@ function handlePointerDown(event: PointerEvent): void {
 
 function ensureGlobalListeners(): void {
   if (stack.length !== 1) return;
-  document.addEventListener("keydown", handleKeyDown);
+  // Capture phase on both: a component inside the layer that calls
+  // `stopPropagation()` on Escape or pointerdown must not suppress dismissal.
+  // Matches focus-trap's capture-phase listener pattern.
+  document.addEventListener("keydown", handleKeyDown, true);
   document.addEventListener("pointerdown", handlePointerDown, true);
 }
 
 function teardownGlobalListenersIfEmpty(): void {
   if (stack.length !== 0) return;
-  document.removeEventListener("keydown", handleKeyDown);
+  document.removeEventListener("keydown", handleKeyDown, true);
   document.removeEventListener("pointerdown", handlePointerDown, true);
 }
 

--- a/packages/primitives/src/dismissable-layer/index.ts
+++ b/packages/primitives/src/dismissable-layer/index.ts
@@ -1,0 +1,88 @@
+// Notifies an overlay's owner that the user wants to dismiss it: Escape key,
+// or a pointer-down outside its element. Layers stack — `Escape` fires only
+// on the topmost layer (one tap closes one layer); pointer-down-outside
+// fires on every layer whose element does not contain the click target
+// (one click outside a Popover-in-a-Modal closes both).
+//
+// This primitive only notifies. State management is the consumer's job —
+// the callback is where the consumer sets `open = false` or equivalent.
+
+export type DismissableLayerOptions = {
+  /** Fires when Escape is pressed while this is the topmost layer. */
+  onEscapeKeyDown?: (event: KeyboardEvent) => void;
+  /** Fires when a pointer-down lands outside this layer's element. */
+  onPointerDownOutside?: (event: PointerEvent) => void;
+  /** Convenience: fires alongside any outside-pointer event. */
+  onInteractOutside?: (event: PointerEvent) => void;
+};
+
+export type DismissableLayer = {
+  destroy: () => void;
+};
+
+type LayerInstance = {
+  element: HTMLElement;
+  options: DismissableLayerOptions;
+  destroyed: boolean;
+};
+
+const stack: LayerInstance[] = [];
+
+function handleKeyDown(event: KeyboardEvent): void {
+  if (event.key !== "Escape") return;
+  const top = stack[stack.length - 1];
+  if (!top) return;
+  top.options.onEscapeKeyDown?.(event);
+}
+
+function handlePointerDown(event: PointerEvent): void {
+  const target = event.target;
+  if (!(target instanceof Node)) return;
+  // Snapshot so a callback that destroys a layer doesn't perturb iteration.
+  const snapshot = [...stack];
+  for (const layer of snapshot) {
+    if (layer.destroyed) continue;
+    if (layer.element.contains(target)) continue;
+    layer.options.onPointerDownOutside?.(event);
+    layer.options.onInteractOutside?.(event);
+  }
+}
+
+function ensureGlobalListeners(): void {
+  if (stack.length !== 1) return;
+  document.addEventListener("keydown", handleKeyDown);
+  document.addEventListener("pointerdown", handlePointerDown, true);
+}
+
+function teardownGlobalListenersIfEmpty(): void {
+  if (stack.length !== 0) return;
+  document.removeEventListener("keydown", handleKeyDown);
+  document.removeEventListener("pointerdown", handlePointerDown, true);
+}
+
+/**
+ * Subscribes a dismiss-notifying layer for `element`. Returns `{ destroy }`
+ * which removes the layer from the stack and detaches global listeners when
+ * the stack empties. `destroy` is idempotent.
+ *
+ * The layer does not close itself — wire the callbacks to whatever state
+ * controls the overlay's visibility.
+ */
+export function createDismissableLayer(
+  element: HTMLElement,
+  options: DismissableLayerOptions = {},
+): DismissableLayer {
+  const instance: LayerInstance = { element, options, destroyed: false };
+  stack.push(instance);
+  ensureGlobalListeners();
+
+  return {
+    destroy(): void {
+      if (instance.destroyed) return;
+      instance.destroyed = true;
+      const index = stack.indexOf(instance);
+      if (index !== -1) stack.splice(index, 1);
+      teardownGlobalListenersIfEmpty();
+    },
+  };
+}

--- a/packages/primitives/src/dismissable-layer/react.test.tsx
+++ b/packages/primitives/src/dismissable-layer/react.test.tsx
@@ -7,13 +7,13 @@ import { useDismissableLayer } from "./react.ts";
 let mountTarget: HTMLDivElement;
 let root: Root;
 
-type TrapProps = {
+type LayerProps = {
   active: boolean;
   onEscapeKeyDown?: (event: KeyboardEvent) => void;
   onPointerDownOutside?: (event: PointerEvent) => void;
 };
 
-function Layer(props: TrapProps) {
+function Layer(props: LayerProps) {
   const [element, setElement] = useState<HTMLElement | null>(null);
   useDismissableLayer(element, props.active, {
     onEscapeKeyDown: props.onEscapeKeyDown,
@@ -26,7 +26,7 @@ function Layer(props: TrapProps) {
   );
 }
 
-function render(props: TrapProps): void {
+function render(props: LayerProps): void {
   act(() => {
     root.render(<Layer {...props} />);
   });

--- a/packages/primitives/src/dismissable-layer/react.test.tsx
+++ b/packages/primitives/src/dismissable-layer/react.test.tsx
@@ -1,0 +1,78 @@
+// @vitest-environment happy-dom
+import { act, useState } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useDismissableLayer } from "./react.ts";
+
+let mountTarget: HTMLDivElement;
+let root: Root;
+
+type TrapProps = {
+  active: boolean;
+  onEscapeKeyDown?: (event: KeyboardEvent) => void;
+  onPointerDownOutside?: (event: PointerEvent) => void;
+};
+
+function Layer(props: TrapProps) {
+  const [element, setElement] = useState<HTMLElement | null>(null);
+  useDismissableLayer(element, props.active, {
+    onEscapeKeyDown: props.onEscapeKeyDown,
+    onPointerDownOutside: props.onPointerDownOutside,
+  });
+  return (
+    <div ref={setElement} id="layer">
+      inside
+    </div>
+  );
+}
+
+function render(props: TrapProps): void {
+  act(() => {
+    root.render(<Layer {...props} />);
+  });
+}
+
+beforeEach(() => {
+  mountTarget = document.createElement("div");
+  document.body.appendChild(mountTarget);
+  root = createRoot(mountTarget);
+});
+
+afterEach(() => {
+  act(() => {
+    root.unmount();
+  });
+  mountTarget.remove();
+  document.body.innerHTML = "";
+});
+
+describe("useDismissableLayer (react)", () => {
+  it("fires onEscapeKeyDown when active", () => {
+    const onEscapeKeyDown = vi.fn();
+    render({ active: true, onEscapeKeyDown });
+    document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    expect(onEscapeKeyDown).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not subscribe when active is false", () => {
+    const onEscapeKeyDown = vi.fn();
+    render({ active: false, onEscapeKeyDown });
+    document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    expect(onEscapeKeyDown).not.toHaveBeenCalled();
+  });
+
+  it("fires onPointerDownOutside for clicks outside the element", () => {
+    const onPointerDownOutside = vi.fn();
+    render({ active: true, onPointerDownOutside });
+    document.body.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true }));
+    expect(onPointerDownOutside).toHaveBeenCalledTimes(1);
+  });
+
+  it("unsubscribes when active flips to false", () => {
+    const onEscapeKeyDown = vi.fn();
+    render({ active: true, onEscapeKeyDown });
+    render({ active: false, onEscapeKeyDown });
+    document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    expect(onEscapeKeyDown).not.toHaveBeenCalled();
+  });
+});

--- a/packages/primitives/src/dismissable-layer/react.ts
+++ b/packages/primitives/src/dismissable-layer/react.ts
@@ -1,0 +1,35 @@
+import { useEffect, useRef } from "react";
+import { createDismissableLayer, type DismissableLayerOptions } from "./index.ts";
+
+/**
+ * React adapter for {@link createDismissableLayer}.
+ *
+ * While `active` is true and `element` is non-null, a dismiss-notifying
+ * layer is subscribed. Pass the element directly (e.g. from a state-driven
+ * callback ref, `useState<HTMLElement | null>(null)` plus `ref={setEl}`) so
+ * the effect re-runs when the element itself changes; a `RefObject` is
+ * stable across renders and silently skips element swaps.
+ *
+ * Callbacks are read through a stable ref so a fresh inline `{ onEscapeKeyDown,
+ * ... }` object on every render does not destroy and re-subscribe the layer.
+ */
+export function useDismissableLayer(
+  element: HTMLElement | null,
+  active: boolean,
+  options: DismissableLayerOptions = {},
+): void {
+  const optionsRef = useRef(options);
+  optionsRef.current = options;
+
+  useEffect(() => {
+    if (!active || !element) return;
+    const layer = createDismissableLayer(element, {
+      onEscapeKeyDown: (event) => optionsRef.current.onEscapeKeyDown?.(event),
+      onPointerDownOutside: (event) => optionsRef.current.onPointerDownOutside?.(event),
+      onInteractOutside: (event) => optionsRef.current.onInteractOutside?.(event),
+    });
+    return () => {
+      layer.destroy();
+    };
+  }, [active, element]);
+}

--- a/packages/primitives/src/dismissable-layer/vue.test.ts
+++ b/packages/primitives/src/dismissable-layer/vue.test.ts
@@ -1,0 +1,85 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { type App, createApp, defineComponent, h, nextTick, type Ref, ref } from "vue";
+import { useDismissableLayer } from "./vue.ts";
+
+let mountTarget: HTMLDivElement;
+let app: App | null = null;
+
+type Opts = {
+  onEscapeKeyDown?: () => void;
+  onPointerDownOutside?: () => void;
+};
+
+function mountLayer(initial: boolean, opts: Opts = {}): Ref<boolean> {
+  const active = ref(initial);
+  const elementRef = ref<HTMLElement | null>(null);
+  const Layer = defineComponent({
+    setup() {
+      // biome-ignore lint/correctness/useHookAtTopLevel: vue composable inside setup(), not a react hook
+      useDismissableLayer(elementRef, active, opts);
+      return () =>
+        h(
+          "div",
+          {
+            id: "layer",
+            ref: (el: unknown) => {
+              elementRef.value = el instanceof HTMLElement ? el : null;
+            },
+          },
+          "inside",
+        );
+    },
+  });
+  app = createApp(Layer);
+  app.mount(mountTarget);
+  return active;
+}
+
+beforeEach(() => {
+  mountTarget = document.createElement("div");
+  document.body.appendChild(mountTarget);
+});
+
+afterEach(() => {
+  app?.unmount();
+  app = null;
+  mountTarget.remove();
+  document.body.innerHTML = "";
+});
+
+describe("useDismissableLayer (vue)", () => {
+  it("fires onEscapeKeyDown when active", async () => {
+    const onEscapeKeyDown = vi.fn();
+    mountLayer(true, { onEscapeKeyDown });
+    await nextTick();
+    document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    expect(onEscapeKeyDown).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not subscribe when active is false", async () => {
+    const onEscapeKeyDown = vi.fn();
+    mountLayer(false, { onEscapeKeyDown });
+    await nextTick();
+    document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    expect(onEscapeKeyDown).not.toHaveBeenCalled();
+  });
+
+  it("fires onPointerDownOutside for clicks outside the element", async () => {
+    const onPointerDownOutside = vi.fn();
+    mountLayer(true, { onPointerDownOutside });
+    await nextTick();
+    document.body.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true }));
+    expect(onPointerDownOutside).toHaveBeenCalledTimes(1);
+  });
+
+  it("unsubscribes when active flips to false", async () => {
+    const onEscapeKeyDown = vi.fn();
+    const active = mountLayer(true, { onEscapeKeyDown });
+    await nextTick();
+    active.value = false;
+    await nextTick();
+    document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    expect(onEscapeKeyDown).not.toHaveBeenCalled();
+  });
+});

--- a/packages/primitives/src/dismissable-layer/vue.ts
+++ b/packages/primitives/src/dismissable-layer/vue.ts
@@ -12,8 +12,10 @@ import {
  * notifying layer is subscribed. Re-subscribes when the element changes or
  * `active` toggles, and tears down on component unmount.
  *
- * The options object is captured at subscribe time; pass a new object to
- * re-subscribe with different callbacks.
+ * `setup()` runs once, so the `options` callbacks are captured at first
+ * call. If you need a callback to react to state, close over `ref`s or
+ * `reactive` values declared in `setup()` scope — Vue will see live values
+ * each time the callback fires.
  */
 export function useDismissableLayer(
   elementRef: Ref<HTMLElement | null>,

--- a/packages/primitives/src/dismissable-layer/vue.ts
+++ b/packages/primitives/src/dismissable-layer/vue.ts
@@ -1,0 +1,44 @@
+import { onBeforeUnmount, type Ref, watch } from "vue";
+import {
+  createDismissableLayer,
+  type DismissableLayer,
+  type DismissableLayerOptions,
+} from "./index.ts";
+
+/**
+ * Vue adapter for {@link createDismissableLayer}.
+ *
+ * While `active` is true and `elementRef.value` is non-null, a dismiss-
+ * notifying layer is subscribed. Re-subscribes when the element changes or
+ * `active` toggles, and tears down on component unmount.
+ *
+ * The options object is captured at subscribe time; pass a new object to
+ * re-subscribe with different callbacks.
+ */
+export function useDismissableLayer(
+  elementRef: Ref<HTMLElement | null>,
+  active: Ref<boolean>,
+  options: DismissableLayerOptions = {},
+): void {
+  let layer: DismissableLayer | null = null;
+
+  function teardown(): void {
+    if (layer) {
+      layer.destroy();
+      layer = null;
+    }
+  }
+
+  watch(
+    [elementRef, active],
+    ([element, isActive]) => {
+      teardown();
+      if (isActive && element) {
+        layer = createDismissableLayer(element, options);
+      }
+    },
+    { immediate: true, flush: "post" },
+  );
+
+  onBeforeUnmount(teardown);
+}

--- a/packages/primitives/src/index.ts
+++ b/packages/primitives/src/index.ts
@@ -1,4 +1,9 @@
 export {
+  createDismissableLayer,
+  type DismissableLayer,
+  type DismissableLayerOptions,
+} from "./dismissable-layer/index.ts";
+export {
   createFocusTrap,
   type FocusTrap,
   type FocusTrapOptions,

--- a/packages/primitives/src/index.ts
+++ b/packages/primitives/src/index.ts
@@ -2,6 +2,7 @@ export {
   createDismissableLayer,
   type DismissableLayer,
   type DismissableLayerOptions,
+  type InteractOutsideEvent,
 } from "./dismissable-layer/index.ts";
 export {
   createFocusTrap,

--- a/packages/primitives/src/react.ts
+++ b/packages/primitives/src/react.ts
@@ -1,1 +1,2 @@
+export { useDismissableLayer } from "./dismissable-layer/react.ts";
 export { useFocusTrap } from "./focus-trap/react.ts";

--- a/packages/primitives/src/vue.ts
+++ b/packages/primitives/src/vue.ts
@@ -1,1 +1,2 @@
+export { useDismissableLayer } from "./dismissable-layer/vue.ts";
 export { useFocusTrap } from "./focus-trap/vue.ts";


### PR DESCRIPTION
Closes #654 (dismissable-layer checkbox).

## What

Adds `createDismissableLayer(element, options)` to `@teseor/primitives` with React (`useDismissableLayer(element, active, options)`) and Vue (same signature, refs) adapters. The layer fires:

- `onEscapeKeyDown` when Escape is pressed and this is the topmost active layer.
- `onPointerDownOutside` when a `pointerdown` lands outside the layer's element.
- `onInteractOutside` alongside `onPointerDownOutside` as a convenience union for future channels (focus-outside, etc.).

Layers stack: a click outside a Popover-inside-a-Modal closes both (every layer whose element does not contain the target fires); Escape closes only the topmost (one tap closes one layer). Iteration is snapshot-safe so a callback that destroys a layer mid-fire does not perturb the cascade.

The primitive only notifies — state stays with the consumer. `destroy()` is idempotent; global document listeners attach when the first layer subscribes and detach when the stack empties.

## Why

Tooltip and Popover need a uniform way to say "close on Escape" and "close on click outside." Re-implementing this per component would diverge on the stack semantics (which is the genuinely tricky part). One shared stack underneath thin framework adapters means one place gets the cascade right.

The React adapter takes `HTMLElement | null` (state-driven callback ref pattern), matching `useFocusTrap`'s post-#655 shape — `RefObject` is stable across renders and silently skips element swaps.

## Test plan

- 19 new vitest cases under happy-dom: 11 vanilla (Escape, pointer outside, stack ordering, cascade snapshot safety, idempotent destroy, listener teardown), 4 React, 4 Vue.
- `pnpm lint && pnpm typecheck && pnpm test` green; full pre-push gates green.
- Repo total for `@teseor/primitives` now 42 tests (23 focus-trap + 19 dismissable-layer; portal adds 7 once #656 merges).

## Out of scope

- Anchor positioning — last box on #654.
- `onFocusOutside` — deliberately omitted from v1 (composes poorly with focus-trap pulling focus back; revisit when Tooltip/Popover surface a real need).
