### PR TITLE
feat(spec): JSON Schema artifact for YAML editor autocomplete + validation

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,8 @@
+{
+  "recommendations": [
+    "redhat.vscode-yaml",
+    "biomejs.biome",
+    "stylelint.vscode-stylelint",
+    "editorconfig.editorconfig"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,8 @@
 {
   "css.lint.unknownAtRules": "ignore",
   "scss.lint.unknownAtRules": "ignore",
-  "less.lint.unknownAtRules": "ignore"
+  "less.lint.unknownAtRules": "ignore",
+  "yaml.schemas": {
+    "./schemas/spec.schema.json": "specs/*.yaml"
+  }
 }

--- a/schemas/spec.schema.json
+++ b/schemas/spec.schema.json
@@ -1,0 +1,1005 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "oneOf": [
+    {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "description": {
+          "type": "string"
+        },
+        "dependencies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "cssFile": {
+          "type": "string"
+        },
+        "behavior": {
+          "type": "string",
+          "enum": [
+            "none",
+            "primitive",
+            "stateful"
+          ]
+        },
+        "primitives": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "guidance": {
+          "type": "object",
+          "properties": {
+            "when": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "whenNot": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "variantChoice": {
+              "type": "object",
+              "propertyNames": {
+                "type": "string"
+              },
+              "additionalProperties": {
+                "type": "string"
+              }
+            },
+            "contentRules": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "commonMistakes": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "mistake": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "fix": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                },
+                "required": [
+                  "mistake",
+                  "fix"
+                ],
+                "additionalProperties": false
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        "examples": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string",
+                "minLength": 1
+              },
+              "props": {
+                "type": "object",
+                "propertyNames": {
+                  "type": "string"
+                },
+                "additionalProperties": {}
+              }
+            },
+            "required": [
+              "id"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "coverage": {
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            ]
+          }
+        },
+        "overlay": {
+          "type": "object",
+          "properties": {
+            "anchor": {
+              "type": "string",
+              "minLength": 1
+            },
+            "floating": {
+              "type": "string",
+              "minLength": 1
+            },
+            "mode": {
+              "type": "string",
+              "enum": [
+                "auto",
+                "manual",
+                "hint"
+              ]
+            },
+            "anchorVar": {
+              "type": "string",
+              "pattern": "^--[A-Za-z0-9_-]+$"
+            },
+            "modal": {
+              "default": false,
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "anchor",
+            "floating",
+            "mode",
+            "anchorVar",
+            "modal"
+          ],
+          "additionalProperties": false
+        },
+        "interactions": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "on": {
+                "type": "object",
+                "properties": {
+                  "event": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "target": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "key": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "event",
+                  "target"
+                ],
+                "additionalProperties": false
+              },
+              "do": {
+                "type": "string",
+                "enum": [
+                  "open",
+                  "close",
+                  "toggle"
+                ]
+              },
+              "delay": {
+                "type": "string"
+              },
+              "when": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "on",
+              "do"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "kind": {
+          "type": "string",
+          "const": "atomic"
+        },
+        "element": {
+          "type": "string"
+        },
+        "rootClass": {
+          "type": "string"
+        },
+        "variants": {
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {
+            "type": "object",
+            "properties": {
+              "description": {
+                "type": "string",
+                "minLength": 1
+              }
+            },
+            "required": [
+              "description"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "intents": {
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {
+            "type": "object",
+            "properties": {
+              "description": {
+                "type": "string",
+                "minLength": 1
+              },
+              "tokens": {
+                "type": "object",
+                "propertyNames": {
+                  "type": "string"
+                },
+                "additionalProperties": {
+                  "type": "string",
+                  "pattern": "^--[A-Za-z0-9_-]+$"
+                }
+              }
+            },
+            "required": [
+              "description"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "sizes": {
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {
+            "type": "object",
+            "properties": {
+              "description": {
+                "type": "string",
+                "minLength": 1
+              },
+              "tokens": {
+                "type": "object",
+                "propertyNames": {
+                  "type": "string"
+                },
+                "additionalProperties": {
+                  "type": "string",
+                  "pattern": "^--[A-Za-z0-9_-]+$"
+                }
+              }
+            },
+            "required": [
+              "description"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "props": {
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "string",
+                  "boolean",
+                  "number"
+                ]
+              },
+              "default": {},
+              "description": {
+                "type": "string",
+                "minLength": 1
+              },
+              "responsive": {
+                "type": "boolean"
+              },
+              "slot": {
+                "type": "boolean"
+              },
+              "values": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "pattern": {
+                "type": "string",
+                "const": "controllable"
+              }
+            },
+            "required": [
+              "type",
+              "description"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "tokens": {
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {
+            "type": "object",
+            "properties": {
+              "fallback": {
+                "type": "string",
+                "pattern": "^--[A-Za-z0-9_-]+$"
+              },
+              "desc": {
+                "type": "string",
+                "minLength": 1
+              }
+            },
+            "required": [
+              "fallback",
+              "desc"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "privateTokens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "states": {
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {
+            "type": "object",
+            "properties": {
+              "description": {
+                "type": "string",
+                "minLength": 1
+              }
+            },
+            "required": [
+              "description"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "a11y": {
+          "type": "object",
+          "properties": {
+            "role": {
+              "type": "string"
+            },
+            "keyboard": {
+              "type": "object",
+              "propertyNames": {
+                "type": "string"
+              },
+              "additionalProperties": {
+                "type": "string"
+              }
+            },
+            "states": {
+              "type": "object",
+              "propertyNames": {
+                "type": "string"
+              },
+              "additionalProperties": {
+                "type": "string"
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        "constraints": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "when": {
+                "type": "object",
+                "propertyNames": {
+                  "type": "string"
+                },
+                "additionalProperties": {}
+              },
+              "forbid": {
+                "type": "object",
+                "propertyNames": {
+                  "type": "string"
+                },
+                "additionalProperties": {}
+              },
+              "reason": {
+                "type": "string",
+                "minLength": 1
+              }
+            },
+            "required": [
+              "when",
+              "forbid",
+              "reason"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "motion": {
+          "type": "object",
+          "properties": {
+            "transitions": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "enters": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "exits": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "name",
+        "kind"
+      ],
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "description": {
+          "type": "string"
+        },
+        "dependencies": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "cssFile": {
+          "type": "string"
+        },
+        "behavior": {
+          "type": "string",
+          "enum": [
+            "none",
+            "primitive",
+            "stateful"
+          ]
+        },
+        "primitives": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "guidance": {
+          "type": "object",
+          "properties": {
+            "when": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "whenNot": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "variantChoice": {
+              "type": "object",
+              "propertyNames": {
+                "type": "string"
+              },
+              "additionalProperties": {
+                "type": "string"
+              }
+            },
+            "contentRules": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "commonMistakes": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "mistake": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "fix": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                },
+                "required": [
+                  "mistake",
+                  "fix"
+                ],
+                "additionalProperties": false
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        "examples": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string",
+                "minLength": 1
+              },
+              "props": {
+                "type": "object",
+                "propertyNames": {
+                  "type": "string"
+                },
+                "additionalProperties": {}
+              }
+            },
+            "required": [
+              "id"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "coverage": {
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            ]
+          }
+        },
+        "overlay": {
+          "type": "object",
+          "properties": {
+            "anchor": {
+              "type": "string",
+              "minLength": 1
+            },
+            "floating": {
+              "type": "string",
+              "minLength": 1
+            },
+            "mode": {
+              "type": "string",
+              "enum": [
+                "auto",
+                "manual",
+                "hint"
+              ]
+            },
+            "anchorVar": {
+              "type": "string",
+              "pattern": "^--[A-Za-z0-9_-]+$"
+            },
+            "modal": {
+              "default": false,
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "anchor",
+            "floating",
+            "mode",
+            "anchorVar",
+            "modal"
+          ],
+          "additionalProperties": false
+        },
+        "interactions": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "on": {
+                "type": "object",
+                "properties": {
+                  "event": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "target": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "key": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "event",
+                  "target"
+                ],
+                "additionalProperties": false
+              },
+              "do": {
+                "type": "string",
+                "enum": [
+                  "open",
+                  "close",
+                  "toggle"
+                ]
+              },
+              "delay": {
+                "type": "string"
+              },
+              "when": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "on",
+              "do"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "kind": {
+          "type": "string",
+          "const": "composite"
+        },
+        "parts": {
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {
+            "$ref": "#/$defs/__schema0"
+          }
+        }
+      },
+      "required": [
+        "name",
+        "kind",
+        "parts"
+      ],
+      "additionalProperties": false
+    }
+  ],
+  "$defs": {
+    "__schema0": {
+      "type": "object",
+      "properties": {
+        "element": {
+          "type": "string"
+        },
+        "rootClass": {
+          "type": "string"
+        },
+        "variants": {
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {
+            "type": "object",
+            "properties": {
+              "description": {
+                "type": "string",
+                "minLength": 1
+              }
+            },
+            "required": [
+              "description"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "intents": {
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {
+            "type": "object",
+            "properties": {
+              "description": {
+                "type": "string",
+                "minLength": 1
+              },
+              "tokens": {
+                "type": "object",
+                "propertyNames": {
+                  "type": "string"
+                },
+                "additionalProperties": {
+                  "type": "string",
+                  "pattern": "^--[A-Za-z0-9_-]+$"
+                }
+              }
+            },
+            "required": [
+              "description"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "sizes": {
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {
+            "type": "object",
+            "properties": {
+              "description": {
+                "type": "string",
+                "minLength": 1
+              },
+              "tokens": {
+                "type": "object",
+                "propertyNames": {
+                  "type": "string"
+                },
+                "additionalProperties": {
+                  "type": "string",
+                  "pattern": "^--[A-Za-z0-9_-]+$"
+                }
+              }
+            },
+            "required": [
+              "description"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "props": {
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "string",
+                  "boolean",
+                  "number"
+                ]
+              },
+              "default": {},
+              "description": {
+                "type": "string",
+                "minLength": 1
+              },
+              "responsive": {
+                "type": "boolean"
+              },
+              "slot": {
+                "type": "boolean"
+              },
+              "values": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "pattern": {
+                "type": "string",
+                "const": "controllable"
+              }
+            },
+            "required": [
+              "type",
+              "description"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "tokens": {
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {
+            "type": "object",
+            "properties": {
+              "fallback": {
+                "type": "string",
+                "pattern": "^--[A-Za-z0-9_-]+$"
+              },
+              "desc": {
+                "type": "string",
+                "minLength": 1
+              }
+            },
+            "required": [
+              "fallback",
+              "desc"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "privateTokens": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "states": {
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {
+            "type": "object",
+            "properties": {
+              "description": {
+                "type": "string",
+                "minLength": 1
+              }
+            },
+            "required": [
+              "description"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "a11y": {
+          "type": "object",
+          "properties": {
+            "role": {
+              "type": "string"
+            },
+            "keyboard": {
+              "type": "object",
+              "propertyNames": {
+                "type": "string"
+              },
+              "additionalProperties": {
+                "type": "string"
+              }
+            },
+            "states": {
+              "type": "object",
+              "propertyNames": {
+                "type": "string"
+              },
+              "additionalProperties": {
+                "type": "string"
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        "constraints": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "when": {
+                "type": "object",
+                "propertyNames": {
+                  "type": "string"
+                },
+                "additionalProperties": {}
+              },
+              "forbid": {
+                "type": "object",
+                "propertyNames": {
+                  "type": "string"
+                },
+                "additionalProperties": {}
+              },
+              "reason": {
+                "type": "string",
+                "minLength": 1
+              }
+            },
+            "required": [
+              "when",
+              "forbid",
+              "reason"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "motion": {
+          "type": "object",
+          "properties": {
+            "transitions": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "enters": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "exits": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        "fromChildren": {
+          "type": "boolean"
+        },
+        "parts": {
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {
+            "$ref": "#/$defs/__schema0"
+          }
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/scripts/codegen/src/generators/gen-schema.ts
+++ b/scripts/codegen/src/generators/gen-schema.ts
@@ -1,0 +1,34 @@
+// Emits `schemas/spec.schema.json` — a JSON Schema (draft-2020-12) artifact
+// derived from the Zod spec via `z.toJSONSchema`. Powers the Red Hat YAML
+// extension in editors: autocomplete, hover docs, and shape validation as
+// authors type `specs/<name>.yaml`. Cross-field rules (`kind: composite`
+// requires `parts:`, etc.) stay in Zod's `.refine()` / `semantic-checks.ts`
+// — the JSON Schema only covers shape, enums, and recursion.
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { z } from "zod";
+import type { GeneratorContext, GeneratorReport } from "../registry.ts";
+import { registerGenerator } from "../registry.ts";
+import { Spec as SpecSchema } from "../schema.ts";
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..", "..", "..");
+const SCHEMA_PATH = resolve(REPO_ROOT, "schemas", "spec.schema.json");
+
+async function schemaGenerator(_ctx: GeneratorContext): Promise<GeneratorReport> {
+  // Metadata (descriptions, titles) from `.describe()` / `.meta()` calls in
+  // `schema.ts` is sourced from Zod's global registry by default — passing
+  // `metadata` explicitly is for custom registries only.
+  const jsonSchema = z.toJSONSchema(SpecSchema, {
+    target: "draft-2020-12",
+  });
+  const body = `${JSON.stringify(jsonSchema, null, 2)}\n`;
+  await mkdir(dirname(SCHEMA_PATH), { recursive: true });
+  await writeFile(SCHEMA_PATH, body, "utf8");
+  return {
+    filesWritten: [SCHEMA_PATH],
+    notes: [`schema: spec -> ${SCHEMA_PATH.replace(`${REPO_ROOT}/`, "")}`],
+  };
+}
+
+registerGenerator("schema", schemaGenerator);

--- a/scripts/codegen/src/generators/index.ts
+++ b/scripts/codegen/src/generators/index.ts
@@ -1,5 +1,6 @@
 import "./gen-contract.ts";
 import "./gen-docs.ts";
 import "./gen-react.ts";
+import "./gen-schema.ts";
 import "./gen-tests.ts";
 import "./gen-vue.ts";

--- a/scripts/lint/file-rules/spec-schema-directive.test.ts
+++ b/scripts/lint/file-rules/spec-schema-directive.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { hasDirective, rule } from "./spec-schema-directive.ts";
+
+describe("hasDirective", () => {
+  it("accepts the canonical directive", () => {
+    const source = "# yaml-language-server: $schema=../schemas/spec.schema.json\nname: button\n";
+    expect(hasDirective(source)).toBe(true);
+  });
+
+  it("accepts any schema URL after the prefix", () => {
+    expect(hasDirective("# yaml-language-server: $schema=./other.schema.json\nname: x\n")).toBe(
+      true,
+    );
+  });
+
+  it("rejects when the first line is anything else", () => {
+    expect(hasDirective("name: button\nkind: atomic\n")).toBe(false);
+  });
+
+  it("rejects when the directive appears below the first line", () => {
+    const source = "\n# yaml-language-server: $schema=../schemas/spec.schema.json\nname: x\n";
+    expect(hasDirective(source)).toBe(false);
+  });
+
+  it("rejects an empty file", () => {
+    expect(hasDirective("")).toBe(false);
+  });
+});
+
+describe("rule.accepts", () => {
+  const accepts = rule.accepts ?? (() => true);
+
+  it("scans component spec files", () => {
+    expect(accepts("specs/button.yaml")).toBe(true);
+    expect(accepts("specs/modal.yaml")).toBe(true);
+  });
+
+  it("exempts `_breakpoints.yaml` and `_vocabulary.yaml`", () => {
+    expect(accepts("specs/_breakpoints.yaml")).toBe(false);
+    expect(accepts("specs/_vocabulary.yaml")).toBe(false);
+  });
+});
+
+describe("rule.run", () => {
+  it("returns no violations when the directive is present", () => {
+    const source = "# yaml-language-server: $schema=../schemas/spec.schema.json\nname: x\n";
+    expect(rule.run("specs/button.yaml", source)).toEqual([]);
+  });
+
+  it("flags line 1 when the directive is missing", () => {
+    const violations = rule.run("specs/button.yaml", "name: x\nkind: atomic\n");
+    expect(violations).toHaveLength(1);
+    expect(violations[0]?.line).toBe(1);
+  });
+});

--- a/scripts/lint/file-rules/spec-schema-directive.ts
+++ b/scripts/lint/file-rules/spec-schema-directive.ts
@@ -1,0 +1,32 @@
+// Requires every `specs/<component>.yaml` to declare the JSON Schema mapping
+// on the first line so the Red Hat YAML extension picks it up. Without the
+// directive, editors fall back to no schema and authors lose autocomplete /
+// validation — the artifact stays correct but the authoring loop regresses
+// silently. Exempt: `_breakpoints.yaml` and `_vocabulary.yaml` use different
+// schemas.
+import type { FileRule } from "../registry.ts";
+
+const DIRECTIVE_PREFIX = "# yaml-language-server: $schema=";
+const EXEMPT = new Set(["specs/_breakpoints.yaml", "specs/_vocabulary.yaml"]);
+
+/** Returns true when the file's first line declares a yaml-language-server schema. */
+export function hasDirective(source: string): boolean {
+  const firstLine = source.split("\n", 1)[0] ?? "";
+  return firstLine.startsWith(DIRECTIVE_PREFIX);
+}
+
+/** Registry entry consumed by `scripts/lint/run.ts`. */
+export const rule: FileRule = {
+  kind: "file-rule",
+  pathspec: ["specs/*.yaml"],
+  noun: "spec file(s)",
+  accepts: (rel) => !EXEMPT.has(rel),
+  run: (_file, source) =>
+    hasDirective(source)
+      ? []
+      : [{ line: 1, message: `missing \`${DIRECTIVE_PREFIX}…\` directive on line 1` }],
+  hint:
+    "Prepend `# yaml-language-server: $schema=../schemas/spec.schema.json` as the\n" +
+    "first line of the spec. The Red Hat YAML extension reads this comment to wire\n" +
+    "autocomplete and validation in the editor.",
+};

--- a/scripts/lint/registry.ts
+++ b/scripts/lint/registry.ts
@@ -25,6 +25,7 @@ import { rule as componentCss } from "./file-rules/component-css.ts";
 import { rule as motionScale } from "./file-rules/motion-scale.ts";
 import { rule as noAsUnknownCast } from "./file-rules/no-as-unknown-cast.ts";
 import { rule as noDocumentTypeof } from "./file-rules/no-document-typeof.ts";
+import { rule as specSchemaDirective } from "./file-rules/spec-schema-directive.ts";
 import { rule as transitionableProperty } from "./file-rules/transitionable-property.ts";
 
 export type ViolationDetail = { file?: string; line?: number; message: string };
@@ -125,6 +126,7 @@ export const REGISTRY: Readonly<Record<string, Check>> = {
   "no-document-typeof": noDocumentTypeof,
   "component-css": componentCss,
   "motion-scale": motionScale,
+  "spec-schema-directive": specSchemaDirective,
   "transitionable-property": transitionableProperty,
   "script-aggregators": scriptAggregators,
   "script-catalog": scriptCatalog,

--- a/specs/button.yaml
+++ b/specs/button.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../schemas/spec.schema.json
 name: button
 description: A trigger that performs an action when activated.
 kind: atomic

--- a/specs/cluster.yaml
+++ b/specs/cluster.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../schemas/spec.schema.json
 name: cluster
 description: A horizontal layout primitive. Wraps children on the inline axis with consistent spacing.
 kind: atomic

--- a/specs/modal.yaml
+++ b/specs/modal.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../schemas/spec.schema.json
 name: modal
 description: A modal overlay that traps focus and inerts the rest of the page until dismissed.
 kind: composite

--- a/specs/stack.yaml
+++ b/specs/stack.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../schemas/spec.schema.json
 name: stack
 description: A vertical layout primitive. Stacks children on the block axis with consistent spacing.
 kind: atomic

--- a/specs/tooltip.yaml
+++ b/specs/tooltip.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../schemas/spec.schema.json
 name: tooltip
 description: A non-interactive hint that appears when its trigger is hovered or focused.
 kind: composite


### PR DESCRIPTION
Closes #748.

## What

- New `schema` generator (`scripts/codegen/src/generators/gen-schema.ts`) that emits `schemas/spec.schema.json` via `z.toJSONSchema(Spec, { target: "draft-2020-12" })`. Picked up by `pnpm gen` through the existing generator registry; `gen-drift` already covers refresh.
- The schema artifact at `schemas/spec.schema.json` — top-level `oneOf` over atomic/composite, `additionalProperties: false` (from `strictObject`), recursive `parts` via `$ref` to a shared `$def`.
- `# yaml-language-server: $schema=../schemas/spec.schema.json` directive prepended to every component spec (`button`, `cluster`, `modal`, `stack`, `tooltip`). `_breakpoints.yaml` and `_vocabulary.yaml` are exempt (different schemas).
- New `spec-schema-directive` `FileRule` enforcing that directive on line 1, with a colocated test. Registered in `scripts/lint/registry.ts`; picked up automatically by `pnpm lint` and the lefthook pre-commit dispatch.
- `.vscode/extensions.json` recommends `redhat.vscode-yaml` (plus the Biome / Stylelint / EditorConfig extensions in everyday use).
- `.vscode/settings.json` adds a `yaml.schemas` entry mapping the schema to `specs/*.yaml` so editor wiring works even before the directive is read.

## Why

Hand-edited spec YAMLs had no editor-side feedback loop: typos and missing fields surfaced only when `pnpm lint`'s spec validator ran. Wiring a JSON Schema makes the loop instant — autocomplete, hover, and shape validation as authors type. The Zod spec stays the single source of truth; the JSON Schema is a derived artifact that `pnpm gen` keeps current. Cross-field rules (e.g., `kind: composite` requires `parts:`) stay in Zod's `.refine()` / `semantic-checks.ts` — translating refinement predicates into JSON Schema isn't worth the complexity for what is a developer-facing aid.

## Test plan

- [x] `node scripts/codegen/src/cli.ts schema` generates a clean draft-2020-12 file with the expected shape (top-level `oneOf`, `kind` enum, recursive `$ref`).
- [x] Re-running the generator is idempotent (no diff after a second `pnpm gen`).
- [x] `node scripts/lint/run.ts --spec-schema-directive` reports `5 spec file(s) clean`; manually removing a directive surfaces the violation with the expected hint.
- [x] `node_modules/.bin/vitest run scripts/lint/file-rules/spec-schema-directive.test.ts` — 9 tests pass.
- [x] `tsc --noEmit` clean.
- [x] Full vitest run: 484 tests pass. Two pre-existing transform failures (`Modal.test.tsx`, `Tooltip.test.tsx`) are due to missing built CSS in the worktree, not this PR.
- [ ] Manual editor verification with the Red Hat YAML extension installed — autocomplete fires and red squiggles appear on a deliberately broken field. (Worth confirming locally before merging.)

## Out of scope

- `.describe()` pass on `scripts/codegen/src/schema.ts` to enrich hover docs. The infra lands here; descriptions can follow in one or more PRs.
- VSCode snippets (`spec-atomic`, `spec-composite`).
- JSON Schemas for `_breakpoints.yaml` / `_vocabulary.yaml`.

## Open question

Whether `emit-schema` deserves its own top-level `pnpm schema` script in `package.json` or stays folded into `pnpm gen`. Default in this PR: folded — keeps `dev-scripts.md` short and the `script-catalog` lint happy.