### PR TITLE
chore(repo): audit stale pnpm overrides via monthly workflow

### DIFF
--- a/.github/workflows/audit-overrides.yml
+++ b/.github/workflows/audit-overrides.yml
@@ -1,0 +1,56 @@
+name: audit-overrides
+
+on:
+  schedule:
+    - cron: '0 6 1 * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup
+      - name: Run audit
+        id: audit
+        run: |
+          OUTPUT=$(node scripts/repo/audit-overrides.ts)
+          echo "$OUTPUT"
+          {
+            echo "result<<AUDIT_EOF"
+            echo "$OUTPUT"
+            echo "AUDIT_EOF"
+          } >> "$GITHUB_OUTPUT"
+      - name: Open issue for redundant overrides
+        if: fromJSON(steps.audit.outputs.result).redundant[0] != null
+        uses: actions/github-script@v9
+        env:
+          AUDIT_RESULT: ${{ steps.audit.outputs.result }}
+        with:
+          script: |
+            const result = JSON.parse(process.env.AUDIT_RESULT);
+            const date = new Date().toISOString().slice(0, 10);
+            const lines = [
+              `## Redundant overrides — ${date}`,
+              '',
+              'These `overrides` entries in `pnpm-workspace.yaml` no longer change any resolved version. Safe to drop:',
+              '',
+              ...result.redundant.map((n) => `- \`${n}\``),
+            ];
+            if (result.hardRequired.length > 0) {
+              lines.push('', '### Hard-required (informational)', '', 'Removing these breaks the install — confirmed load-bearing:', '');
+              for (const entry of result.hardRequired) {
+                lines.push(`- \`${entry.name}\` — ${entry.reason}`);
+              }
+            }
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `chore(repo): redundant overrides detected — ${date}`,
+              body: lines.join('\n'),
+              labels: ['type:chore', 'area:repo', 'dependencies'],
+            });

--- a/.github/workflows/audit-overrides.yml
+++ b/.github/workflows/audit-overrides.yml
@@ -52,5 +52,5 @@ jobs:
               repo: context.repo.repo,
               title: `chore(repo): redundant overrides detected — ${date}`,
               body: lines.join('\n'),
-              labels: ['type:chore', 'area:repo', 'dependencies'],
+              labels: ['type:chore', 'area:repo', 'dep'],
             });

--- a/docs/process/dev-scripts.md
+++ b/docs/process/dev-scripts.md
@@ -25,6 +25,7 @@ The bare-verb defaults are the verbs you reach for daily: `dev`, `build`, `test`
 | `pnpm typecheck` | `tsc --noEmit` at the root plus recursive `typecheck` across packages | Before push; in CI; via lefthook | Developer + CI + lefthook |
 | `pnpm size` | `size-limit` — per-entry CSS bundle budgets | When bundle size may have moved | Developer + CI |
 | `pnpm migrate:specs` | One-off spec migration (`scripts/repo/migrate-specs.ts`) | Rare — bulk spec-format changes | Maintainer |
+| `pnpm audit:overrides` | Audits `pnpm-workspace.yaml` `overrides` entries; drops each, re-resolves, and reports which are redundant (`scripts/repo/audit-overrides.ts`) | Monthly via the `audit-overrides` workflow; ad-hoc before bumping shared deps | Maintainer + CI |
 | `pnpm changeset` | Changesets CLI — writes a release entry to `.changeset/<slug>.md` | After implementation | Developer |
 | `pnpm release` | Publish to npm with provenance | CI only (errors locally) | CI |
 | `pnpm prepare` | Lifecycle hook — runs `lefthook install` on `pnpm install` | Automatic; not run directly | — |

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "typecheck": "tsc --noEmit && pnpm -r --if-present run typecheck",
     "size": "size-limit",
     "migrate:specs": "node scripts/repo/migrate-specs.ts",
+    "audit:overrides": "node scripts/repo/audit-overrides.ts",
     "changeset": "changeset",
     "release": "changeset publish",
     "prepare": "lefthook install --force"
@@ -70,6 +71,7 @@
     "stylelint": "^17.12.0",
     "stylelint-config-standard": "^40.0.0",
     "typescript": "^6.0.3",
-    "vitest": "^4.1.7"
+    "vitest": "^4.1.7",
+    "yaml": "^2.9.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,6 +62,9 @@ importers:
       vitest:
         specifier: ^4.1.7
         version: 4.1.7(@types/node@24.12.4)(happy-dom@20.9.0)(vite@8.0.14(@types/node@24.12.4)(esbuild@0.27.7)(yaml@2.9.0))
+      yaml:
+        specifier: ^2.8.3
+        version: 2.9.0
 
   apps/docs:
     dependencies:

--- a/scripts/repo/audit-overrides.ts
+++ b/scripts/repo/audit-overrides.ts
@@ -1,0 +1,99 @@
+#!/usr/bin/env node
+import { execFileSync } from "node:child_process";
+import { readFileSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { parseDocument } from "yaml";
+
+const REPO_ROOT = resolve(import.meta.dirname, "../..");
+const WORKSPACE_PATH = resolve(REPO_ROOT, "pnpm-workspace.yaml");
+const LOCKFILE_PATH = resolve(REPO_ROOT, "pnpm-lock.yaml");
+
+type AuditResult = {
+  redundant: string[];
+  hardRequired: Array<{ name: string; reason: string }>;
+  stillNeeded: string[];
+};
+
+function reinstall(): void {
+  execFileSync("pnpm", ["install", "--lockfile-only"], {
+    cwd: REPO_ROOT,
+    stdio: "ignore",
+  });
+}
+
+function resolvedVersions(lockText: string, packageName: string): Set<string> {
+  // pnpm-lock.yaml emits `  packageName@version:` keys under the `packages:`
+  // section. Match a real key (two-space indent + literal name + `@`).
+  const matches = lockText.matchAll(new RegExp(`^  ${escapeRegex(packageName)}@([^:\\s]+):`, "gm"));
+  const versions = new Set<string>();
+  for (const m of matches) versions.add(m[1] ?? "");
+  return versions;
+}
+
+function escapeRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function setsEqual(a: Set<string>, b: Set<string>): boolean {
+  if (a.size !== b.size) return false;
+  for (const v of a) if (!b.has(v)) return false;
+  return true;
+}
+
+function main(): void {
+  const originalWorkspaceText = readFileSync(WORKSPACE_PATH, "utf8");
+  const originalLockfileText = readFileSync(LOCKFILE_PATH, "utf8");
+  const doc = parseDocument(originalWorkspaceText);
+  const overridesNode = doc.get("overrides");
+  const overrides =
+    overridesNode && typeof overridesNode === "object"
+      ? (doc.toJS().overrides as Record<string, string> | undefined)
+      : undefined;
+  const overrideNames = overrides ? Object.keys(overrides) : [];
+
+  if (overrideNames.length === 0) {
+    console.log(JSON.stringify({ redundant: [], hardRequired: [], stillNeeded: [] }));
+    return;
+  }
+
+  reinstall();
+  const baselineLock = readFileSync(LOCKFILE_PATH, "utf8");
+
+  const result: AuditResult = { redundant: [], hardRequired: [], stillNeeded: [] };
+
+  try {
+    for (const name of overrideNames) {
+      const trialDoc = parseDocument(originalWorkspaceText);
+      trialDoc.deleteIn(["overrides", name]);
+      writeFileSync(WORKSPACE_PATH, trialDoc.toString());
+
+      try {
+        reinstall();
+        const trialLock = readFileSync(LOCKFILE_PATH, "utf8");
+        const baseVersions = resolvedVersions(baselineLock, name);
+        const trialVersions = resolvedVersions(trialLock, name);
+        if (setsEqual(baseVersions, trialVersions)) {
+          result.redundant.push(name);
+        } else {
+          result.stillNeeded.push(name);
+        }
+      } catch (err) {
+        result.hardRequired.push({
+          name,
+          reason:
+            err instanceof Error
+              ? (err.message.split("\n")[0] ?? "install failed")
+              : "install failed",
+        });
+      }
+    }
+  } finally {
+    writeFileSync(WORKSPACE_PATH, originalWorkspaceText);
+    writeFileSync(LOCKFILE_PATH, originalLockfileText);
+    reinstall();
+  }
+
+  console.log(JSON.stringify(result));
+}
+
+main();


### PR DESCRIPTION
## What

Adds a monthly scheduled GitHub Actions workflow + `scripts/repo/audit-overrides.ts` that detects `pnpm-workspace.yaml` `overrides` entries whose removal no longer changes any resolved version, and opens a `chore(repo)` issue when redundant overrides are found.

- `scripts/repo/audit-overrides.ts`: for each override, drops the entry, re-runs `pnpm install --lockfile-only`, compares the resolved versions of the override target, and classifies as `redundant` / `stillNeeded` / `hardRequired` (install fails without it). Restores workspace + lockfile via try/finally on exit. Emits JSON to stdout.
- `.github/workflows/audit-overrides.yml`: cron at 06:00 UTC on the 1st of each month plus `workflow_dispatch`; uses the existing `./.github/actions/setup` composite, runs the script, and files a combined issue with `type:chore` / `area:repo` / `dependencies` labels when `redundant[0]` is non-null.
- `package.json`: new `audit:overrides` script + `yaml@^2.9.0` devDep (the script uses `yaml.parseDocument` to preserve comments on round-trip).
- `docs/process/dev-scripts.md`: catalog row for the new script.

## Why

`pnpm-workspace.yaml` currently pins `yaml: '^2.8.3'` to dodge a transitive `yaml@2.7.1` stack-overflow advisory (#625). The override has no expiry and nothing re-checks it; once upstream catches up, it becomes silent dead weight. Detection requires re-resolving without the override and diffing — a per-PR check is wrong cadence (overrides go stale on an upstream-release timescale, not a commit timescale), so a monthly cron is the right shape.

I dry-ran the audit manually before committing: dropping the current `yaml` override reintroduces `yaml@2.7.1` to the lockfile, so the override is still load-bearing today and the next scheduled run will correctly find no redundant entries.

## Test plan

- [x] `pnpm audit:overrides` locally reports `{"redundant":[],"hardRequired":[],"stillNeeded":["yaml"]}`.
- [x] Working tree is clean after the script runs (workspace + lockfile restored via try/finally).
- [x] `pnpm typecheck`, `pnpm lint` pass.
- [ ] First scheduled cron run reports no redundant overrides (will verify on the next monthly trigger or via `workflow_dispatch`).

## Out of scope

- Per-PR enforcement — wrong cadence; overrides don't change on a commit cycle.
- Auto-removing redundant overrides from `pnpm-workspace.yaml` — the audit reports, a human edits. Auto-removal would surprise.
- Support for pattern-keyed overrides (e.g. `'yaml@<2.8.3'`); today only plain-name keys are in use.

Closes #627.