### PR TITLE
feat(docs): auto-generate sidenav from specs/

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -15,7 +15,7 @@
     "@teseor/react": "workspace:*",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
-    "yaml": "^2.9.0"
+    "yaml": "^2.8.3"
   },
   "devDependencies": {
     "@astrojs/check": "^0.9.9",

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -14,7 +14,8 @@
     "@teseor/css": "workspace:*",
     "@teseor/react": "workspace:*",
     "react": "^19.2.6",
-    "react-dom": "^19.2.6"
+    "react-dom": "^19.2.6",
+    "yaml": "^2.9.0"
   },
   "devDependencies": {
     "@astrojs/check": "^0.9.9",

--- a/apps/docs/src/layouts/Base.astro
+++ b/apps/docs/src/layouts/Base.astro
@@ -2,6 +2,7 @@
 // dogfood-allow: temporary layout shell — Sidebar primitive lands in v0.3
 import { ClientRouter } from "astro:transitions";
 import "@teseor/css";
+import { components } from "../lib/components.ts";
 
 interface Props {
   title: string;
@@ -11,10 +12,7 @@ const { title } = Astro.props;
 
 const navItems = [
   { href: "/", label: "Home" },
-  { href: "/components/button/", label: "Button" },
-  { href: "/components/cluster/", label: "Cluster" },
-  { href: "/components/stack/", label: "Stack" },
-  { href: "/components/tooltip/", label: "Tooltip" },
+  ...components.map((c) => ({ href: c.href, label: c.label })),
 ];
 
 const currentPath = Astro.url.pathname.replace(/\/$/, "") || "/";

--- a/apps/docs/src/lib/components.ts
+++ b/apps/docs/src/lib/components.ts
@@ -1,0 +1,78 @@
+import { parse as parseYaml } from "yaml";
+
+/** Raw YAML strings for every spec, keyed by Vite-resolved path. */
+const rawSpecs = import.meta.glob<string>("../../../../specs/*.yaml", {
+  query: "?raw",
+  import: "default",
+  eager: true,
+});
+
+type SpecFile = { name: string; description?: string };
+
+function pascalCase(name: string): string {
+  return name
+    .split(/[-_\s]+/)
+    .map((part) => (part.length === 0 ? part : part.charAt(0).toUpperCase() + part.slice(1)))
+    .join("");
+}
+
+function basename(path: string): string {
+  const lastSlash = path.lastIndexOf("/");
+  return lastSlash === -1 ? path : path.slice(lastSlash + 1);
+}
+
+function parseSpec(path: string, raw: string): SpecFile {
+  const file = basename(path);
+  const parsed = parseYaml(raw) as { name?: unknown; description?: unknown };
+  if (typeof parsed?.name !== "string" || parsed.name.length === 0) {
+    throw new Error(`spec ${file} is missing a string \`name\` field`);
+  }
+  const expected = file.slice(0, -5);
+  if (parsed.name !== expected) {
+    throw new Error(`spec ${file} declares name "${parsed.name}"; expected "${expected}"`);
+  }
+  const description = typeof parsed.description === "string" ? parsed.description : undefined;
+  return { name: parsed.name, description };
+}
+
+type ComponentNavEntry = {
+  /** Lowercase spec name. */
+  name: string;
+  /** Display label in PascalCase. */
+  label: string;
+  /** Generated docs page route. */
+  href: string;
+  /** Spec description, if present. */
+  description?: string;
+};
+
+/**
+ * Build-time list of component nav entries derived from `specs/*.yaml`.
+ *
+ * Underscore-prefixed files (`_vocabulary.yaml`, `_breakpoints.yaml`) are
+ * skipped — they are configuration, not components. Entries are sorted
+ * alphabetically by display label: the current sidenav is a flat list and
+ * with five components the marginal value of section headings is low.
+ * Groupings (per `specs/_vocabulary.yaml`) can replace this when the list
+ * grows past a single screen.
+ */
+function loadComponents(): ComponentNavEntry[] {
+  const entries = Object.entries(rawSpecs)
+    .filter(([path]) => !basename(path).startsWith("_"))
+    .map(([path, raw]) => {
+      const spec = parseSpec(path, raw);
+      return {
+        name: spec.name,
+        label: pascalCase(spec.name),
+        href: `/components/${spec.name}/`,
+        description: spec.description,
+      };
+    });
+  entries.sort((a, b) => a.label.localeCompare(b.label));
+  return entries;
+}
+
+const components = loadComponents();
+
+export type { ComponentNavEntry };
+export { components };

--- a/apps/docs/src/lib/components.ts
+++ b/apps/docs/src/lib/components.ts
@@ -23,7 +23,12 @@ function basename(path: string): string {
 
 function parseSpec(path: string, raw: string): SpecFile {
   const file = basename(path);
-  const parsed = parseYaml(raw) as { name?: unknown; description?: unknown };
+  let parsed: { name?: unknown; description?: unknown };
+  try {
+    parsed = parseYaml(raw) as { name?: unknown; description?: unknown };
+  } catch (err) {
+    throw new Error(`spec ${file} failed to parse: ${err instanceof Error ? err.message : err}`);
+  }
   if (typeof parsed?.name !== "string" || parsed.name.length === 0) {
     throw new Error(`spec ${file} is missing a string \`name\` field`);
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,6 +77,9 @@ importers:
       react-dom:
         specifier: ^19.2.6
         version: 19.2.6(react@19.2.6)
+      yaml:
+        specifier: ^2.8.3
+        version: 2.9.0
     devDependencies:
       '@astrojs/check':
         specifier: ^0.9.9


### PR DESCRIPTION
## What

Replaces the hand-maintained component list in `apps/docs/src/layouts/Base.astro` with a build-time read of `specs/*.yaml`. New entries appear automatically after `pnpm gen` and a fresh build.

## Why

The hand-maintained list drifts. New components require an extra edit and reviewers notice the gap only when they look at the rendered nav.

## How

`apps/docs/src/lib/components.ts` uses Vite's `import.meta.glob` with `query: '?raw'` to pull every `specs/*.yaml` at build time, parses each with the existing `yaml` package, and exports a typed list. `Base.astro` imports the list and spreads it after the "Home" entry.

Underscore-prefixed files (`_vocabulary.yaml`, `_breakpoints.yaml`) are skipped — they are configuration, not components.

### Sort order

Alphabetical by display label. The vocabulary file (`specs/_vocabulary.yaml`) has section comments (Atoms, Surfaces, Navigation, Overlays, etc.) but with four shipped components and a flat-list visual today, section headers would add structure that isn't earning its keep yet. Grouping by vocabulary sections is a one-helper change once the list grows past a single screen.

## Test plan

- `pnpm build:docs` renders all four current components (Button, Cluster, Stack, Tooltip) in the sidenav.
- `pnpm --filter @teseor/docs run dev` serves the same list on the home route.
- `pnpm test` and `pnpm lint` are clean.
- Manual: adding a spec file under `specs/` (without touching `Base.astro`) surfaces it in the next build.

## Out of scope

- Vocabulary-grouped sections (deferred until the list is longer).
- Token / architecture nav sections (none exist today).
- Docs page generation (already handled by `gen-docs`).

Closes #709