### PR TITLE
feat(codegen): reject slots/loading/as/disabled on void-element specs

### DIFF
--- a/scripts/codegen/src/semantic-checks.test.ts
+++ b/scripts/codegen/src/semantic-checks.test.ts
@@ -539,6 +539,18 @@ describe("checkVoidElementConstraints", () => {
     expect(checkVoidElementConstraints(spec)).toEqual([]);
   });
 
+  test("accepts `disabled` on case-variant form-control voids (`INPUT`, `Input`)", () => {
+    // `isVoidElement` lowercases its input; the FORM_CONTROL_VOIDS membership
+    // check must do the same so an upper/mixed-case spec doesn't get the
+    // `<INPUT> ignores disabled` false positive.
+    for (const element of ["INPUT", "Input"]) {
+      const spec = makeVoid(element, {
+        disabled: { type: "boolean", responsive: false, description: "Disabled." },
+      });
+      expect(checkVoidElementConstraints(spec)).toEqual([]);
+    }
+  });
+
   test("walks composite parts", () => {
     const spec: Spec = {
       name: "field",

--- a/scripts/codegen/src/semantic-checks.test.ts
+++ b/scripts/codegen/src/semantic-checks.test.ts
@@ -17,6 +17,7 @@ import {
   checkTokenContract,
   checkVariantChoiceKeys,
   checkVocabulary,
+  checkVoidElementConstraints,
   levenshtein,
   suggest,
 } from "./semantic-checks.ts";
@@ -458,6 +459,102 @@ describe("checkAsIsConstrained", () => {
     };
     const issues = checkAsIsConstrained(spec);
     expect(issues.some((i) => i.path === "parts.trigger.props.as.values")).toBe(true);
+  });
+});
+
+describe("checkVoidElementConstraints", () => {
+  function makeVoid(element: string, props: Record<string, unknown> = {}): Spec {
+    return {
+      name: "divider",
+      kind: "atomic",
+      element,
+      rootClass: "t-divider",
+      props,
+    } as Spec;
+  }
+
+  test("ignores non-void elements", () => {
+    const spec = makeVoid("div", {
+      content: { slot: true, type: "string", responsive: false, description: "Body." },
+      loading: { type: "boolean", responsive: false, description: "Loading." },
+      as: {
+        type: "string",
+        values: ["div", "span"],
+        responsive: false,
+        description: "Polymorphic.",
+      },
+      disabled: { type: "boolean", responsive: false, description: "Disabled." },
+    });
+    expect(checkVoidElementConstraints(spec)).toEqual([]);
+  });
+
+  test("ignores a void element with no offending props", () => {
+    expect(checkVoidElementConstraints(makeVoid("hr"))).toEqual([]);
+  });
+
+  test("flags slot props on a void element (one issue per slot)", () => {
+    const spec = makeVoid("hr", {
+      leading: { slot: true, type: "string", responsive: false, description: "Leading slot." },
+      trailing: { slot: true, type: "string", responsive: false, description: "Trailing slot." },
+    });
+    const issues = checkVoidElementConstraints(spec);
+    expect(issues.map((i) => i.path)).toEqual(["props.leading", "props.trailing"]);
+    expect(issues[0]?.message).toMatch(/<hr> cannot host slot props/);
+  });
+
+  test("flags `loading` on a void element", () => {
+    const spec = makeVoid("img", {
+      loading: { type: "boolean", responsive: false, description: "Loading." },
+    });
+    const issues = checkVoidElementConstraints(spec);
+    expect(issues).toHaveLength(1);
+    expect(issues[0]?.path).toBe("props.loading");
+    expect(issues[0]?.message).toMatch(/<img> cannot render a loading spinner/);
+  });
+
+  test("flags `as` on a void element", () => {
+    const spec = makeVoid("hr", {
+      as: { type: "string", values: ["hr", "div"], responsive: false, description: "Polymorphic." },
+    });
+    const issues = checkVoidElementConstraints(spec);
+    expect(issues).toHaveLength(1);
+    expect(issues[0]?.path).toBe("props.as");
+    expect(issues[0]?.message).toMatch(/<hr> cannot declare `as`/);
+  });
+
+  test("flags `disabled` on a non-form-control void element", () => {
+    const spec = makeVoid("img", {
+      disabled: { type: "boolean", responsive: false, description: "Disabled." },
+    });
+    const issues = checkVoidElementConstraints(spec);
+    expect(issues).toHaveLength(1);
+    expect(issues[0]?.path).toBe("props.disabled");
+    expect(issues[0]?.message).toMatch(/<img> ignores `disabled`/);
+  });
+
+  test("accepts `disabled` on <input> (form-control void)", () => {
+    const spec = makeVoid("input", {
+      disabled: { type: "boolean", responsive: false, description: "Disabled." },
+    });
+    expect(checkVoidElementConstraints(spec)).toEqual([]);
+  });
+
+  test("walks composite parts", () => {
+    const spec: Spec = {
+      name: "field",
+      kind: "composite",
+      parts: {
+        separator: {
+          element: "hr",
+          props: {
+            loading: { type: "boolean", description: "Loading." },
+          },
+        },
+      },
+    } as Spec;
+    const issues = checkVoidElementConstraints(spec);
+    expect(issues).toHaveLength(1);
+    expect(issues[0]?.path).toBe("parts.separator.props.loading");
   });
 });
 

--- a/scripts/codegen/src/semantic-checks.ts
+++ b/scripts/codegen/src/semantic-checks.ts
@@ -637,6 +637,9 @@ export function checkVoidElementConstraints(spec: Spec): Issue[] {
   visitNodes(spec, (node, path) => {
     if (!node.element || !isVoidElement(node.element)) return;
     const tag = node.element;
+    // `isVoidElement` lowercases its input; compare the FORM_CONTROL_VOIDS
+    // membership the same way so `element: INPUT` is treated as `element: input`.
+    const tagLower = tag.toLowerCase();
     const propsPath = (key: string) => (path === "" ? `props.${key}` : `${path}.props.${key}`);
     const slotProps = Object.entries(node.props ?? {})
       .filter(([, d]) => d.slot === true)
@@ -664,7 +667,7 @@ export function checkVoidElementConstraints(spec: Spec): Issue[] {
         ),
       );
     }
-    if ("disabled" in (node.props ?? {}) && !FORM_CONTROL_VOIDS.has(tag)) {
+    if ("disabled" in (node.props ?? {}) && !FORM_CONTROL_VOIDS.has(tagLower)) {
       issues.push(
         issue(
           spec.name,

--- a/scripts/codegen/src/semantic-checks.ts
+++ b/scripts/codegen/src/semantic-checks.ts
@@ -4,6 +4,7 @@
 // drift with Levenshtein suggestions, motion in/out symmetry, dependency
 // cycles, the `@import` allowlist driven by `dependencies:`, and
 // `guidance.variantChoice` key equality with `spec.variants`.
+import { isVoidElement } from "./lib/html-void-elements.ts";
 import { REACT_EVENT_VOCABULARY } from "./lib/react-events.ts";
 import type { Vocabulary } from "./lib/vocabulary.ts";
 import type { Spec, SpecPart } from "./schema.ts";
@@ -618,6 +619,64 @@ export function checkAsIsConstrained(spec: Spec): Issue[] {
   return issues;
 }
 
+// ── Void HTML elements reject child-bearing prop declarations ───────────────
+
+/**
+ * Void elements (`hr`, `img`, `input`, `br`, …) cannot have children, so
+ * codegen emits the self-closing form. A spec author who declares slot props,
+ * `loading`, or `as` on a void element gets no compile-time signal — the
+ * codegen silently ignores them. Flag at spec-validation time so the dead
+ * fields surface in review. `disabled` is rejected on non-form-control voids
+ * (where it is a no-op) but accepted on `input` (where it carries native
+ * semantics). Walks composite parts.
+ */
+const FORM_CONTROL_VOIDS = new Set(["input"]);
+
+export function checkVoidElementConstraints(spec: Spec): Issue[] {
+  const issues: Issue[] = [];
+  visitNodes(spec, (node, path) => {
+    if (!node.element || !isVoidElement(node.element)) return;
+    const tag = node.element;
+    const propsPath = (key: string) => (path === "" ? `props.${key}` : `${path}.props.${key}`);
+    const slotProps = Object.entries(node.props ?? {})
+      .filter(([, d]) => d.slot === true)
+      .map(([n]) => n);
+    for (const slot of slotProps) {
+      issues.push(
+        issue(spec.name, propsPath(slot), `void element <${tag}> cannot host slot props`),
+      );
+    }
+    if ("loading" in (node.props ?? {})) {
+      issues.push(
+        issue(
+          spec.name,
+          propsPath("loading"),
+          `void element <${tag}> cannot render a loading spinner child`,
+        ),
+      );
+    }
+    if ("as" in (node.props ?? {})) {
+      issues.push(
+        issue(
+          spec.name,
+          propsPath("as"),
+          `void element <${tag}> cannot declare \`as\` — polymorphism to a non-void element breaks codegen-time void detection`,
+        ),
+      );
+    }
+    if ("disabled" in (node.props ?? {}) && !FORM_CONTROL_VOIDS.has(tag)) {
+      issues.push(
+        issue(
+          spec.name,
+          propsPath("disabled"),
+          `void element <${tag}> ignores \`disabled\` (only form-control voids like <input> honor it)`,
+        ),
+      );
+    }
+  });
+  return issues;
+}
+
 // ── Responsive: explicit per-prop decision (#594) ───────────────────────────
 
 /**
@@ -828,6 +887,7 @@ export function runSemanticChecks(
     ...checkVariantChoiceKeys(spec),
     ...checkResponsiveExplicit(spec),
     ...checkAsIsConstrained(spec),
+    ...checkVoidElementConstraints(spec),
     ...checkInteractionRefs(spec),
     ...checkInteractionEventVocabulary(spec),
     ...checkOverlayEscapeRules(spec),


### PR DESCRIPTION
## What

`checkVoidElementConstraints` in `scripts/codegen/src/semantic-checks.ts` rejects a spec when its `element` is an HTML void element (`hr`, `img`, `input`, `br`, …) and the node also declares any of:

- a slot prop (void elements have no children — the slot is unreachable)
- `loading` (the spinner is a child node)
- `as` (polymorphism to a non-void element defeats codegen-time void detection)
- `disabled` on any void element other than `<input>` (no-op on `<hr>`, `<img>`, etc.; `<input disabled>` is allowed)

Walks composite parts so `parts.<name>` with `element: hr` is covered.

## Why

PR #752 added the self-closing void-element emission (`lib/html-void-elements.ts`) but the codegen silently ignored these dead prop declarations. The validator now catches them at spec-validation time so a spec author sees the error in `pnpm lint` instead of discovering it at runtime / review.

## Test plan

- New `describe("checkVoidElementConstraints")` block in `semantic-checks.test.ts` covers: ignore non-void, ignore void with no offending props, flag slot props (one issue per slot), flag `loading`, flag `as`, flag `disabled` on `<img>`, accept `disabled` on `<input>`, walk composite parts.
- `pnpm lint` clean — none of the existing specs use a void element, so no current spec triggers the new check.
- 817/817 tests pass (8 new + 809 prior).
- Pre-push fully green on push.

## Out of scope

- Changing what the codegen emits when these violations are present — handled in PR #752; codegen continues to silently ignore.
- Auto-fix / removal of offending props.
- A separate warn severity. The `disabled`-on-non-form-void case is reported as an error rather than a warning because the existing `Issue[]` infrastructure has no severity field; adding one solely for this check would be over-engineering.

Closes #754