### PR TITLE
fix(repo): worktree-friendly prepare; isolate git env in lib tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "migrate:specs": "node scripts/repo/migrate-specs.ts",
     "changeset": "changeset",
     "release": "changeset publish",
-    "prepare": "lefthook install"
+    "prepare": "lefthook install --force"
   },
   "size-limit": [
     {

--- a/scripts/lib/enumerate.test.ts
+++ b/scripts/lib/enumerate.test.ts
@@ -5,6 +5,13 @@ import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 import { lsFiles } from "./enumerate.ts";
 
+// Under lefthook pre-push, vitest inherits GIT_DIR / GIT_WORK_TREE / GIT_INDEX_FILE
+// from the hook context. git honors those env vars over per-call `cwd`, so the
+// temp-repo setup below would otherwise leak into the parent worktree's .git.
+delete process.env.GIT_DIR;
+delete process.env.GIT_WORK_TREE;
+delete process.env.GIT_INDEX_FILE;
+
 function makeRepo(layout: Record<string, string>): string {
   const dir = mkdtempSync(resolve(tmpdir(), "teseor-lib-enum-"));
   execSync("git init -q -b main", { cwd: dir });

--- a/scripts/lib/git.test.ts
+++ b/scripts/lib/git.test.ts
@@ -5,6 +5,13 @@ import { resolve } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { getChangedFiles, resolveBase } from "./git.ts";
 
+// Under lefthook pre-push, vitest inherits GIT_DIR / GIT_WORK_TREE / GIT_INDEX_FILE
+// from the hook context. git honors those env vars over per-call `cwd`, so the
+// temp-repo setup below would otherwise leak into the parent worktree's .git.
+delete process.env.GIT_DIR;
+delete process.env.GIT_WORK_TREE;
+delete process.env.GIT_INDEX_FILE;
+
 function makeRepo(): string {
   const dir = mkdtempSync(resolve(tmpdir(), "teseor-lib-git-"));
   execSync("git init -q -b main", { cwd: dir });


### PR DESCRIPTION
## What

- `prepare` script: `lefthook install` → `lefthook install --force`. Accepts the existing `core.hooksPath` that worktrees inherit from the main checkout.
- `scripts/lib/{enumerate,git}.test.ts`: clear `GIT_DIR` / `GIT_WORK_TREE` / `GIT_INDEX_FILE` at module load. Stops temp-repo fixtures from writing into the parent worktree's `.git` under lefthook pre-push.

## Why

PR #752 hit both repeatedly. Worktree pushes required `git push --no-verify` plus a `verifyDepsBeforeRun: false` patch in `pnpm-workspace.yaml` (committed and reverted each cycle). With these two fixes, worktree pushes work normally.

## Test plan

- Main checkout: `pnpm install` (prepare succeeds), `pnpm test` (809/809), `git push` (full pre-push green).
- Detached worktree at HEAD: `pnpm install` succeeds with no workaround applied. Then `GIT_DIR=\$(git rev-parse --git-dir) GIT_WORK_TREE=\$(pwd) pnpm exec vitest run scripts/lib/{enumerate,git}.test.ts` passes 8/8 while parent `.git` stays clean (HEAD unchanged, working tree clean, no rogue branches, `core.bare` unset).

## Out of scope

- pnpm 11's `verifyDepsBeforeRun` itself.
- Hardening `lib/{enumerate,git}.ts` to filter inherited GIT env — that's the test's responsibility.
- Auditing other test files for the same pattern; only these two use git inside `execSync`.

Closes #755
Closes #756