### PR TITLE
fix(wrapper): Vue Slot short-circuits slot handler on child preventDefault

### DIFF
--- a/.changeset/684-vue-slot-prevent-default.md
+++ b/.changeset/684-vue-slot-prevent-default.md
@@ -1,0 +1,5 @@
+---
+"@teseor/vue": patch
+---
+
+Fix Vue `Slot` so a child handler's `event.preventDefault()` short-circuits the slot handler — React parity (PR #660). After `cloneVNode` merges `on*` handlers into `[childHandler, attrHandler]` arrays, wrap each array so the loop stops once the child sets `defaultPrevented`. Single handlers (only child or only attrs) stay as plain functions and are left untouched. Unblocks Vue composites that use `asChild` with consumer handlers that need to suppress overlay behavior.

--- a/packages/vue/src/components/Slot.test.ts
+++ b/packages/vue/src/components/Slot.test.ts
@@ -109,6 +109,21 @@ describe("Slot", () => {
     expect(calls).toEqual(["child", "slot"]);
   });
 
+  it("skips slot handler when child calls event.preventDefault (React parity, #684)", async () => {
+    const calls: string[] = [];
+    const childHandler = (event: Event) => {
+      calls.push("child");
+      event.preventDefault();
+    };
+    const slotHandler = () => calls.push("slot");
+    const wrapper = mountTracked(Slot, {
+      attrs: { onClick: slotHandler },
+      slots: { default: () => h("button", { type: "button", onClick: childHandler }, "x") },
+    });
+    await wrapper.find("button").trigger("click");
+    expect(calls).toEqual(["child"]);
+  });
+
   it("forwards aria / data attributes onto the child", () => {
     const wrapper = mountTracked(Slot, {
       attrs: { "aria-describedby": "tip-1", "data-state": "open" },

--- a/packages/vue/src/components/Slot.test.ts
+++ b/packages/vue/src/components/Slot.test.ts
@@ -6,7 +6,7 @@ import {
 } from "@teseor/test-internals";
 import { mount, type VueWrapper } from "@vue/test-utils";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import { type Component, Fragment, h } from "vue";
+import { type Component, defineComponent, Fragment, h } from "vue";
 import { Slot } from "./Slot.ts";
 
 beforeAll(installDomPolyfills);
@@ -122,6 +122,35 @@ describe("Slot", () => {
     });
     await wrapper.find("button").trigger("click");
     expect(calls).toEqual(["child"]);
+  });
+
+  it("forwards non-Event payloads to composed handlers (custom emit arity)", () => {
+    const childCalls: unknown[][] = [];
+    const slotCalls: unknown[][] = [];
+    const Child = defineComponent({
+      emits: ["update:modelValue"],
+      setup(_, { emit }) {
+        return () =>
+          h("button", {
+            type: "button",
+            onClick: () => emit("update:modelValue", "next", { meta: true }),
+          });
+      },
+    });
+    const wrapper = mountTracked(Slot, {
+      attrs: {
+        "onUpdate:modelValue": (...args: unknown[]) => slotCalls.push(args),
+      },
+      slots: {
+        default: () =>
+          h(Child, {
+            "onUpdate:modelValue": (...args: unknown[]) => childCalls.push(args),
+          }),
+      },
+    });
+    wrapper.find("button").element.dispatchEvent(new Event("click"));
+    expect(childCalls).toEqual([["next", { meta: true }]]);
+    expect(slotCalls).toEqual([["next", { meta: true }]]);
   });
 
   it("forwards aria / data attributes onto the child", () => {

--- a/packages/vue/src/components/Slot.test.ts
+++ b/packages/vue/src/components/Slot.test.ts
@@ -153,6 +153,23 @@ describe("Slot", () => {
     expect(slotCalls).toEqual([["next", { meta: true }]]);
   });
 
+  it("leaves non-listener props starting with 'on' untouched (onboardingSteps)", () => {
+    const stepsReceived: unknown[] = [];
+    const Child = defineComponent({
+      props: { onboardingSteps: { type: Array, default: () => [] } },
+      setup(props) {
+        return () => {
+          stepsReceived.push(props.onboardingSteps);
+          return h("button", { type: "button" }, "x");
+        };
+      },
+    });
+    mountTracked(Slot, {
+      slots: { default: () => h(Child, { onboardingSteps: [1, 2, 3] }) },
+    });
+    expect(stepsReceived).toEqual([[1, 2, 3]]);
+  });
+
   it("forwards aria / data attributes onto the child", () => {
     const wrapper = mountTracked(Slot, {
       attrs: { "aria-describedby": "tip-1", "data-state": "open" },

--- a/packages/vue/src/components/Slot.test.ts
+++ b/packages/vue/src/components/Slot.test.ts
@@ -124,6 +124,21 @@ describe("Slot", () => {
     expect(calls).toEqual(["child"]);
   });
 
+  it("skips slot handler when child calls event.stopImmediatePropagation (Vue array-listener parity)", async () => {
+    const calls: string[] = [];
+    const childHandler = (event: Event) => {
+      calls.push("child");
+      event.stopImmediatePropagation();
+    };
+    const slotHandler = () => calls.push("slot");
+    const wrapper = mountTracked(Slot, {
+      attrs: { onClick: slotHandler },
+      slots: { default: () => h("button", { type: "button", onClick: childHandler }, "x") },
+    });
+    await wrapper.find("button").trigger("click");
+    expect(calls).toEqual(["child"]);
+  });
+
   it("forwards non-Event payloads to composed handlers (custom emit arity)", () => {
     const childCalls: unknown[][] = [];
     const slotCalls: unknown[][] = [];

--- a/packages/vue/src/components/Slot.ts
+++ b/packages/vue/src/components/Slot.ts
@@ -4,6 +4,17 @@ import { cloneVNode, defineComponent } from "vue";
 type EventHandler = (...args: unknown[]) => void;
 
 /**
+ * Mirrors Vue's internal `isOn` (`@vue/shared`): char 0/1 are `o`/`n` and
+ * char 2 is not a lowercase letter (uppercase, digit, or `:` for
+ * `onUpdate:*`). Narrower than `startsWith("on")` so we don't wrap props
+ * like `onboardingSteps` whose value happens to be an array.
+ */
+const isVueListenerKey = (key: string): boolean =>
+  key.charCodeAt(0) === 111 &&
+  key.charCodeAt(1) === 110 &&
+  (key.charCodeAt(2) > 122 || key.charCodeAt(2) < 97);
+
+/**
  * Renders the default slot's first VNode with merged attrs from the parent —
  * Vue equivalent of React's `cloneElement` Slot. Used by composite wrappers
  * when `asChild` is true so the consumer's element receives event handlers,
@@ -38,13 +49,13 @@ export const Slot = defineComponent({
       const props = cloned.props;
       if (props) {
         for (const key of Object.keys(props)) {
-          if (!key.startsWith("on")) continue;
+          if (!isVueListenerKey(key)) continue;
           const value = props[key];
           if (!Array.isArray(value)) continue;
-          const handlers = value as EventHandler[];
+          const handlers = value.filter((fn): fn is EventHandler => typeof fn === "function");
+          if (handlers.length === 0) continue;
           props[key] = (...args: unknown[]) => {
             for (const fn of handlers) {
-              if (typeof fn !== "function") continue;
               fn(...args);
               const event = args[0] as { defaultPrevented?: boolean } | undefined;
               if (event?.defaultPrevented === true) return;

--- a/packages/vue/src/components/Slot.ts
+++ b/packages/vue/src/components/Slot.ts
@@ -26,9 +26,15 @@ const isVueListenerKey = (key: string): boolean =>
  * double event handlers since `cloneVNode` already merges internally.
  *
  * Wraps composed `on*` handler arrays so a child handler's `preventDefault()`
- * short-circuits the slot handler (React-parity, #684). Vue's `mergeProps`
- * orders the array as `[childHandler, attrHandler]`; single handlers (only
- * child or only attrs) stay as plain functions and are left untouched.
+ * or `stopImmediatePropagation()` short-circuits the slot handler (React-parity,
+ * #684). Vue's `mergeProps` orders the array as `[childHandler, attrHandler]`;
+ * single handlers (only child or only attrs) stay as plain functions and are
+ * left untouched.
+ *
+ * Replacing the array with a single function bypasses Vue runtime-dom's
+ * `patchStopImmediatePropagation`, which would otherwise set `event._stopped`
+ * on a `stopImmediatePropagation()` call and skip subsequent array entries.
+ * Install the same override locally so the short-circuit still fires.
  */
 export const Slot = defineComponent({
   name: "Slot",
@@ -55,9 +61,19 @@ export const Slot = defineComponent({
           const handlers = value.filter((fn): fn is EventHandler => typeof fn === "function");
           if (handlers.length === 0) continue;
           props[key] = (...args: unknown[]) => {
+            const event = args[0] as
+              | { defaultPrevented?: boolean; _stopped?: boolean; stopImmediatePropagation?: () => void }
+              | undefined;
+            if (event && typeof event.stopImmediatePropagation === "function" && !event._stopped) {
+              const originalStop = event.stopImmediatePropagation.bind(event);
+              event.stopImmediatePropagation = () => {
+                originalStop();
+                event._stopped = true;
+              };
+            }
             for (const fn of handlers) {
+              if (event?._stopped === true) return;
               fn(...args);
-              const event = args[0] as { defaultPrevented?: boolean } | undefined;
               if (event?.defaultPrevented === true) return;
             }
           };

--- a/packages/vue/src/components/Slot.ts
+++ b/packages/vue/src/components/Slot.ts
@@ -1,6 +1,8 @@
 import { warnOnce } from "@teseor/primitives";
 import { cloneVNode, defineComponent } from "vue";
 
+type EventHandler = (event: Event) => void;
+
 /**
  * Renders the default slot's first VNode with merged attrs from the parent —
  * Vue equivalent of React's `cloneElement` Slot. Used by composite wrappers
@@ -11,6 +13,11 @@ import { cloneVNode, defineComponent } from "vue";
  * `<><a/><b/></>` wrappers don't pass the single-child invariant. Passes
  * `attrs` straight to `cloneVNode` — pre-merging via `mergeProps` would
  * double event handlers since `cloneVNode` already merges internally.
+ *
+ * Wraps composed `on*` handler arrays so a child handler's `preventDefault()`
+ * short-circuits the slot handler (React-parity, #684). Vue's `mergeProps`
+ * orders the array as `[childHandler, attrHandler]`; single handlers (only
+ * child or only attrs) stay as plain functions and are left untouched.
  */
 export const Slot = defineComponent({
   name: "Slot",
@@ -27,7 +34,24 @@ export const Slot = defineComponent({
       }
       const child = vnodes[0];
       if (!child) return null;
-      return cloneVNode(child, attrs);
+      const cloned = cloneVNode(child, attrs);
+      const props = cloned.props;
+      if (props) {
+        for (const key of Object.keys(props)) {
+          if (!key.startsWith("on")) continue;
+          const value = props[key];
+          if (!Array.isArray(value)) continue;
+          const handlers = value as EventHandler[];
+          props[key] = (event: Event) => {
+            for (const fn of handlers) {
+              if (typeof fn !== "function") continue;
+              fn(event);
+              if (event.defaultPrevented) return;
+            }
+          };
+        }
+      }
+      return cloned;
     };
   },
 });

--- a/packages/vue/src/components/Slot.ts
+++ b/packages/vue/src/components/Slot.ts
@@ -1,7 +1,7 @@
 import { warnOnce } from "@teseor/primitives";
 import { cloneVNode, defineComponent } from "vue";
 
-type EventHandler = (event: Event) => void;
+type EventHandler = (...args: unknown[]) => void;
 
 /**
  * Renders the default slot's first VNode with merged attrs from the parent —
@@ -42,11 +42,12 @@ export const Slot = defineComponent({
           const value = props[key];
           if (!Array.isArray(value)) continue;
           const handlers = value as EventHandler[];
-          props[key] = (event: Event) => {
+          props[key] = (...args: unknown[]) => {
             for (const fn of handlers) {
               if (typeof fn !== "function") continue;
-              fn(event);
-              if (event.defaultPrevented) return;
+              fn(...args);
+              const event = args[0] as { defaultPrevented?: boolean } | undefined;
+              if (event?.defaultPrevented === true) return;
             }
           };
         }


### PR DESCRIPTION
Closes #684.

## What

Vue `Slot` now short-circuits the slot handler when a child handler calls `event.preventDefault()` — matching React Slot's behavior since #660.

## Why

Vue's internal `mergeProps` collects merged `on*` handlers into a `[child, attr]` array and invokes each in order without consulting `event.defaultPrevented`. A consumer's `@click.prevent` on the child element therefore could not suppress the slot's own handler, which became a real bug for composites that use `asChild` (Menu, Popover, etc.). After `cloneVNode`, this PR wraps every `on*` array prop so the loop stops as soon as `defaultPrevented` becomes true. Single handlers (only child or only attrs) stay as plain functions and are left untouched.

## Test plan

- New `Slot.test.ts` case "skips slot handler when child calls event.preventDefault" mirrors React's parity test: child calls `preventDefault`, asserts `calls === ["child"]`. Watched it fail on the unfixed Slot, then pass after the wrap.
- Existing 7 Slot tests (multi-child, Fragment, empty, class merge, style merge, plain handler composition, aria/data forwarding) unchanged.
- `pnpm gen` drift-free; `pnpm lint`, `pnpm typecheck`, full `pnpm test` (343/343) clean.

## Out of scope

- React Slot — already handles this.
- Slot type system / rich slot content — #668.
- `useOverlay` event composition (different code path).
