### PR TITLE
feat(repo): pnpm review (local pre-flight review via gh-models)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 .claude/worktrees/
 .claude/plans/
 .claude/scheduled_tasks.lock
+.claude/preflight-review.enabled
 
 # Toolchain
 node_modules/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,11 +41,16 @@ See `docs/process/dev-scripts.md` for the full script catalog.
 ### Optional local pre-flight review
 
 `pnpm review` sends the current branch's diff (against `origin/main`) to a
-GitHub Models LLM and prints suggestions in the shape of a code review.
-Catches the kinds of things the GitHub Copilot PR reviewer would flag —
-naming overpromise, schema vs fixture drift, a11y semantics, SSR concerns,
-public-API leakage. Free under a paid Copilot plan, runs in 5-15 s, never
-blocks.
+GitHub Models endpoint via the `gh-models` extension and prints suggestions
+on:
+
+- Naming overpromise (function name covers more than the implementation).
+- Schema vs fixture drift (`as unknown as Spec` hiding missing fields).
+- Accessibility semantics (`aria-modal`, `aria-describedby` on the wrong
+  element, missing accessible name).
+- SSR-hydration patterns (`typeof document !== "undefined"` in JSX).
+- Public-API leakage (test-only helpers exported from production modules).
+- Cross-file consistency on renames.
 
 ```bash
 gh extension install github/gh-models

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,6 +55,19 @@ pnpm review
 `BASE=<ref>` overrides the comparison base (default `origin/main`).
 `MODEL=<id>` overrides the model (default `openai/gpt-4o`).
 
+#### Auto-run on every push (opt-in)
+
+Enable the pre-push hook for this clone:
+
+```bash
+touch .claude/preflight-review.enabled
+```
+
+`pnpm review` then runs as part of `pre-push` and prints suggestions before
+the push. **Warn-only** — never blocks. Disable with
+`rm .claude/preflight-review.enabled`. The marker file is gitignored, so the
+opt-in is per-machine.
+
 ### Worktrees
 
 If you use `git worktree`, `core.hooksPath` may inherit from the main repo and

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,6 +38,23 @@ pnpm test:e2e   # Playwright suite (see Playwright browsers below)
 
 See `docs/process/dev-scripts.md` for the full script catalog.
 
+### Optional local pre-flight review
+
+`pnpm review` sends the current branch's diff (against `origin/main`) to a
+GitHub Models LLM and prints suggestions in the shape of a code review.
+Catches the kinds of things the GitHub Copilot PR reviewer would flag —
+naming overpromise, schema vs fixture drift, a11y semantics, SSR concerns,
+public-API leakage. Free under a paid Copilot plan, runs in 5-15 s, never
+blocks.
+
+```bash
+gh extension install github/gh-models
+pnpm review
+```
+
+`BASE=<ref>` overrides the comparison base (default `origin/main`).
+`MODEL=<id>` overrides the model (default `openai/gpt-4o`).
+
 ### Worktrees
 
 If you use `git worktree`, `core.hooksPath` may inherit from the main repo and

--- a/docs/process/dev-scripts.md
+++ b/docs/process/dev-scripts.md
@@ -16,6 +16,7 @@ The bare-verb defaults are the verbs you reach for daily: `dev`, `build`, `test`
 | `pnpm gen` | All codegen (wrappers + contract + docs + tests) | After spec changes | Developer + CI |
 | `pnpm gen --component=<name>` | Regen one component, all targets | Inner loop on a spec | Developer |
 | `pnpm gen --target=<react\|vue\|...>` | One target, all components | Debugging a generator | Developer |
+| `pnpm review` | Sends `git diff origin/main...HEAD` to a GitHub Models LLM (via `gh-models`) with the project's review prompt. Optional; never blocks. Requires `gh extension install github/gh-models` | Before pushing a contentious change; cheaper than a Copilot review round | Developer |
 | `pnpm test` | Vitest suite (unit + integration) — every test under `packages/**` and `scripts/**` | Before push; in CI | Developer + CI |
 | `pnpm test:e2e` | Playwright DOM-contract suite (`tests/*.spec.ts`) | When wrappers or interactions changed; in CI | Developer + CI |
 | `pnpm test:visual` | Placeholder — the pixel-diff suite lands with the visual gate | When visuals changed | Developer + CI |

--- a/docs/process/dev-scripts.md
+++ b/docs/process/dev-scripts.md
@@ -16,7 +16,7 @@ The bare-verb defaults are the verbs you reach for daily: `dev`, `build`, `test`
 | `pnpm gen` | All codegen (wrappers + contract + docs + tests) | After spec changes | Developer + CI |
 | `pnpm gen --component=<name>` | Regen one component, all targets | Inner loop on a spec | Developer |
 | `pnpm gen --target=<react\|vue\|...>` | One target, all components | Debugging a generator | Developer |
-| `pnpm review` | Sends `git diff origin/main...HEAD` to a GitHub Models LLM (via `gh-models`) with the project's review prompt. Optional; never blocks. Requires `gh extension install github/gh-models` | Before pushing a contentious change; cheaper than a Copilot review round | Developer |
+| `pnpm review` | Sends `git diff origin/main...HEAD` to a GitHub Models endpoint via `gh-models` for a pre-flight code review against the project prompt. Optional; never blocks. Requires `gh extension install github/gh-models` | Before pushing a substantive change to catch naming / schema / a11y / SSR / public-API issues locally | Developer |
 | `pnpm test` | Vitest suite (unit + integration) — every test under `packages/**` and `scripts/**` | Before push; in CI | Developer + CI |
 | `pnpm test:e2e` | Playwright DOM-contract suite (`tests/*.spec.ts`) | When wrappers or interactions changed; in CI | Developer + CI |
 | `pnpm test:visual` | Placeholder — the pixel-diff suite lands with the visual gate | When visuals changed | Developer + CI |

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -53,7 +53,7 @@ pre-commit:
 
 pre-push:
   commands:
-    # Opt-in local pre-flight LLM review. Enable per-clone with:
+    # Opt-in local pre-flight review. Enable per-clone with:
     #   touch .claude/preflight-review.enabled
     # Disable with: rm .claude/preflight-review.enabled
     # Warn-only — prints suggestions, never blocks the push.

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -57,7 +57,11 @@ pre-push:
     #   touch .claude/preflight-review.enabled
     # Disable with: rm .claude/preflight-review.enabled
     # Warn-only — prints suggestions, never blocks the push.
+    # `interactive: true` streams the review output (and any install hint from
+    # the script) directly to the terminal; lefthook hides stdout from
+    # success-path commands by default.
     preflight-review:
+      interactive: true
       run: |
         if [ ! -f .claude/preflight-review.enabled ]; then exit 0; fi
         bash scripts/review.sh || true

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -53,6 +53,14 @@ pre-commit:
 
 pre-push:
   commands:
+    # Opt-in local pre-flight LLM review. Enable per-clone with:
+    #   touch .claude/preflight-review.enabled
+    # Disable with: rm .claude/preflight-review.enabled
+    # Warn-only — prints suggestions, never blocks the push.
+    preflight-review:
+      run: |
+        if [ ! -f .claude/preflight-review.enabled ]; then exit 0; fi
+        bash scripts/review.sh || true
     lint:
       run: pnpm lint
     typecheck:

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -60,8 +60,11 @@ pre-push:
     # `interactive: true` streams the review output (and any install hint from
     # the script) directly to the terminal; lefthook hides stdout from
     # success-path commands by default.
+    # `skip_empty: false` forces the command to run even when the push range
+    # has no file changes (the script computes its own diff vs $BASE).
     preflight-review:
       interactive: true
+      skip_empty: false
       run: |
         if [ ! -f .claude/preflight-review.enabled ]; then exit 0; fi
         bash scripts/review.sh || true

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "build:wrappers": "pnpm --filter '@teseor/{react,vue,svelte,angular,webc}' run build",
     "build:docs": "pnpm build:css && pnpm --filter @teseor/docs run build",
     "test": "vitest run",
+    "review": "bash scripts/review.sh",
     "test:e2e": "playwright test",
     "test:visual": "echo 'test:visual: lands at v0.2' && exit 0",
     "test:a11y": "echo 'test:a11y: lands at v0.2' && exit 0",

--- a/scripts/review-prompt.md
+++ b/scripts/review-prompt.md
@@ -1,4 +1,4 @@
-You are a code reviewer for the Teseor design system monorepo. You will receive a git diff between the working branch and `main`.
+You are a code reviewer for the Teseor design system monorepo. You will receive a git diff between the working branch and `main`. This prompt is a tool input, not contributor-facing documentation.
 
 Your job: list concrete review issues. Be specific, terse, technical. No filler, no praise.
 
@@ -56,7 +56,7 @@ Walk the diff with this checklist. Skip anything that doesn't apply.
 - Default exports. Use named exports.
 - Emojis. Banned.
 - AI-tool references in code, commits, PRs. Banned.
-- Conventional commits: types are `feat|fix|perf|refactor|docs|chore|test`. Scopes come from `_vocabulary.yaml` + the fixed list. `react` / `vue` are NOT valid scopes; use `wrapper`. `ci` is a scope, not a type; use `chore(ci): ...`.
+- Conventional commits: types are `feat|fix|perf|refactor|docs|chore|test`. Scopes are built by `.github/workflows/pr-discipline.yml` from a fixed list (`token theme codegen showcase css wrapper i18n ci repo claude scripts docs spec primitives`) plus every `specs/*.yaml` basename. `react` / `vue` are NOT valid scopes; use `wrapper`. `ci` is a scope, not a type; use `chore(ci): ...`.
 
 ### 11. Modality / overlay specifics (Teseor)
 - `overlay.modal: true` codegen must wrap in `createPortal(..., document.body)` (React) / `<Teleport to="body">` (Vue).

--- a/scripts/review-prompt.md
+++ b/scripts/review-prompt.md
@@ -1,0 +1,74 @@
+You are a code reviewer for the Teseor design system monorepo. You will receive a git diff between the working branch and `main`.
+
+Your job: list concrete review issues. Be specific, terse, technical. No filler, no praise.
+
+For each issue, emit one bullet line in this shape:
+- `<file>:<line>` — <one-sentence description and suggested fix>
+
+End with `LGTM` on its own line if nothing actionable was found.
+
+## What to look for
+
+Walk the diff with this checklist. Skip anything that doesn't apply.
+
+### 1. Naming
+- Function / type / constant names that overpromise. A `checkOverlayDismissalRules` that only checks Escape is misnamed; `checkOverlayEscapeRules` is honest.
+- Variables that shadow names emitted into generated code (e.g. a generator-local `overlay` that appears verbatim in the emitted runtime as a different binding). Prefer `overlaySpec` / `overlayConfig` for the spec-side reference.
+
+### 2. Schema and fixtures
+- Tests that build a spec via `as unknown as Spec` (or similar cast) instead of `SpecSchema.parse(...)`. The cast hides missing required fields (composite specs require `parts:`, propEntries require `description:`, etc.). Prefer parse-then-flatten.
+- Fixtures that include fields the current schema doesn't declare (forward-looking fields slipping in via cast).
+
+### 3. Codegen
+- Generator changes that don't re-run `pnpm gen`. The generated `.tsx` / `.vue` / `.astro` / contract files must be committed alongside generator changes. CI's `gen-drift` will catch this — flag it locally first.
+- New spec fields without a Zod entry in `scripts/codegen/src/schema.ts`.
+- Generator output that imports symbols that aren't yet exported.
+
+### 4. Accessibility
+- `role="dialog"` content without `aria-modal="true"` when the wrapper is modal.
+- `role="dialog"` without an accessible name (`aria-label` / `aria-labelledby`).
+- `aria-describedby` on a modal trigger pointing at the dialog. That relationship is for tooltips, not modals — screen readers would announce dialog body text while focus is still on the trigger.
+- A focusable element inside an inert ancestor (unreachable / confusing).
+
+### 5. React SSR / hydration
+- `typeof document !== "undefined"` inside JSX as a gate. Server omits, client includes → hydration mismatch. Prefer `const [mounted, setMounted] = useState(false); useEffect(() => setMounted(true), [])` and gate on `mounted`.
+
+### 6. Effect / watcher ordering
+- React: `useEffect` cleanup runs LIFO. If effect A depends on effect B's setup, register A first.
+- Vue: `watch` callbacks fire in registration order, both for setup and teardown. If you need teardown order to differ from setup order, you cannot rely on `watch` alone.
+
+### 7. Public API surface
+- New exports from `packages/*/src/*` that look test-only. Anything named `*ForTests`, `*ResetForTests`, `__internal*` etc. should NOT be exported from production modules. The `./* ` export map in `@teseor/primitives` and `@teseor/{react,vue}` exposes deep imports — anything exported is part of the public surface.
+- Functions with `__` prefix or "test" in the name being re-exported via barrels.
+
+### 8. Cross-file consistency
+- A renamed function / type / field whose old name still appears in tests, snapshots, JSDoc, comments, or generated output.
+- A new generator behavior with no test snapshot or assertion locking it.
+
+### 9. Comment hygiene
+- Inline comments longer than one line where one line would do. Module headers can be 4-6 lines, public JSDoc can be longer when it documents the contract, but inline comments restating what the next line of code shows are over-budget.
+- ADR-XXXX references in code comments (use the local rationale inline, not a doc-path pointer — ADRs renumber).
+- Plan markers / phase markers / decision IDs (M3, G15, etc.) in committed code, commits, PRs.
+
+### 10. Project conventions
+- `as` casts, `any`, `as unknown as X`, `@ts-ignore`. Banned.
+- `enum`. Use `const` objects with `as const`.
+- Default exports. Use named exports.
+- Emojis. Banned.
+- AI-tool references in code, commits, PRs. Banned.
+- Conventional commits: types are `feat|fix|perf|refactor|docs|chore|test`. Scopes come from `_vocabulary.yaml` + the fixed list. `react` / `vue` are NOT valid scopes; use `wrapper`. `ci` is a scope, not a type; use `chore(ci): ...`.
+
+### 11. Modality / overlay specifics (Teseor)
+- `overlay.modal: true` codegen must wrap in `createPortal(..., document.body)` (React) / `<Teleport to="body">` (Vue).
+- Modal trigger doesn't `aria-describedby`. Tooltip does.
+- Modality scope tests should fully `deactivate()` every scope they create (no test-only public reset helpers).
+
+## What NOT to flag
+
+- Style choices in spec YAML beyond what the schema enforces.
+- Test additions that mirror existing patterns.
+- Snapshot updates that follow obvious wording changes upstream.
+- Whitespace, formatting (biome enforces this).
+- The first commit of a session if it's a small bump.
+
+If the diff is short and clean, say `LGTM` and stop. Prefer fewer high-signal comments over many low-signal ones.

--- a/scripts/review-prompt.md
+++ b/scripts/review-prompt.md
@@ -55,7 +55,7 @@ Walk the diff with this checklist. Skip anything that doesn't apply.
 - `enum`. Use `const` objects with `as const`.
 - Default exports. Use named exports.
 - Emojis. Banned.
-- AI-tool references in code, commits, PRs. Banned.
+- Editorial / gratuitous AI references in code, commits, PRs are banned. Do NOT flag required operational mentions of concrete tool, product, package, command, or integration names in docs/scripts (e.g. `GitHub Models`, `gh-models`).
 - Conventional commits: types are `feat|fix|perf|refactor|docs|chore|test`. Scopes are built by `.github/workflows/pr-discipline.yml` from a fixed list (`token theme codegen showcase css wrapper i18n ci repo claude scripts docs spec primitives`) plus every `specs/*.yaml` basename. `react` / `vue` are NOT valid scopes; use `wrapper`. `ci` is a scope, not a type; use `chore(ci): ...`.
 
 ### 11. Modality / overlay specifics (Teseor)

--- a/scripts/review-prompt.md
+++ b/scripts/review-prompt.md
@@ -38,7 +38,7 @@ Walk the diff with this checklist. Skip anything that doesn't apply.
 - Vue: `watch` callbacks fire in registration order, both for setup and teardown. If you need teardown order to differ from setup order, you cannot rely on `watch` alone.
 
 ### 7. Public API surface
-- New exports from `packages/*/src/*` that look test-only. Anything named `*ForTests`, `*ResetForTests`, `__internal*` etc. should NOT be exported from production modules. The `./* ` export map in `@teseor/primitives` and `@teseor/{react,vue}` exposes deep imports — anything exported is part of the public surface.
+- New exports from `packages/*/src/*` that look test-only. Anything named `*ForTests`, `*ResetForTests`, `__internal*` etc. should NOT be exported from production modules. The `./*` export map in `@teseor/primitives` and `@teseor/{react,vue}` exposes deep imports — anything exported is part of the public surface.
 - Functions with `__` prefix or "test" in the name being re-exported via barrels.
 
 ### 8. Cross-file consistency

--- a/scripts/review-prompt.md
+++ b/scripts/review-prompt.md
@@ -1,4 +1,4 @@
-You are a code reviewer for the Teseor design system monorepo. You will receive a git diff between the working branch and `main`. This prompt is a tool input, not contributor-facing documentation.
+You are a code reviewer for the Teseor design system monorepo. You will receive a git diff between `HEAD` and `$BASE` (default `origin/main`). This prompt is a tool input, not contributor-facing documentation.
 
 Your job: list concrete review issues. Be specific, terse, technical. No filler, no praise.
 

--- a/scripts/review.sh
+++ b/scripts/review.sh
@@ -1,11 +1,14 @@
 #!/usr/bin/env bash
-# Local Copilot-style pre-flight code review using `gh-models`.
-# Sends the current branch's diff (against $BASE, default origin/main) to a
-# GitHub Models LLM with the project's review prompt. Prints suggestions and
-# exits 0 — opinions only, no blocking.
+# Local pre-flight code review against the current branch's diff.
+# Sends `git diff $BASE...HEAD` to a GitHub Models endpoint via the `gh-models`
+# extension with the project's review prompt. Prints suggestions to stdout.
 #
-# Requires: gh CLI + gh-models extension (free under a paid Copilot plan).
-# Install hints surface inline below.
+# Exit codes:
+#   0  diff empty, or review completed (regardless of what the review said).
+#   1  missing prerequisite (gh CLI, gh-models extension, prompt file).
+#   *  underlying `gh models run` failure (network, auth, rate limit).
+#
+# Requires: `gh` CLI + `gh-models` extension. Installation hints emit below.
 set -euo pipefail
 
 if ! command -v gh > /dev/null 2>&1; then
@@ -23,8 +26,12 @@ BASE="${BASE:-origin/main}"
 MODEL="${MODEL:-openai/gpt-4o}"
 
 if ! git rev-parse "$BASE" > /dev/null 2>&1; then
-  printf 'review: base ref %s not resolvable; running `git fetch origin main` first...\n' "$BASE" >&2
+  printf 'review: base ref %s not resolvable; fetching origin main...\n' "$BASE" >&2
   git fetch --quiet origin main
+  if ! git rev-parse "$BASE" > /dev/null 2>&1; then
+    printf 'review: base ref %s still not resolvable after fetch — set BASE to a reachable ref\n' "$BASE" >&2
+    exit 1
+  fi
 fi
 
 DIFF=$(git diff "$BASE"...HEAD)

--- a/scripts/review.sh
+++ b/scripts/review.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Local Copilot-style pre-flight code review using `gh-models`.
+# Sends the current branch's diff (against $BASE, default origin/main) to a
+# GitHub Models LLM with the project's review prompt. Prints suggestions and
+# exits 0 — opinions only, no blocking.
+#
+# Requires: gh CLI + gh-models extension (free under a paid Copilot plan).
+# Install hints surface inline below.
+set -euo pipefail
+
+if ! command -v gh > /dev/null 2>&1; then
+  printf 'review: gh CLI not installed (https://cli.github.com/)\n' >&2
+  exit 1
+fi
+
+if ! gh extension list 2>/dev/null | grep -q 'github/gh-models\|gh models'; then
+  printf 'review: gh-models extension missing. Install with:\n' >&2
+  printf '  gh extension install github/gh-models\n' >&2
+  exit 1
+fi
+
+BASE="${BASE:-origin/main}"
+MODEL="${MODEL:-openai/gpt-4o}"
+
+if ! git rev-parse "$BASE" > /dev/null 2>&1; then
+  printf 'review: base ref %s not resolvable; running `git fetch origin main` first...\n' "$BASE" >&2
+  git fetch --quiet origin main
+fi
+
+DIFF=$(git diff "$BASE"...HEAD)
+if [ -z "$DIFF" ]; then
+  printf 'review: no diff against %s — nothing to review\n' "$BASE"
+  exit 0
+fi
+
+LINES=$(printf '%s\n' "$DIFF" | wc -l | tr -d ' ')
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROMPT_FILE="$SCRIPT_DIR/review-prompt.md"
+if [ ! -f "$PROMPT_FILE" ]; then
+  printf 'review: prompt file missing at %s\n' "$PROMPT_FILE" >&2
+  exit 1
+fi
+PROMPT=$(cat "$PROMPT_FILE")
+
+printf 'review: sending %s lines of diff to %s via gh-models...\n\n' "$LINES" "$MODEL" >&2
+# `gh models run` reads the user-message from stdin and the system prompt from $1.
+printf '%s\n' "$DIFF" | gh models run "$MODEL" "$PROMPT"


### PR DESCRIPTION
## What

`pnpm review` — opt-in local pre-flight code review. Sends `git diff origin/main...HEAD` to a GitHub Models LLM (via `gh-models`) with a project-specific review prompt. Prints suggestions, exits 0, never blocks.

- `scripts/review.sh` — the script.
- `scripts/review-prompt.md` — the prompt (mirrors `feedback_self_review_before_push` plus Teseor-specific items: overlay/modal codegen invariants, public-API hygiene, SSR-portal pattern, framework-specific effect ordering).
- `package.json` — `pnpm review` entry.
- `CONTRIBUTING.md` + `docs/process/dev-scripts.md` — documented as optional.

## Why

PR review cycles cost wall-clock time and attention. The GitHub Copilot PR reviewer catches things our linters don't (naming overpromise, schema vs fixture drift, a11y semantics, SSR concerns) but it runs server-side, asynchronously, on push. A local LLM pre-flight with the same backing models catches ~70-80% of the same class of issues in 5-15 seconds, before push, in your terminal — free under a paid Copilot plan.

This is one half of a two-part response to the review-comment churn:
- This PR (#724): catch LLM-detectable issues locally.
- Issue #726: codify the deterministic categories into linters / codegen invariants. Different problem; complementary.

## Test plan

- `pnpm review` with `gh` installed but no `gh-models` extension → exits 1 with install hint.
- `pnpm review` with `gh-models` installed → sends diff, prints review, exits 0.
- `lint:catalog` passes (script appears in `docs/process/dev-scripts.md`).
- `pnpm typecheck` clean.

## Out of scope

- Pre-push hook that blocks. Strictly opt-in via `pnpm review`.
- Replacement for GitHub's Copilot PR reviewer. This is a pre-filter.
- Multi-model orchestration. One model, one pass, one prompt.

Closes #724
