### PR TITLE
feat(primitives): warnOnce helper + retrofit Slot warnings

### DIFF
--- a/.changeset/683-warn-once.md
+++ b/.changeset/683-warn-once.md
@@ -1,0 +1,12 @@
+---
+"@teseor/primitives": minor
+"@teseor/react": patch
+"@teseor/vue": patch
+---
+
+Add `warnOnce(key, message)` to `@teseor/primitives` — a shared helper for
+deduplicated dev warnings. Logs once per key, prefixed `[teseor] `, SSR-safe,
+no-op when `console` is undefined. Browser dedup state lives on
+`window.__teseor_warned` (a `Set<string>`) so test suites can reset it between
+cases. `Slot` (React + Vue) now calls `warnOnce` instead of inline
+`console.warn` blocks.

--- a/packages/primitives/src/index.ts
+++ b/packages/primitives/src/index.ts
@@ -11,3 +11,4 @@ export {
   getFocusableElements,
 } from "./focus-trap/index.ts";
 export { createPortal, type Portal, type PortalOptions } from "./portal/index.ts";
+export { warnOnce } from "./warn-once/index.ts";

--- a/packages/primitives/src/warn-once/index.test.ts
+++ b/packages/primitives/src/warn-once/index.test.ts
@@ -56,12 +56,11 @@ describe("warnOnce", () => {
     expect(warnSpy).toHaveBeenNthCalledWith(2, "[teseor] second");
   });
 
-  it("is SSR-safe — no-op when `window` is undefined", () => {
+  it("still emits when `window` is undefined (SSR-safe, no crash)", () => {
     const originalWindow = globalThis.window;
     delete (globalThis as { window?: Window }).window;
     try {
       expect(() => warnOnce("test.ssr", "msg")).not.toThrow();
-      // Still writes to console in SSR (helpful for build-time warnings).
       expect(warnSpy).toHaveBeenCalledWith("[teseor] msg");
     } finally {
       globalThis.window = originalWindow;
@@ -81,7 +80,7 @@ describe("warnOnce", () => {
     }
   });
 
-  it("is a no-op when `console` is undefined", () => {
+  it("is a no-op when `console` is undefined — dedup set is not mutated", () => {
     const originalConsole = globalThis.console;
     delete (globalThis as { console?: Console }).console;
     try {
@@ -89,5 +88,9 @@ describe("warnOnce", () => {
     } finally {
       globalThis.console = originalConsole;
     }
+    // The key was NOT recorded, so a subsequent call with the same key fires.
+    warnOnce("test.no-console", "msg");
+    expect(warnSpy).toHaveBeenCalledOnce();
+    expect(warnSpy).toHaveBeenCalledWith("[teseor] msg");
   });
 });

--- a/packages/primitives/src/warn-once/index.test.ts
+++ b/packages/primitives/src/warn-once/index.test.ts
@@ -1,0 +1,93 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { warnOnce } from "./index.ts";
+
+type WarnedHost = { __teseor_warned?: Set<string> };
+
+afterEach(() => {
+  delete (window as unknown as WarnedHost).__teseor_warned;
+});
+
+describe("warnOnce", () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it("prefixes the message with `[teseor] `", () => {
+    warnOnce("test.prefix", "hello");
+    expect(warnSpy).toHaveBeenCalledOnce();
+    expect(warnSpy).toHaveBeenCalledWith("[teseor] hello");
+  });
+
+  it("logs only once per key across repeated calls", () => {
+    warnOnce("test.dedup", "first");
+    warnOnce("test.dedup", "second");
+    warnOnce("test.dedup", "third");
+    expect(warnSpy).toHaveBeenCalledOnce();
+    expect(warnSpy).toHaveBeenCalledWith("[teseor] first");
+  });
+
+  it("logs separately for different keys", () => {
+    warnOnce("test.key-a", "a");
+    warnOnce("test.key-b", "b");
+    expect(warnSpy).toHaveBeenCalledTimes(2);
+    expect(warnSpy).toHaveBeenNthCalledWith(1, "[teseor] a");
+    expect(warnSpy).toHaveBeenNthCalledWith(2, "[teseor] b");
+  });
+
+  it("tracks dedup state on `window.__teseor_warned` so consumers can reset it in tests", () => {
+    warnOnce("test.window", "msg");
+    const host = window as unknown as WarnedHost;
+    expect(host.__teseor_warned).toBeInstanceOf(Set);
+    expect(host.__teseor_warned?.has("test.window")).toBe(true);
+  });
+
+  it("re-emits after `window.__teseor_warned` is cleared", () => {
+    warnOnce("test.reset", "first");
+    delete (window as unknown as WarnedHost).__teseor_warned;
+    warnOnce("test.reset", "second");
+    expect(warnSpy).toHaveBeenCalledTimes(2);
+    expect(warnSpy).toHaveBeenNthCalledWith(2, "[teseor] second");
+  });
+
+  it("is SSR-safe — no-op when `window` is undefined", () => {
+    const originalWindow = globalThis.window;
+    delete (globalThis as { window?: Window }).window;
+    try {
+      expect(() => warnOnce("test.ssr", "msg")).not.toThrow();
+      // Still writes to console in SSR (helpful for build-time warnings).
+      expect(warnSpy).toHaveBeenCalledWith("[teseor] msg");
+    } finally {
+      globalThis.window = originalWindow;
+    }
+  });
+
+  it("dedups within SSR too — when `window` is undefined, dedup falls back to a module-level set", () => {
+    // Two calls in an SSR-shaped environment should still only emit once per key.
+    const originalWindow = globalThis.window;
+    delete (globalThis as { window?: Window }).window;
+    try {
+      warnOnce("test.ssr-dedup", "msg");
+      warnOnce("test.ssr-dedup", "msg-again");
+      expect(warnSpy).toHaveBeenCalledOnce();
+    } finally {
+      globalThis.window = originalWindow;
+    }
+  });
+
+  it("is a no-op when `console` is undefined", () => {
+    const originalConsole = globalThis.console;
+    delete (globalThis as { console?: Console }).console;
+    try {
+      expect(() => warnOnce("test.no-console", "msg")).not.toThrow();
+    } finally {
+      globalThis.console = originalConsole;
+    }
+  });
+});

--- a/packages/primitives/src/warn-once/index.ts
+++ b/packages/primitives/src/warn-once/index.ts
@@ -1,0 +1,37 @@
+// Deduplicates dev warnings emitted from Teseor packages so a noisy hook or
+// component mounted N times still only logs once per call site. Vanilla JS —
+// React and Vue wrappers both call this directly.
+
+type WarnedHost = { __teseor_warned?: Set<string> };
+
+// Fallback dedup set for SSR / non-browser environments where `window` doesn't
+// exist. Per-process rather than per-page, which is the correct grain for a
+// build / render worker.
+const serverWarned = new Set<string>();
+
+/**
+ * Emits `console.warn` once per `key`, prefixed with `[teseor] `. Subsequent
+ * calls with the same key are dropped within the same session.
+ *
+ * SSR-safe: when `window` is undefined the dedup set lives at module scope
+ * instead, and a missing `console` is a no-op. In the browser the dedup state
+ * lives on `window.__teseor_warned` (a `Set<string>`) so test suites can reset
+ * it between cases by deleting that property.
+ *
+ * @param key  Stable call-site identifier (e.g. `"slot.multi-child"`).
+ * @param message  Human-readable warning text — printed verbatim after the prefix.
+ */
+export function warnOnce(key: string, message: string): void {
+  const warned = resolveWarnedSet();
+  if (warned.has(key)) return;
+  warned.add(key);
+  if (typeof console === "undefined") return;
+  console.warn(`[teseor] ${message}`);
+}
+
+function resolveWarnedSet(): Set<string> {
+  if (typeof window === "undefined") return serverWarned;
+  const host = window as unknown as WarnedHost;
+  host.__teseor_warned ??= new Set<string>();
+  return host.__teseor_warned;
+}

--- a/packages/primitives/src/warn-once/index.ts
+++ b/packages/primitives/src/warn-once/index.ts
@@ -8,7 +8,8 @@ const serverWarned = new Set<string>();
  * `console` is undefined; SSR-safe. Browser dedup state lives on
  * `window.__teseor_warned` — delete it between tests to reset.
  *
- * Keys are global; prefix per package (e.g. `react.slot.multi-child`).
+ * Keys are global and must be finite/static — prefix per package
+ * (e.g. `react.slot.multi-child`). Dynamic keys leak memory.
  */
 export function warnOnce(key: string, message: string): void {
   if (typeof console === "undefined") return;

--- a/packages/primitives/src/warn-once/index.ts
+++ b/packages/primitives/src/warn-once/index.ts
@@ -1,31 +1,20 @@
-// Deduplicates dev warnings emitted from Teseor packages so a noisy hook or
-// component mounted N times still only logs once per call site. Vanilla JS —
-// React and Vue wrappers both call this directly.
-
 type WarnedHost = { __teseor_warned?: Set<string> };
 
-// Fallback dedup set for SSR / non-browser environments where `window` doesn't
-// exist. Per-process rather than per-page, which is the correct grain for a
-// build / render worker.
+// SSR fallback when `window` is unavailable.
 const serverWarned = new Set<string>();
 
 /**
- * Emits `console.warn` once per `key`, prefixed with `[teseor] `. Subsequent
- * calls with the same key are dropped within the same session.
+ * Emits `console.warn` once per `key`, prefixed `[teseor] `. No-op when
+ * `console` is undefined; SSR-safe. Browser dedup state lives on
+ * `window.__teseor_warned` — delete it between tests to reset.
  *
- * SSR-safe: when `window` is undefined the dedup set lives at module scope
- * instead, and a missing `console` is a no-op. In the browser the dedup state
- * lives on `window.__teseor_warned` (a `Set<string>`) so test suites can reset
- * it between cases by deleting that property.
- *
- * @param key  Stable call-site identifier (e.g. `"slot.multi-child"`).
- * @param message  Human-readable warning text — printed verbatim after the prefix.
+ * Keys are global; prefix per package (e.g. `react.slot.multi-child`).
  */
 export function warnOnce(key: string, message: string): void {
+  if (typeof console === "undefined") return;
   const warned = resolveWarnedSet();
   if (warned.has(key)) return;
   warned.add(key);
-  if (typeof console === "undefined") return;
   console.warn(`[teseor] ${message}`);
 }
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -24,7 +24,8 @@
     "directory": "packages/react"
   },
   "dependencies": {
-    "@teseor/css": "workspace:*"
+    "@teseor/css": "workspace:*",
+    "@teseor/primitives": "workspace:*"
   },
   "peerDependencies": {
     "react": ">=18"

--- a/packages/react/src/components/Slot.test.tsx
+++ b/packages/react/src/components/Slot.test.tsx
@@ -16,6 +16,9 @@ afterAll(uninstallDomPolyfills);
 afterEach(() => {
   cleanup();
   resetDomPolyfills();
+  // `warnOnce` dedups per key on `window.__teseor_warned`; clear it so each
+  // test sees a fresh warning rather than the first test silencing the rest.
+  delete (window as unknown as { __teseor_warned?: Set<string> }).__teseor_warned;
 });
 
 describe("Slot", () => {

--- a/packages/react/src/components/Slot.tsx
+++ b/packages/react/src/components/Slot.tsx
@@ -61,7 +61,7 @@ export function Slot({ children, ...slotProps }: SlotProps): ReactElement | null
   const elements = Children.toArray(children).filter(isValidElement);
   if (elements.length !== 1) {
     warnOnce(
-      "slot.multi-child",
+      "react.slot.multi-child",
       `Slot: expected exactly one React element child, got ${elements.length}. Pass a single element (e.g. <button>...</button>) or drop \`asChild\`.`,
     );
     return null;
@@ -71,7 +71,7 @@ export function Slot({ children, ...slotProps }: SlotProps): ReactElement | null
   // length check, then `cloneElement` silently drops slot props on it.
   if (child.type === Fragment) {
     warnOnce(
-      "slot.fragment",
+      "react.slot.fragment",
       "Slot: expected a single element child but got a Fragment. Pass a single element (e.g. <button>...</button>) or drop `asChild`.",
     );
     return null;
@@ -82,7 +82,7 @@ export function Slot({ children, ...slotProps }: SlotProps): ReactElement | null
   // there is no workaround at the React layer.
   if (typeof child.type === "string" && child.type.startsWith("astro-")) {
     warnOnce(
-      "slot.astro",
+      "react.slot.astro",
       "Slot: `asChild` does not work inside Astro slots — children arrive wrapped in <astro-slot>. Drop `asChild` (use the default wrapper) when rendering this component from a .astro file.",
     );
     return cloneElement(child, mergeSlotProps(child.props ?? {}, slotProps));

--- a/packages/react/src/components/Slot.tsx
+++ b/packages/react/src/components/Slot.tsx
@@ -1,3 +1,4 @@
+import { warnOnce } from "@teseor/primitives";
 import {
   Children,
   cloneElement,
@@ -59,22 +60,20 @@ function mergeSlotProps(
 export function Slot({ children, ...slotProps }: SlotProps): ReactElement | null {
   const elements = Children.toArray(children).filter(isValidElement);
   if (elements.length !== 1) {
-    if (typeof console !== "undefined") {
-      console.warn(
-        `Slot: expected exactly one React element child, got ${elements.length}. Pass a single element (e.g. <button>...</button>) or drop \`asChild\`.`,
-      );
-    }
+    warnOnce(
+      "slot.multi-child",
+      `Slot: expected exactly one React element child, got ${elements.length}. Pass a single element (e.g. <button>...</button>) or drop \`asChild\`.`,
+    );
     return null;
   }
   const child = elements[0] as ReactElement<Record<string, unknown>>;
   // `Children.toArray` doesn't flatten Fragments — a Fragment slips past the
   // length check, then `cloneElement` silently drops slot props on it.
   if (child.type === Fragment) {
-    if (typeof console !== "undefined") {
-      console.warn(
-        "Slot: expected a single element child but got a Fragment. Pass a single element (e.g. <button>...</button>) or drop `asChild`.",
-      );
-    }
+    warnOnce(
+      "slot.fragment",
+      "Slot: expected a single element child but got a Fragment. Pass a single element (e.g. <button>...</button>) or drop `asChild`.",
+    );
     return null;
   }
   // Astro wraps slotted children in `<astro-slot>`. `cloneElement` merges
@@ -82,11 +81,10 @@ export function Slot({ children, ...slotProps }: SlotProps): ReactElement | null
   // `aria-describedby` never reach the consumer's button. Warn loudly —
   // there is no workaround at the React layer.
   if (typeof child.type === "string" && child.type.startsWith("astro-")) {
-    if (typeof console !== "undefined") {
-      console.warn(
-        "Slot: `asChild` does not work inside Astro slots — children arrive wrapped in <astro-slot>. Drop `asChild` (use the default wrapper) when rendering this component from a .astro file.",
-      );
-    }
+    warnOnce(
+      "slot.astro",
+      "Slot: `asChild` does not work inside Astro slots — children arrive wrapped in <astro-slot>. Drop `asChild` (use the default wrapper) when rendering this component from a .astro file.",
+    );
     return cloneElement(child, mergeSlotProps(child.props ?? {}, slotProps));
   }
   return cloneElement(child, mergeSlotProps(child.props ?? {}, slotProps));

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -24,7 +24,8 @@
     "directory": "packages/vue"
   },
   "dependencies": {
-    "@teseor/css": "workspace:*"
+    "@teseor/css": "workspace:*",
+    "@teseor/primitives": "workspace:*"
   },
   "peerDependencies": {
     "vue": ">=3.5"

--- a/packages/vue/src/components/Slot.test.ts
+++ b/packages/vue/src/components/Slot.test.ts
@@ -19,6 +19,9 @@ afterEach(() => {
   teardown.length = 0;
   document.body.innerHTML = "";
   resetDomPolyfills();
+  // `warnOnce` dedups per key on `window.__teseor_warned`; clear it so each
+  // test sees a fresh warning rather than the first test silencing the rest.
+  delete (window as unknown as { __teseor_warned?: Set<string> }).__teseor_warned;
 });
 
 function mountTracked<C extends Component>(

--- a/packages/vue/src/components/Slot.ts
+++ b/packages/vue/src/components/Slot.ts
@@ -20,7 +20,7 @@ export const Slot = defineComponent({
       const vnodes = (slots.default?.() ?? []).filter((v) => typeof v.type !== "symbol");
       if (vnodes.length !== 1) {
         warnOnce(
-          "slot.multi-child",
+          "vue.slot.multi-child",
           `Slot: expected exactly one VNode child, got ${vnodes.length}. Pass a single element or drop \`asChild\`.`,
         );
         return null;

--- a/packages/vue/src/components/Slot.ts
+++ b/packages/vue/src/components/Slot.ts
@@ -1,3 +1,4 @@
+import { warnOnce } from "@teseor/primitives";
 import { cloneVNode, defineComponent } from "vue";
 
 /**
@@ -18,11 +19,10 @@ export const Slot = defineComponent({
     return () => {
       const vnodes = (slots.default?.() ?? []).filter((v) => typeof v.type !== "symbol");
       if (vnodes.length !== 1) {
-        if (typeof console !== "undefined") {
-          console.warn(
-            `Slot: expected exactly one VNode child, got ${vnodes.length}. Pass a single element or drop \`asChild\`.`,
-          );
-        }
+        warnOnce(
+          "slot.multi-child",
+          `Slot: expected exactly one VNode child, got ${vnodes.length}. Pass a single element or drop \`asChild\`.`,
+        );
         return null;
       }
       const child = vnodes[0];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -241,6 +241,9 @@ importers:
       '@teseor/css':
         specifier: workspace:*
         version: link:../css
+      '@teseor/primitives':
+        specifier: workspace:*
+        version: link:../primitives
     devDependencies:
       '@teseor/test-internals':
         specifier: workspace:*

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -208,6 +208,9 @@ importers:
       '@teseor/css':
         specifier: workspace:*
         version: link:../css
+      '@teseor/primitives':
+        specifier: workspace:*
+        version: link:../primitives
     devDependencies:
       '@teseor/test-internals':
         specifier: workspace:*


### PR DESCRIPTION
Closes #683.

## What

- New `warnOnce(key, message)` helper in `@teseor/primitives` (`packages/primitives/src/warn-once/`). Pure-JS, no deps, framework-agnostic. Logs `console.warn` once per `key`, prefixed `[teseor] `. SSR-safe (falls back to a module-level dedup set when `window` is undefined); no-op when `console` is undefined. Browser dedup state lives on `window.__teseor_warned: Set<string>` so test suites can reset it.
- React `Slot` retrofitted — three warnings (multi-child, Fragment, Astro) now call `warnOnce("slot.<key>", …)` instead of inline `typeof console !== "undefined"` guards.
- Vue `Slot` retrofitted — multi-child warning likewise.
- Slot tests gain a per-test `delete window.__teseor_warned` so dedup doesn't mute warnings across cases. Existing `vi.spyOn(console, "warn")` still observes the call underneath.

## Why

Source-level `console.warn` calls were scattered across the wrapper packages, each repeating the `typeof console !== "undefined"` guard and the `[teseor] ` prefix. Two consumers today (React Slot, Vue Slot), three more incoming (#664's `useOverlay` retries). One shared helper means consistent prefix, per-session dedup so a hook mounted N times doesn't log N times, and a single window-bound override hook for muted-warning test suites.

The shape was already settled in #664's design discussion — this PR extracts the helper to its natural home so #664 can adopt it next without each callsite reinventing it.

## Test plan

- `pnpm exec vitest run packages/primitives/src/warn-once/` — 8 tests cover prefix, dedup, distinct keys, `window.__teseor_warned` integration, reset behavior, SSR (`window` undefined), SSR dedup, missing-`console` no-op.
- `pnpm test` — full suite, 338 tests pass (incl. 11 React Slot + 7 Vue Slot tests unchanged in shape).
- `pnpm gen` drift-free.
- `pnpm lint`, `pnpm typecheck` clean.

## Out of scope

- `useOverlay`'s silent `catch {}` blocks — tracked under #664. That PR will adopt the same `warnOnce` helper.
- `__DEV__` / `process.env.NODE_ENV` stripping — settled in #664: deferred until there's a production build pipeline that does DCE cleanly. Today the wrapper packages ship raw TS via `"exports": "./src/index.ts"`, so there's nowhere to strip.
- Consumer-installable telemetry hook (custom error reporter) — not in v0.3 scope.
