### PR TITLE
refactor(wrapper): useOverlay surfaces popover failures via warnOnce

### DIFF
--- a/.changeset/664-use-overlay-warn.md
+++ b/.changeset/664-use-overlay-warn.md
@@ -1,0 +1,11 @@
+---
+"@teseor/react": patch
+"@teseor/vue": patch
+---
+
+`useOverlay` (React + Vue) now surfaces Popover API failures via the shared
+`warnOnce` helper instead of swallowing the error silently. A consumer running
+on a browser without Popover API support, or whose element is `display: none`,
+sees one dev warning per page session per failure (`react.overlay.show-popover-failed`,
+`react.overlay.hide-popover-failed`, and the Vue equivalents). No behavior
+change in supported browsers.

--- a/packages/react/src/hooks/useOverlay.test.tsx
+++ b/packages/react/src/hooks/useOverlay.test.tsx
@@ -18,6 +18,8 @@ afterAll(uninstallDomPolyfills);
 afterEach(() => {
   cleanup();
   resetDomPolyfills();
+  // `warnOnce` dedups per key on `window.__teseor_warned`; reset between tests.
+  delete (window as unknown as { __teseor_warned?: Set<string> }).__teseor_warned;
 });
 
 type UseOverlayConfig = Parameters<typeof useOverlay>[0];
@@ -230,6 +232,67 @@ describe("useOverlay", () => {
     };
     expect(() => render(<Harness />)).not.toThrow();
     // popoverIsOpen returned undefined → showPopover ran (open && !== true).
+  });
+
+  it("warns once when showPopover throws (Popover API unsupported / display:none)", () => {
+    const htmlProto = HTMLElement.prototype as unknown as {
+      showPopover: () => void;
+      hidePopover: () => void;
+    };
+    const originalShow = htmlProto.showPopover;
+    htmlProto.showPopover = () => {
+      throw new Error("not supported");
+    };
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const Harness = () => {
+      const o = useOverlay<HTMLDivElement>({ ...BASE_CONFIG, defaultOpen: true });
+      return (
+        <div ref={o.contentRef} popover="auto" id={o.popoverId} data-testid="content">
+          x
+        </div>
+      );
+    };
+    try {
+      render(<Harness />);
+      render(<Harness />);
+      expect(warnSpy).toHaveBeenCalledOnce();
+      expect(String(warnSpy.mock.calls[0]?.[0])).toContain("[teseor]");
+      expect(String(warnSpy.mock.calls[0]?.[0])).toContain("showPopover");
+    } finally {
+      htmlProto.showPopover = originalShow;
+      warnSpy.mockRestore();
+    }
+  });
+
+  it("warns once when hidePopover throws", () => {
+    const htmlProto = HTMLElement.prototype as unknown as {
+      showPopover: () => void;
+      hidePopover: () => void;
+    };
+    const originalHide = htmlProto.hidePopover;
+    htmlProto.hidePopover = () => {
+      throw new Error("not supported");
+    };
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const Harness = ({ open }: { open: boolean }) => {
+      const o = useOverlay<HTMLDivElement>({ ...BASE_CONFIG, open });
+      return (
+        <div ref={o.contentRef} popover="auto" id={o.popoverId} data-testid="content">
+          x
+        </div>
+      );
+    };
+    try {
+      const { rerender } = render(<Harness open={true} />);
+      rerender(<Harness open={false} />);
+      rerender(<Harness open={true} />);
+      rerender(<Harness open={false} />);
+      expect(warnSpy).toHaveBeenCalledOnce();
+      expect(String(warnSpy.mock.calls[0]?.[0])).toContain("hidePopover");
+    } finally {
+      htmlProto.hidePopover = originalHide;
+      warnSpy.mockRestore();
+    }
   });
 
   it("gates schedule() against disabled at the active breakpoint (PR #660: responsive disabled shape)", () => {

--- a/packages/react/src/hooks/useOverlay.ts
+++ b/packages/react/src/hooks/useOverlay.ts
@@ -1,3 +1,4 @@
+import { warnOnce } from "@teseor/primitives";
 import { type Ref, useCallback, useEffect, useId, useRef, useState } from "react";
 import { isActiveAt, type Responsive, useActiveBreakpoint } from "../_runtime.ts";
 
@@ -167,11 +168,21 @@ export function useOverlay<T extends HTMLElement = HTMLElement>(
     if (open && popoverState !== true) {
       try {
         contentNode.showPopover();
-      } catch {}
+      } catch (err) {
+        warnOnce(
+          "react.overlay.show-popover-failed",
+          `useOverlay: showPopover() failed on <${contentNode.tagName.toLowerCase()}>. Popover API may be unsupported (Baseline 2026) or the element is display:none. Underlying error: ${err}`,
+        );
+      }
     } else if (!open && popoverState !== false) {
       try {
         contentNode.hidePopover();
-      } catch {}
+      } catch (err) {
+        warnOnce(
+          "react.overlay.hide-popover-failed",
+          `useOverlay: hidePopover() failed on <${contentNode.tagName.toLowerCase()}>. Popover API may be unsupported (Baseline 2026). Underlying error: ${err}`,
+        );
+      }
     }
   }, [open, contentNode]);
 

--- a/packages/vue/src/composables/useOverlay.test.ts
+++ b/packages/vue/src/composables/useOverlay.test.ts
@@ -31,6 +31,8 @@ afterEach(() => {
   teardown.length = 0;
   document.body.innerHTML = "";
   resetDomPolyfills();
+  // `warnOnce` dedups per key on `window.__teseor_warned`; reset between tests.
+  delete (window as unknown as { __teseor_warned?: Set<string> }).__teseor_warned;
 });
 
 /** mount() variant that schedules the wrapper for unmount in `afterEach`. */
@@ -287,6 +289,81 @@ describe("useOverlay", () => {
     });
     expect(() => mountTracked(Harness)).not.toThrow();
     await flushPromises();
+  });
+
+  it("warns once when showPopover throws (Popover API unsupported / display:none)", async () => {
+    const htmlProto = HTMLElement.prototype as unknown as {
+      showPopover: () => void;
+      hidePopover: () => void;
+    };
+    const originalShow = htmlProto.showPopover;
+    htmlProto.showPopover = function () {
+      throw new Error("not supported");
+    };
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const Harness = defineComponent({
+      setup() {
+        const o = useOverlay({ ...BASE_CONFIG, defaultOpen: true });
+        return () =>
+          h("div", {
+            ref: o.contentRef as unknown as Ref<HTMLElement | null>,
+            popover: "auto",
+            id: o.popoverId,
+            "data-testid": "content",
+          });
+      },
+    });
+    try {
+      mountTracked(Harness);
+      mountTracked(Harness);
+      await flushPromises();
+      expect(warnSpy).toHaveBeenCalledOnce();
+      expect(String(warnSpy.mock.calls[0]?.[0])).toContain("[teseor]");
+      expect(String(warnSpy.mock.calls[0]?.[0])).toContain("showPopover");
+    } finally {
+      htmlProto.showPopover = originalShow;
+      warnSpy.mockRestore();
+    }
+  });
+
+  it("warns once when hidePopover throws", async () => {
+    const htmlProto = HTMLElement.prototype as unknown as {
+      showPopover: () => void;
+      hidePopover: () => void;
+    };
+    const originalHide = htmlProto.hidePopover;
+    htmlProto.hidePopover = function () {
+      throw new Error("not supported");
+    };
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const openRef = ref(true);
+    const Harness = defineComponent({
+      setup() {
+        const o = useOverlay({ ...BASE_CONFIG, open: () => openRef.value });
+        return () =>
+          h("div", {
+            ref: o.contentRef as unknown as Ref<HTMLElement | null>,
+            popover: "auto",
+            id: o.popoverId,
+            "data-testid": "content",
+          });
+      },
+    });
+    try {
+      mountTracked(Harness);
+      await flushPromises();
+      openRef.value = false;
+      await flushPromises();
+      openRef.value = true;
+      await flushPromises();
+      openRef.value = false;
+      await flushPromises();
+      expect(warnSpy).toHaveBeenCalledOnce();
+      expect(String(warnSpy.mock.calls[0]?.[0])).toContain("hidePopover");
+    } finally {
+      htmlProto.hidePopover = originalHide;
+      warnSpy.mockRestore();
+    }
   });
 
   it("gates schedule() against disabled at the active breakpoint (PR #660: responsive disabled shape)", () => {

--- a/packages/vue/src/composables/useOverlay.ts
+++ b/packages/vue/src/composables/useOverlay.ts
@@ -1,3 +1,4 @@
+import { warnOnce } from "@teseor/primitives";
 import {
   computed,
   onBeforeUnmount,
@@ -139,11 +140,21 @@ export function useOverlay(config: OverlayConfig): OverlayReturn {
       if (current && popoverState !== true) {
         try {
           node.showPopover();
-        } catch {}
+        } catch (err) {
+          warnOnce(
+            "vue.overlay.show-popover-failed",
+            `useOverlay: showPopover() failed on <${node.tagName.toLowerCase()}>. Popover API may be unsupported (Baseline 2026) or the element is display:none. Underlying error: ${err}`,
+          );
+        }
       } else if (!current && popoverState !== false) {
         try {
           node.hidePopover();
-        } catch {}
+        } catch (err) {
+          warnOnce(
+            "vue.overlay.hide-popover-failed",
+            `useOverlay: hidePopover() failed on <${node.tagName.toLowerCase()}>. Popover API may be unsupported (Baseline 2026). Underlying error: ${err}`,
+          );
+        }
       }
     },
     { immediate: true, flush: "post" },


### PR DESCRIPTION
Closes #664. Builds on #685 (now merged) — uses the shared `warnOnce` helper from `@teseor/primitives`.

## What

Replace the four silent `catch {}` blocks in `useOverlay` (React + Vue, around `showPopover` / `hidePopover`) with `warnOnce` calls. The `popoverIsOpen` probe `catch` stays silent — that's a designed support-detection signal, not a swallowed failure.

Per-package keys:

- `react.overlay.show-popover-failed` / `react.overlay.hide-popover-failed`
- `vue.overlay.show-popover-failed` / `vue.overlay.hide-popover-failed`

Each warning includes the failing tag name, the likely cause (Popover API unsupported in Baseline 2026 / element is `display: none`), and the underlying error.

## Why

Today a consumer running Safari 24, or whose CSS hid the popover with `display: none`, sees broken tooltips with no console output. "Silent degradation" only works if the developer can find out it's happening — and the typing failures are exactly the cases a dev needs to learn about.

## Test plan

- New cases in both `useOverlay.test.tsx` and `useOverlay.test.ts` mock `showPopover` / `hidePopover` to throw, mount two harnesses (or trigger four open↔close transitions), and assert exactly one `console.warn` per session per key.
- `pnpm test` — 342 tests pass (+4 new).
- `pnpm gen` drift-free, `pnpm lint`, `pnpm typecheck` clean.

## Out of scope

- Production-build warning stripping (`__DEV__` / NODE_ENV gating) — deferred until there's a production build pipeline that does DCE cleanly (settled in #683).
- Consumer-installable telemetry hook — out of v0.3 scope.
