### PR TITLE
feat(codegen): gen-docs overlay rows + reject keydown:Escape document/window

### DIFF
--- a/apps/docs/src/pages/components/button.astro
+++ b/apps/docs/src/pages/components/button.astro
@@ -142,7 +142,7 @@ import Base from "../../layouts/Base.astro";
       <h2>Accessibility</h2>
       <p>Role: <code>button</code></p>
       <table>
-        <thead><tr><th>Key</th><th>Action</th></tr></thead>
+        <thead><tr><th>Interaction</th><th>Action</th></tr></thead>
         <tbody>
         <tr><td><code>Enter</code></td><td>activate</td></tr>
         <tr><td><code>Space</code></td><td>activate</td></tr>

--- a/apps/docs/src/pages/components/tooltip.astro
+++ b/apps/docs/src/pages/components/tooltip.astro
@@ -103,6 +103,13 @@ import Base from "../../layouts/Base.astro";
     <section class="t-stack" data-gap="3">
       <h2>Accessibility</h2>
       <p>Role: <code>tooltip</code></p>
+      <table>
+        <thead><tr><th>Key</th><th>Action</th></tr></thead>
+        <tbody>
+        <tr><td><code>Escape</code></td><td>Closes the overlay. Topmost-wins when multiple overlays are open.</td></tr>
+        <tr><td><code>Outside pointer-down</code></td><td>Pressing outside the content closes the overlay.</td></tr>
+        </tbody>
+      </table>
     </section>
   </main>
 </Base>

--- a/apps/docs/src/pages/components/tooltip.astro
+++ b/apps/docs/src/pages/components/tooltip.astro
@@ -104,7 +104,7 @@ import Base from "../../layouts/Base.astro";
       <h2>Accessibility</h2>
       <p>Role: <code>tooltip</code></p>
       <table>
-        <thead><tr><th>Key</th><th>Action</th></tr></thead>
+        <thead><tr><th>Interaction</th><th>Action</th></tr></thead>
         <tbody>
         <tr><td><code>Escape</code></td><td>Closes the overlay. Topmost-wins when multiple overlays are open.</td></tr>
         <tr><td><code>Outside pointer-down</code></td><td>Pressing outside the content closes the overlay.</td></tr>

--- a/scripts/codegen/__tests__/__snapshots__/gen-docs.test.ts.snap
+++ b/scripts/codegen/__tests__/__snapshots__/gen-docs.test.ts.snap
@@ -145,7 +145,7 @@ import Base from "../../layouts/Base.astro";
       <h2>Accessibility</h2>
       <p>Role: <code>button</code></p>
       <table>
-        <thead><tr><th>Key</th><th>Action</th></tr></thead>
+        <thead><tr><th>Interaction</th><th>Action</th></tr></thead>
         <tbody>
         <tr><td><code>Enter</code></td><td>activate</td></tr>
         <tr><td><code>Space</code></td><td>activate</td></tr>
@@ -462,7 +462,7 @@ import Base from "../../layouts/Base.astro";
       <h2>Accessibility</h2>
       <p>Role: <code>tooltip</code></p>
       <table>
-        <thead><tr><th>Key</th><th>Action</th></tr></thead>
+        <thead><tr><th>Interaction</th><th>Action</th></tr></thead>
         <tbody>
         <tr><td><code>Escape</code></td><td>Closes the overlay. Topmost-wins when multiple overlays are open.</td></tr>
         <tr><td><code>Outside pointer-down</code></td><td>Pressing outside the content closes the overlay.</td></tr>

--- a/scripts/codegen/__tests__/__snapshots__/gen-docs.test.ts.snap
+++ b/scripts/codegen/__tests__/__snapshots__/gen-docs.test.ts.snap
@@ -354,3 +354,122 @@ import Base from "../../layouts/Base.astro";
 </Base>
 "
 `;
+
+exports[`gen-docs > renders the Tooltip docs page with universal overlay rows 1`] = `
+"---
+import { Tooltip, Button } from "@teseor/react";
+import Base from "../../layouts/Base.astro";
+---
+
+<Base title="Tooltip — Teseor">
+  <main class="t-stack" data-gap="6">
+    <h1>Tooltip</h1>
+    <p>A non-interactive hint that appears when its trigger is hovered or focused.</p>
+    <section class="t-stack" data-gap="3">
+      <h2>Examples</h2>
+      <div class="t-stack" data-gap="2">
+        <h3>default</h3>
+        <div class="t-cluster" data-gap="3">
+          <Tooltip text="Saves your changes." client:visible>
+            <Button variant="solid" intent="primary">Trigger</Button>
+          </Tooltip>
+        </div>
+        <pre><code>&lt;Tooltip text="Saves your changes."&gt;
+  &lt;Button variant="solid" intent="primary"&gt;Trigger&lt;/Button&gt;
+&lt;/Tooltip&gt;</code></pre>
+      </div>
+      <div class="t-stack" data-gap="2">
+        <h3>placement-right</h3>
+        <div class="t-cluster" data-gap="3">
+          <Tooltip text="Settings" placement="right" client:visible>
+            <Button variant="solid" intent="primary">Trigger</Button>
+          </Tooltip>
+        </div>
+        <pre><code>&lt;Tooltip text="Settings" placement="right"&gt;
+  &lt;Button variant="solid" intent="primary"&gt;Trigger&lt;/Button&gt;
+&lt;/Tooltip&gt;</code></pre>
+      </div>
+      <div class="t-stack" data-gap="2">
+        <h3>placement-bottom</h3>
+        <div class="t-cluster" data-gap="3">
+          <Tooltip text="More options" placement="bottom" client:visible>
+            <Button variant="solid" intent="primary">Trigger</Button>
+          </Tooltip>
+        </div>
+        <pre><code>&lt;Tooltip text="More options" placement="bottom"&gt;
+  &lt;Button variant="solid" intent="primary"&gt;Trigger&lt;/Button&gt;
+&lt;/Tooltip&gt;</code></pre>
+      </div>
+      <div class="t-stack" data-gap="2">
+        <h3>hide-on-mobile</h3>
+        <div class="t-cluster" data-gap="3">
+          <Tooltip text="⌘S" disabled={{ base: true, md: false }} client:visible>
+            <Button variant="solid" intent="primary">Trigger</Button>
+          </Tooltip>
+        </div>
+        <pre><code>&lt;Tooltip text="⌘S" disabled=&lbrace;&lbrace; base: true, md: false &rbrace;&rbrace;&gt;
+  &lt;Button variant="solid" intent="primary"&gt;Trigger&lt;/Button&gt;
+&lt;/Tooltip&gt;</code></pre>
+      </div>
+      <div class="t-stack" data-gap="2">
+        <h3>controlled-open</h3>
+        <div class="t-cluster" data-gap="3">
+          <Tooltip text="Step 1: click here" open client:visible>
+            <Button variant="solid" intent="primary">Trigger</Button>
+          </Tooltip>
+        </div>
+        <pre><code>&lt;Tooltip text="Step 1: click here" open&gt;
+  &lt;Button variant="solid" intent="primary"&gt;Trigger&lt;/Button&gt;
+&lt;/Tooltip&gt;</code></pre>
+      </div>
+    </section>
+    <section class="t-stack" data-gap="3">
+      <h2>Props</h2>
+      <table>
+        <thead><tr><th>Prop</th><th>Type</th><th>Default</th><th>Description</th></tr></thead>
+        <tbody>
+        <tr><td><code>open</code></td><td><code>boolean, controllable</code></td><td><code>false</code></td><td>Open state. Uncontrolled by default; pass \`open\` and optionally \`onOpenChange\` to drive it from the consumer (e.g. guided tours).</td></tr>
+        <tr><td><code>defaultOpen</code></td><td><code>boolean</code></td><td><code>false</code></td><td>Initial open state (uncontrolled).</td></tr>
+        <tr><td><code>onOpenChange</code></td><td><code>(open: boolean) =&gt; void</code></td><td><code>null</code></td><td>Fires when the open state changes.</td></tr>
+        <tr><td><code>disabled</code></td><td><code>boolean, responsive</code></td><td><code>false</code></td><td>Suppresses the tooltip entirely. Responsive so the tooltip can be hidden at narrow viewports (e.g. \`disabled: &lbrace; base: true, md: false &rbrace;\`).</td></tr>
+        <tr><td><code>openDelay</code></td><td><code>number</code></td><td><code>300</code></td><td>Milliseconds before the tooltip opens after hover or focus. Prevents flicker during cursor scanning.</td></tr>
+        <tr><td><code>closeDelay</code></td><td><code>number</code></td><td><code>0</code></td><td>Milliseconds before the tooltip closes after leave or blur.</td></tr>
+        <tr><td><code>text</code></td><td><code>string, slot</code></td><td><code>null</code></td><td>Tooltip content. Plain text; use Popover for interactive content.</td></tr>
+        <tr><td><code>placement</code></td><td><code>string, responsive</code></td><td><code>top</code></td><td>Preferred side relative to the trigger. CSS \`position-try-fallbacks\` auto-flips on overflow.</td></tr>
+        <tr><td><code>asChild</code></td><td><code>boolean</code></td><td><code>false</code></td><td>Render the trigger directly on the consumer's child element (cloneElement) instead of wrapping in a &lt;span&gt;. Single-child invariant; the child must accept &lt;code&gt;style&lt;/code&gt;, &lt;code&gt;data-state&lt;/code&gt;, &lt;code&gt;aria-describedby&lt;/code&gt;, and the trigger event handlers. Not compatible with Astro slots — use the default wrapper there.</td></tr>
+        </tbody>
+      </table>
+    </section>
+    <section class="t-stack" data-gap="3">
+      <h2>Tokens</h2>
+      <table>
+        <thead><tr><th>Token</th><th>Fallback</th><th>Description</th></tr></thead>
+        <tbody>
+        <tr><td><code>--t-tooltip-bg</code></td><td><code>--t-neutral-90</code></td><td>Background fill. Defaults to a dark neutral; consumers override via \`--t-tooltip-bg\`.</td></tr>
+        <tr><td><code>--t-tooltip-fg</code></td><td><code>--t-neutral-10</code></td><td>Text color. Pairs with \`bg\`.</td></tr>
+        <tr><td><code>--t-tooltip-pad-x</code></td><td><code>--t-space-3</code></td><td>Inline padding.</td></tr>
+        <tr><td><code>--t-tooltip-pad-y</code></td><td><code>--t-space-2</code></td><td>Block padding.</td></tr>
+        <tr><td><code>--t-tooltip-radius</code></td><td><code>--t-radius-sm</code></td><td>Corner radius.</td></tr>
+        <tr><td><code>--t-tooltip-gap</code></td><td><code>--t-space-2</code></td><td>Distance from the trigger.</td></tr>
+        <tr><td><code>--t-tooltip-dur</code></td><td><code>--t-dur-fast</code></td><td>Entry and exit duration.</td></tr>
+        <tr><td><code>--t-tooltip-ease</code></td><td><code>--t-ease-out</code></td><td>Entry and exit easing.</td></tr>
+        <tr><td><code>--t-tooltip-arrow-size</code></td><td><code>--t-space-3</code></td><td>Arrow square size. Rotated 45° to form the pointer; visible triangle is roughly size/√2 tall.</td></tr>
+        <tr><td><code>--t-tooltip-arrow-bg</code></td><td><code>--t-neutral-90</code></td><td>Arrow fill. Defaults to the same neutral as \`bg\` so the arrow blends seamlessly with the body.</td></tr>
+        </tbody>
+      </table>
+    </section>
+    <section class="t-stack" data-gap="3">
+      <h2>Accessibility</h2>
+      <p>Role: <code>tooltip</code></p>
+      <table>
+        <thead><tr><th>Key</th><th>Action</th></tr></thead>
+        <tbody>
+        <tr><td><code>Escape</code></td><td>Closes the overlay. Topmost-wins when multiple overlays are open.</td></tr>
+        <tr><td><code>Outside pointer-down</code></td><td>Pressing outside the content closes the overlay.</td></tr>
+        </tbody>
+      </table>
+    </section>
+  </main>
+</Base>
+"
+`;

--- a/scripts/codegen/__tests__/gen-docs.test.ts
+++ b/scripts/codegen/__tests__/gen-docs.test.ts
@@ -58,7 +58,6 @@ describe("gen-docs", () => {
         floating: "content",
         mode: "manual",
         anchorVar: "--t-fancy-popover-anchor",
-        modal: false,
       },
       a11y: { keyboard: { Escape: "Custom Escape wording from the spec." } },
       examples: [],

--- a/scripts/codegen/__tests__/gen-docs.test.ts
+++ b/scripts/codegen/__tests__/gen-docs.test.ts
@@ -49,8 +49,11 @@ describe("gen-docs", () => {
   test("spec-declared keyboard entries win on key collision with overlay rows", () => {
     // A spec that goes out of its way to redeclare an overlay key keeps its
     // wording; the synthetic row for that key is skipped. Other overlay keys
-    // still inject normally.
-    const spec = {
+    // still inject normally. Built via the real schema-parse + flatten path
+    // (same one `loadSpec` uses) so the fixture can't drift from the spec
+    // contract — a missing `parts:`, a wrong field name, an off-shape `a11y:`
+    // would fail Zod here.
+    const parsed = SpecSchema.parse({
       name: "fancy-popover",
       kind: "composite",
       popover: {
@@ -59,9 +62,15 @@ describe("gen-docs", () => {
         mode: "manual",
         anchorVar: "--t-fancy-popover-anchor",
       },
-      a11y: { keyboard: { Escape: "Custom Escape wording from the spec." } },
-      examples: [],
-    } as unknown as DocsSpec;
+      parts: {
+        trigger: { fromChildren: true },
+        content: {
+          element: "div",
+          a11y: { keyboard: { Escape: "Custom Escape wording from the spec." } },
+        },
+      },
+    });
+    const spec = flattenSpec(parsed) as DocsSpec;
     const rendered = renderDocsPage(spec);
     expect(rendered).toContain("Custom Escape wording from the spec.");
     expect(rendered).not.toContain("Topmost-wins when multiple overlays are open.");

--- a/scripts/codegen/__tests__/gen-docs.test.ts
+++ b/scripts/codegen/__tests__/gen-docs.test.ts
@@ -4,12 +4,15 @@ import { describe, expect, test } from "vitest";
 import { parse as parseYaml } from "yaml";
 import type { DocsSpec } from "../src/generators/gen-docs.ts";
 import { renderDocsPage } from "../src/generators/gen-docs.ts";
+import { flattenSpec } from "../src/lib/flatten.ts";
+import { Spec as SpecSchema } from "../src/schema.ts";
 
 const REPO_ROOT = resolve(import.meta.dirname, "..", "..", "..");
 
 async function loadSpec(name: string): Promise<DocsSpec> {
   const raw = await readFile(resolve(REPO_ROOT, "specs", `${name}.yaml`), "utf8");
-  return parseYaml(raw);
+  const parsed = SpecSchema.parse(parseYaml(raw));
+  return flattenSpec(parsed) as DocsSpec;
 }
 
 describe("gen-docs", () => {
@@ -23,6 +26,24 @@ describe("gen-docs", () => {
 
   test("renders the Cluster docs page", async () => {
     expect(renderDocsPage(await loadSpec("cluster"))).toMatchSnapshot();
+  });
+
+  test("renders the Tooltip docs page with universal overlay rows", async () => {
+    expect(renderDocsPage(await loadSpec("tooltip"))).toMatchSnapshot();
+  });
+
+  test("injects Escape + outside-pointer rows for any spec with a popover block", async () => {
+    const rendered = renderDocsPage(await loadSpec("tooltip"));
+    expect(rendered).toContain("<code>Escape</code>");
+    expect(rendered).toContain("Topmost-wins when multiple overlays are open.");
+    expect(rendered).toContain("<code>Outside pointer-down</code>");
+    expect(rendered).toContain("Pressing outside the content closes the overlay.");
+  });
+
+  test("omits the universal overlay rows for non-overlay specs", async () => {
+    const rendered = renderDocsPage(await loadSpec("button"));
+    expect(rendered).not.toContain("Outside pointer-down");
+    expect(rendered).not.toContain("Topmost-wins");
   });
 
   test("is deterministic across runs", async () => {

--- a/scripts/codegen/__tests__/gen-docs.test.ts
+++ b/scripts/codegen/__tests__/gen-docs.test.ts
@@ -46,6 +46,32 @@ describe("gen-docs", () => {
     expect(rendered).not.toContain("Topmost-wins");
   });
 
+  test("spec-declared keyboard entries win on key collision with overlay rows", () => {
+    // A spec that goes out of its way to redeclare an overlay key keeps its
+    // wording; the synthetic row for that key is skipped. Other overlay keys
+    // still inject normally.
+    const spec = {
+      name: "fancy-popover",
+      kind: "composite",
+      popover: {
+        anchor: "trigger",
+        floating: "content",
+        mode: "manual",
+        anchorVar: "--t-fancy-popover-anchor",
+        modal: false,
+      },
+      a11y: { keyboard: { Escape: "Custom Escape wording from the spec." } },
+      examples: [],
+    } as unknown as DocsSpec;
+    const rendered = renderDocsPage(spec);
+    expect(rendered).toContain("Custom Escape wording from the spec.");
+    expect(rendered).not.toContain("Topmost-wins when multiple overlays are open.");
+    // Outside pointer-down is not redeclared, so the universal row still
+    // injects.
+    expect(rendered).toContain("<code>Outside pointer-down</code>");
+    expect(rendered).toContain("Pressing outside the content closes the overlay.");
+  });
+
   test("is deterministic across runs", async () => {
     const spec = await loadSpec("button");
     expect(renderDocsPage(spec)).toBe(renderDocsPage(spec));

--- a/scripts/codegen/src/generators/gen-docs.ts
+++ b/scripts/codegen/src/generators/gen-docs.ts
@@ -283,8 +283,10 @@ function renderA11y(spec: DocsSpec): string {
     lines.push(`      <p>Role: <code>${esc(role)}</code></p>`);
   }
   if (keyboard.length > 0) {
+    // Header is `Interaction`, not `Key` — overlay specs inject a
+    // pointer-down row alongside the keyboard rows and `Key` would mis-label it.
     const rows = keyboard.map(([key, action]) => [`<code>${esc(key)}</code>`, esc(action)]);
-    lines.push(renderTable(["Key", "Action"], rows));
+    lines.push(renderTable(["Interaction", "Action"], rows));
   }
   return section("Accessibility", lines.join("\n"));
 }

--- a/scripts/codegen/src/generators/gen-docs.ts
+++ b/scripts/codegen/src/generators/gen-docs.ts
@@ -269,7 +269,13 @@ const OVERLAY_KEYBOARD_ROWS: Array<[string, string]> = [
 function renderA11y(spec: DocsSpec): string {
   const role = spec.a11y?.role;
   const declaredKeyboard: Array<[string, string]> = Object.entries(spec.a11y?.keyboard ?? {});
-  const overlayKeyboard = spec.popover ? OVERLAY_KEYBOARD_ROWS : [];
+  // Spec-declared rows win when the key collides — a spec that goes out of its
+  // way to redeclare `Escape` or `Outside pointer-down` keeps its wording, and
+  // the universal contract only fills in keys the spec didn't speak to.
+  const declaredKeys = new Set(declaredKeyboard.map(([key]) => key));
+  const overlayKeyboard = spec.popover
+    ? OVERLAY_KEYBOARD_ROWS.filter(([key]) => !declaredKeys.has(key))
+    : [];
   const keyboard = [...declaredKeyboard, ...overlayKeyboard];
   if (!role && keyboard.length === 0) return "";
   const lines: string[] = [];

--- a/scripts/codegen/src/generators/gen-docs.ts
+++ b/scripts/codegen/src/generators/gen-docs.ts
@@ -257,21 +257,29 @@ function renderTokens(spec: DocsSpec): string {
   return section("Tokens", renderTable(["Token", "Fallback", "Description"], rows));
 }
 
+// Universal overlay dismissal contract, wired in `useOverlay` via
+// `useDismissableLayer` for every spec with a `popover:` block (PR #698).
+// Injected here so individual specs don't redeclare the rows in their
+// `a11y.keyboard` block and drift from the runtime contract.
+const OVERLAY_KEYBOARD_ROWS: Array<[string, string]> = [
+  ["Escape", "Closes the overlay. Topmost-wins when multiple overlays are open."],
+  ["Outside pointer-down", "Pressing outside the content closes the overlay."],
+];
+
 function renderA11y(spec: DocsSpec): string {
-  if (!spec.a11y) return "";
+  const role = spec.a11y?.role;
+  const declaredKeyboard: Array<[string, string]> = Object.entries(spec.a11y?.keyboard ?? {});
+  const overlayKeyboard = spec.popover ? OVERLAY_KEYBOARD_ROWS : [];
+  const keyboard = [...declaredKeyboard, ...overlayKeyboard];
+  if (!role && keyboard.length === 0) return "";
   const lines: string[] = [];
-  if (spec.a11y.role) {
-    lines.push(`      <p>Role: <code>${esc(spec.a11y.role)}</code></p>`);
+  if (role) {
+    lines.push(`      <p>Role: <code>${esc(role)}</code></p>`);
   }
-  const keyboard = spec.a11y.keyboard ?? {};
-  if (Object.keys(keyboard).length > 0) {
-    const rows = Object.entries(keyboard).map(([key, action]) => [
-      `<code>${esc(key)}</code>`,
-      esc(action),
-    ]);
+  if (keyboard.length > 0) {
+    const rows = keyboard.map(([key, action]) => [`<code>${esc(key)}</code>`, esc(action)]);
     lines.push(renderTable(["Key", "Action"], rows));
   }
-  if (lines.length === 0) return "";
   return section("Accessibility", lines.join("\n"));
 }
 

--- a/scripts/codegen/src/semantic-checks.test.ts
+++ b/scripts/codegen/src/semantic-checks.test.ts
@@ -11,6 +11,7 @@ import {
   checkExamplesReferences,
   checkInteractionRefs,
   checkMotionSymmetry,
+  checkOverlayDismissalRules,
   checkResponsiveExplicit,
   checkTokenContract,
   checkVariantChoiceKeys,
@@ -608,5 +609,66 @@ describe("checkInteractionRefs", () => {
       ],
     } as Spec;
     expect(checkInteractionRefs(spec)).toEqual([]);
+  });
+});
+
+describe("checkOverlayDismissalRules", () => {
+  test("returns no issues when no interactions are declared", () => {
+    expect(checkOverlayDismissalRules(makeButton())).toEqual([]);
+  });
+
+  test("ignores keydown:Escape rules targeting a part (not document/window)", () => {
+    const spec = makeButton({
+      interactions: [{ on: { event: "keydown", key: "Escape", target: "trigger" }, do: "close" }],
+    });
+    expect(checkOverlayDismissalRules(spec)).toEqual([]);
+  });
+
+  test("ignores keydown rules with a different key on document", () => {
+    const spec = makeButton({
+      interactions: [{ on: { event: "keydown", key: "Enter", target: "document" }, do: "open" }],
+    });
+    expect(checkOverlayDismissalRules(spec)).toEqual([]);
+  });
+
+  test("ignores non-keydown rules on document", () => {
+    const spec = makeButton({
+      interactions: [{ on: { event: "pointerdown", target: "document" }, do: "close" }],
+    });
+    expect(checkOverlayDismissalRules(spec)).toEqual([]);
+  });
+
+  test("flags keydown:Escape on document", () => {
+    const spec = makeButton({
+      interactions: [{ on: { event: "keydown", key: "Escape", target: "document" }, do: "close" }],
+    });
+    const issues = checkOverlayDismissalRules(spec);
+    expect(issues).toHaveLength(1);
+    expect(issues[0]?.path).toBe("interactions[0]");
+    expect(issues[0]?.message).toMatch(/useDismissableLayer/);
+    expect(issues[0]?.message).toMatch(/document/);
+  });
+
+  test("flags keydown:Escape on window", () => {
+    const spec = makeButton({
+      interactions: [{ on: { event: "keydown", key: "Escape", target: "window" }, do: "close" }],
+    });
+    const issues = checkOverlayDismissalRules(spec);
+    expect(issues).toHaveLength(1);
+    expect(issues[0]?.message).toMatch(/window/);
+  });
+
+  test("flags each offending rule independently", () => {
+    const spec = makeButton({
+      interactions: [
+        { on: { event: "keydown", key: "Escape", target: "document" }, do: "close" },
+        { on: { event: "pointerenter", target: "trigger" }, do: "open" },
+        { on: { event: "keydown", key: "Escape", target: "window" }, do: "close" },
+      ],
+    });
+    expect(checkOverlayDismissalRules(spec).map((i) => i.path)).toEqual([
+      "interactions[0]",
+      "interactions[2]",
+    ]);
   });
 });

--- a/scripts/codegen/src/semantic-checks.test.ts
+++ b/scripts/codegen/src/semantic-checks.test.ts
@@ -613,33 +613,60 @@ describe("checkInteractionRefs", () => {
 });
 
 describe("checkOverlayDismissalRules", () => {
+  /** Tooltip-shaped overlay fixture — composite with a `popover:` block.
+   *  The check only fires for specs with a popover block (overlays go through
+   *  `useOverlay`, where the dismissable-layer ownership applies). */
+  function makeOverlay(overrides: Partial<Extract<Spec, { kind: "composite" }>> = {}): Spec {
+    return {
+      name: "tooltip",
+      kind: "composite",
+      popover: {
+        anchor: "trigger",
+        floating: "content",
+        mode: "manual",
+        anchorVar: "--t-tooltip-anchor",
+      },
+      parts: { trigger: { fromChildren: true }, content: { element: "div" } },
+      ...overrides,
+    } as Spec;
+  }
+
   test("returns no issues when no interactions are declared", () => {
-    expect(checkOverlayDismissalRules(makeButton())).toEqual([]);
+    expect(checkOverlayDismissalRules(makeOverlay())).toEqual([]);
+  });
+
+  test("ignores specs without a popover block (non-overlay)", () => {
+    // Non-overlay specs don't go through useOverlay; the dismissable-layer
+    // ownership rationale doesn't apply, so the check stays quiet.
+    const spec = makeButton({
+      interactions: [{ on: { event: "keydown", key: "Escape", target: "document" }, do: "close" }],
+    });
+    expect(checkOverlayDismissalRules(spec)).toEqual([]);
   });
 
   test("ignores keydown:Escape rules targeting a part (not document/window)", () => {
-    const spec = makeButton({
+    const spec = makeOverlay({
       interactions: [{ on: { event: "keydown", key: "Escape", target: "trigger" }, do: "close" }],
     });
     expect(checkOverlayDismissalRules(spec)).toEqual([]);
   });
 
   test("ignores keydown rules with a different key on document", () => {
-    const spec = makeButton({
+    const spec = makeOverlay({
       interactions: [{ on: { event: "keydown", key: "Enter", target: "document" }, do: "open" }],
     });
     expect(checkOverlayDismissalRules(spec)).toEqual([]);
   });
 
   test("ignores non-keydown rules on document", () => {
-    const spec = makeButton({
+    const spec = makeOverlay({
       interactions: [{ on: { event: "pointerdown", target: "document" }, do: "close" }],
     });
     expect(checkOverlayDismissalRules(spec)).toEqual([]);
   });
 
   test("flags keydown:Escape on document", () => {
-    const spec = makeButton({
+    const spec = makeOverlay({
       interactions: [{ on: { event: "keydown", key: "Escape", target: "document" }, do: "close" }],
     });
     const issues = checkOverlayDismissalRules(spec);
@@ -650,7 +677,7 @@ describe("checkOverlayDismissalRules", () => {
   });
 
   test("flags keydown:Escape on window", () => {
-    const spec = makeButton({
+    const spec = makeOverlay({
       interactions: [{ on: { event: "keydown", key: "Escape", target: "window" }, do: "close" }],
     });
     const issues = checkOverlayDismissalRules(spec);
@@ -659,7 +686,7 @@ describe("checkOverlayDismissalRules", () => {
   });
 
   test("flags each offending rule independently", () => {
-    const spec = makeButton({
+    const spec = makeOverlay({
       interactions: [
         { on: { event: "keydown", key: "Escape", target: "document" }, do: "close" },
         { on: { event: "pointerenter", target: "trigger" }, do: "open" },

--- a/scripts/codegen/src/semantic-checks.test.ts
+++ b/scripts/codegen/src/semantic-checks.test.ts
@@ -11,7 +11,7 @@ import {
   checkExamplesReferences,
   checkInteractionRefs,
   checkMotionSymmetry,
-  checkOverlayDismissalRules,
+  checkOverlayEscapeRules,
   checkResponsiveExplicit,
   checkTokenContract,
   checkVariantChoiceKeys,
@@ -612,7 +612,7 @@ describe("checkInteractionRefs", () => {
   });
 });
 
-describe("checkOverlayDismissalRules", () => {
+describe("checkOverlayEscapeRules", () => {
   /** Tooltip-shaped overlay fixture — composite with a `popover:` block.
    *  The check only fires for specs with a popover block (overlays go through
    *  `useOverlay`, where the dismissable-layer ownership applies). */
@@ -632,7 +632,7 @@ describe("checkOverlayDismissalRules", () => {
   }
 
   test("returns no issues when no interactions are declared", () => {
-    expect(checkOverlayDismissalRules(makeOverlay())).toEqual([]);
+    expect(checkOverlayEscapeRules(makeOverlay())).toEqual([]);
   });
 
   test("ignores specs without a popover block (non-overlay)", () => {
@@ -641,35 +641,35 @@ describe("checkOverlayDismissalRules", () => {
     const spec = makeButton({
       interactions: [{ on: { event: "keydown", key: "Escape", target: "document" }, do: "close" }],
     });
-    expect(checkOverlayDismissalRules(spec)).toEqual([]);
+    expect(checkOverlayEscapeRules(spec)).toEqual([]);
   });
 
   test("ignores keydown:Escape rules targeting a part (not document/window)", () => {
     const spec = makeOverlay({
       interactions: [{ on: { event: "keydown", key: "Escape", target: "trigger" }, do: "close" }],
     });
-    expect(checkOverlayDismissalRules(spec)).toEqual([]);
+    expect(checkOverlayEscapeRules(spec)).toEqual([]);
   });
 
   test("ignores keydown rules with a different key on document", () => {
     const spec = makeOverlay({
       interactions: [{ on: { event: "keydown", key: "Enter", target: "document" }, do: "open" }],
     });
-    expect(checkOverlayDismissalRules(spec)).toEqual([]);
+    expect(checkOverlayEscapeRules(spec)).toEqual([]);
   });
 
   test("ignores non-keydown rules on document", () => {
     const spec = makeOverlay({
       interactions: [{ on: { event: "pointerdown", target: "document" }, do: "close" }],
     });
-    expect(checkOverlayDismissalRules(spec)).toEqual([]);
+    expect(checkOverlayEscapeRules(spec)).toEqual([]);
   });
 
   test("flags keydown:Escape on document", () => {
     const spec = makeOverlay({
       interactions: [{ on: { event: "keydown", key: "Escape", target: "document" }, do: "close" }],
     });
-    const issues = checkOverlayDismissalRules(spec);
+    const issues = checkOverlayEscapeRules(spec);
     expect(issues).toHaveLength(1);
     expect(issues[0]?.path).toBe("interactions[0]");
     expect(issues[0]?.message).toMatch(/useDismissableLayer/);
@@ -680,7 +680,7 @@ describe("checkOverlayDismissalRules", () => {
     const spec = makeOverlay({
       interactions: [{ on: { event: "keydown", key: "Escape", target: "window" }, do: "close" }],
     });
-    const issues = checkOverlayDismissalRules(spec);
+    const issues = checkOverlayEscapeRules(spec);
     expect(issues).toHaveLength(1);
     expect(issues[0]?.message).toMatch(/window/);
   });
@@ -693,7 +693,7 @@ describe("checkOverlayDismissalRules", () => {
         { on: { event: "keydown", key: "Escape", target: "window" }, do: "close" },
       ],
     });
-    expect(checkOverlayDismissalRules(spec).map((i) => i.path)).toEqual([
+    expect(checkOverlayEscapeRules(spec).map((i) => i.path)).toEqual([
       "interactions[0]",
       "interactions[2]",
     ]);

--- a/scripts/codegen/src/semantic-checks.ts
+++ b/scripts/codegen/src/semantic-checks.ts
@@ -751,7 +751,7 @@ export function checkInteractionRefs(spec: Spec): Issue[] {
  * up for overlays via `useOverlay`. A non-overlay spec with a document-target
  * rule has no layer to conflict with, so the rationale doesn't apply.
  */
-export function checkOverlayDismissalRules(spec: Spec): Issue[] {
+export function checkOverlayEscapeRules(spec: Spec): Issue[] {
   if (!spec.popover) return [];
   const rules = spec.interactions ?? [];
   if (rules.length === 0) return [];
@@ -793,7 +793,7 @@ export function runSemanticChecks(
     ...checkResponsiveExplicit(spec),
     ...checkAsIsConstrained(spec),
     ...checkInteractionRefs(spec),
-    ...checkOverlayDismissalRules(spec),
+    ...checkOverlayEscapeRules(spec),
   ];
 }
 

--- a/scripts/codegen/src/semantic-checks.ts
+++ b/scripts/codegen/src/semantic-checks.ts
@@ -737,6 +737,35 @@ export function checkInteractionRefs(spec: Spec): Issue[] {
   return issues;
 }
 
+// ── Overlay dismissal owned by useDismissableLayer ──────────────────────────
+
+/**
+ * Escape on `document` / `window` is owned by `useDismissableLayer` (stacked,
+ * topmost-wins) since PR #698. A spec-level
+ * `{ event: "keydown", key: "Escape", target: "document" | "window" }` rule
+ * bypasses the stack and fires `setOpen(false)` twice on one press — once
+ * via the layer, once via the spec interaction. Reject at spec time so a
+ * future composite spec can't reintroduce the duplicate-fire path.
+ */
+export function checkOverlayDismissalRules(spec: Spec): Issue[] {
+  const rules = spec.interactions ?? [];
+  if (rules.length === 0) return [];
+  const issues: Issue[] = [];
+  rules.forEach((rule, i) => {
+    if (rule.on.event !== "keydown") return;
+    if (rule.on.key !== "Escape") return;
+    if (rule.on.target !== "document" && rule.on.target !== "window") return;
+    issues.push(
+      issue(
+        spec.name,
+        `interactions[${i}]`,
+        `keydown:Escape on '${rule.on.target}' is owned by useDismissableLayer (stacked, topmost-wins). Remove this rule.`,
+      ),
+    );
+  });
+  return issues;
+}
+
 // ── Aggregate ───────────────────────────────────────────────────────────────
 
 export function runSemanticChecks(
@@ -759,6 +788,7 @@ export function runSemanticChecks(
     ...checkResponsiveExplicit(spec),
     ...checkAsIsConstrained(spec),
     ...checkInteractionRefs(spec),
+    ...checkOverlayDismissalRules(spec),
   ];
 }
 

--- a/scripts/codegen/src/semantic-checks.ts
+++ b/scripts/codegen/src/semantic-checks.ts
@@ -746,8 +746,13 @@ export function checkInteractionRefs(spec: Spec): Issue[] {
  * bypasses the stack and fires `setOpen(false)` twice on one press — once
  * via the layer, once via the spec interaction. Reject at spec time so a
  * future composite spec can't reintroduce the duplicate-fire path.
+ *
+ * Scoped to specs with a `popover:` block — `useDismissableLayer` only wires
+ * up for overlays via `useOverlay`. A non-overlay spec with a document-target
+ * rule has no layer to conflict with, so the rationale doesn't apply.
  */
 export function checkOverlayDismissalRules(spec: Spec): Issue[] {
+  if (!spec.popover) return [];
   const rules = spec.interactions ?? [];
   if (rules.length === 0) return [];
   const issues: Issue[] = [];


### PR DESCRIPTION
## What

- `gen-docs.ts` injects two synthetic Accessibility rows for any spec with a `popover:` block:
  - `Escape` — "Closes the overlay. Topmost-wins when multiple overlays are open."
  - `Outside pointer-down` — "Pressing outside the content closes the overlay."
- New semantic check `checkOverlayDismissalRules` rejects `{ event: "keydown", key: "Escape", target: "document" | "window" }` interactions at spec time.
- Tooltip's regenerated docs page picks up both rows; Button (non-overlay) doesn't.

## Why

PR #698 wired `useDismissableLayer` into `useOverlay` as a universal contract — Escape topmost-wins and outside-pointer-down dismissal apply to every overlay. `gen-docs.ts` only read `spec.a11y.keyboard` so the docs were silent on these behaviors; redeclaring them in each spec would duplicate the contract and drift if the runtime changes. Synthesizing the rows in the generator keeps one source of truth across Tooltip, Popover, Dialog, Menu.

The validator rejection closes the symmetric gap: nothing today stops a future spec from reintroducing `keydown:Escape@document`, which would bypass the stack and fire `setOpen(false)` twice on one press. Tooltip already lacks the rule post-#698; this just prevents it from coming back.

## Test plan

- `pnpm gen` regenerates Tooltip docs with both rows.
- `pnpm test` — `gen-docs` suite covers Tooltip snapshot, injection wording, and the negative case for non-overlay specs. `semantic-checks` suite covers `document`, `window`, mixed-rule, and the no-op cases (non-Escape key, non-keydown event, part-targeted Escape).
- `pnpm typecheck` and `pnpm lint` green.

## Out of scope

- Auto-injection for non-overlay components.
- Per-spec opt-out (none of the planned overlays need it).
- PR B's modality / portal / focus-trap work — tracked under #675.

Closes #700
Closes #701
