### PR TITLE
chore(css): per-breakpoint cost ADR + auto-generated size config + docs sizes

### DIFF
--- a/.github/workflows/size-data.yml
+++ b/.github/workflows/size-data.yml
@@ -25,6 +25,9 @@ jobs:
       - if: steps.dist.outputs.have_dist == 'true'
         run: pnpm exec size-limit --json > size-current.json
       - if: steps.dist.outputs.have_dist == 'true'
+        name: Measure per-component breakpoint share
+        run: node scripts/repo/measure-bp-cost.ts > bp-share.json
+      - if: steps.dist.outputs.have_dist == 'true'
         name: Record PR number for the report job
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -35,5 +38,6 @@ jobs:
           name: size-data
           path: |
             size-current.json
+            bp-share.json
             pr-number.txt
           if-no-files-found: error

--- a/.github/workflows/size-report.yml
+++ b/.github/workflows/size-report.yml
@@ -48,6 +48,24 @@ jobs:
                 process.stdout.write(`| ${entry.name} | ${size} | ${gz} | ${limit} |\n`);
               }
             '
+            echo ''
+            echo '### Per-component breakpoint share (brotli)'
+            echo ''
+            echo '| Component | Brotli | BP share | % BP |'
+            echo '| --- | --- | --- | --- |'
+            # shellcheck disable=SC2016
+            node -e '
+              const rows = JSON.parse(require("fs").readFileSync("bp-share.json", "utf8"));
+              for (const row of rows) {
+                const total = row.brotli != null ? row.brotli + " B" : "—";
+                const share = row.bpShare != null ? row.bpShare + " B" : "—";
+                const pct = row.bpPct != null ? row.bpPct.toFixed(1) + "%" : "—";
+                const flag = row.bpPct >= 50 ? " ⚠" : "";
+                process.stdout.write(`| ${row.name} | ${total} | ${share} | ${pct}${flag} |\n`);
+              }
+            '
+            echo ''
+            echo '> The ⚠ marker fires when a single component crosses 50% breakpoint share — soft signal to revisit the per-breakpoint cost decision, not a CI failure.'
             echo 'EOT'
           } >> "$GITHUB_OUTPUT"
       - if: steps.artifact.outcome == 'success'

--- a/.size-limit.json
+++ b/.size-limit.json
@@ -21,7 +21,8 @@
   },
   {
     "name": "@teseor/css/components/button.css",
-    "path": "packages/css/dist/components/button.css"
+    "path": "packages/css/dist/components/button.css",
+    "limit": "4 kB"
   },
   {
     "name": "@teseor/css/components/cluster.css",

--- a/.size-limit.json
+++ b/.size-limit.json
@@ -1,14 +1,42 @@
 [
   {
-    "name": "teseor.css (full bundle)",
+    "name": "@teseor/css (full bundle)",
     "path": "packages/css/dist/teseor.css",
-    "limit": "12 KB",
-    "gzip": true
+    "limit": "8 kB"
   },
   {
-    "name": "tokens.css",
+    "name": "@teseor/css/tokens.css",
     "path": "packages/css/dist/tokens.css",
-    "limit": "2.5 KB",
-    "gzip": true
+    "limit": "4 kB"
+  },
+  {
+    "name": "@teseor/css/utilities.css",
+    "path": "packages/css/dist/utilities.css",
+    "limit": "2 kB"
+  },
+  {
+    "name": "@teseor/css/tailwind.css",
+    "path": "packages/css/dist/tailwind.css",
+    "limit": "6 kB"
+  },
+  {
+    "name": "@teseor/css/components/button.css",
+    "path": "packages/css/dist/components/button.css"
+  },
+  {
+    "name": "@teseor/css/components/cluster.css",
+    "path": "packages/css/dist/components/cluster.css"
+  },
+  {
+    "name": "@teseor/css/components/modal.css",
+    "path": "packages/css/dist/components/modal.css"
+  },
+  {
+    "name": "@teseor/css/components/stack.css",
+    "path": "packages/css/dist/components/stack.css"
+  },
+  {
+    "name": "@teseor/css/components/tooltip.css",
+    "path": "packages/css/dist/components/tooltip.css"
   }
 ]

--- a/apps/docs/src/pages/components/button.astro
+++ b/apps/docs/src/pages/components/button.astro
@@ -156,5 +156,14 @@ import Base from "../../layouts/Base.astro";
         <li>Loading already disables interaction; disabling on top is redundant.</li>
       </ul>
     </section>
+    <section class="t-stack" data-gap="3">
+      <h2>Bundle size</h2>
+      <table>
+        <thead><tr><th>Artifact</th><th>Raw</th><th>Gzip</th><th>Brotli</th></tr></thead>
+        <tbody>
+        <tr><td><a href="https://github.com/teseor/teseor/blob/main/packages/css/src/components/button/button.css"><code>@teseor/css/components/button.css</code></a></td><td>8.29 KB</td><td>1.58 KB</td><td>1.32 KB</td></tr>
+        </tbody>
+      </table>
+    </section>
   </main>
 </Base>

--- a/apps/docs/src/pages/components/cluster.astro
+++ b/apps/docs/src/pages/components/cluster.astro
@@ -92,5 +92,14 @@ import Base from "../../layouts/Base.astro";
       <h2>Accessibility</h2>
       <p>Role: <code>generic</code></p>
     </section>
+    <section class="t-stack" data-gap="3">
+      <h2>Bundle size</h2>
+      <table>
+        <thead><tr><th>Artifact</th><th>Raw</th><th>Gzip</th><th>Brotli</th></tr></thead>
+        <tbody>
+        <tr><td><a href="https://github.com/teseor/teseor/blob/main/packages/css/src/components/cluster/cluster.css"><code>@teseor/css/components/cluster.css</code></a></td><td>9.13 KB</td><td>0.95 KB</td><td>0.74 KB</td></tr>
+        </tbody>
+      </table>
+    </section>
   </main>
 </Base>

--- a/apps/docs/src/pages/components/modal.astro
+++ b/apps/docs/src/pages/components/modal.astro
@@ -58,5 +58,14 @@ import Base from "../../layouts/Base.astro";
         </tbody>
       </table>
     </section>
+    <section class="t-stack" data-gap="3">
+      <h2>Bundle size</h2>
+      <table>
+        <thead><tr><th>Artifact</th><th>Raw</th><th>Gzip</th><th>Brotli</th></tr></thead>
+        <tbody>
+        <tr><td><a href="https://github.com/teseor/teseor/blob/main/packages/css/src/components/modal/modal.css"><code>@teseor/css/components/modal.css</code></a></td><td>1.23 KB</td><td>0.52 KB</td><td>0.44 KB</td></tr>
+        </tbody>
+      </table>
+    </section>
   </main>
 </Base>

--- a/apps/docs/src/pages/components/stack.astro
+++ b/apps/docs/src/pages/components/stack.astro
@@ -83,5 +83,14 @@ import Base from "../../layouts/Base.astro";
       <h2>Accessibility</h2>
       <p>Role: <code>generic</code></p>
     </section>
+    <section class="t-stack" data-gap="3">
+      <h2>Bundle size</h2>
+      <table>
+        <thead><tr><th>Artifact</th><th>Raw</th><th>Gzip</th><th>Brotli</th></tr></thead>
+        <tbody>
+        <tr><td><a href="https://github.com/teseor/teseor/blob/main/packages/css/src/components/stack/stack.css"><code>@teseor/css/components/stack.css</code></a></td><td>6.49 KB</td><td>0.73 KB</td><td>0.59 KB</td></tr>
+        </tbody>
+      </table>
+    </section>
   </main>
 </Base>

--- a/apps/docs/src/pages/components/tooltip.astro
+++ b/apps/docs/src/pages/components/tooltip.astro
@@ -112,5 +112,14 @@ import Base from "../../layouts/Base.astro";
         </tbody>
       </table>
     </section>
+    <section class="t-stack" data-gap="3">
+      <h2>Bundle size</h2>
+      <table>
+        <thead><tr><th>Artifact</th><th>Raw</th><th>Gzip</th><th>Brotli</th></tr></thead>
+        <tbody>
+        <tr><td><a href="https://github.com/teseor/teseor/blob/main/packages/css/src/components/tooltip/tooltip.css"><code>@teseor/css/components/tooltip.css</code></a></td><td>11.55 KB</td><td>1.97 KB</td><td>1.61 KB</td></tr>
+        </tbody>
+      </table>
+    </section>
   </main>
 </Base>

--- a/docs/ADR/0016-per-breakpoint-css-cost.md
+++ b/docs/ADR/0016-per-breakpoint-css-cost.md
@@ -1,0 +1,79 @@
+# ADR-0016 — Per-breakpoint CSS cost: status quo with a per-component brotli budget
+
+- **Status:** Accepted.
+- **Deciders:** repo owner (letanure).
+
+## Decision
+
+Keep the current per-breakpoint emission for responsive props (each
+`@each $bp` loop expands into `breakpoints × values` rules per
+responsive prop, per component). Do not introduce a build-time
+breakpoint configuration, wrapper-resolved inline custom properties,
+or per-breakpoint-set entry points. Adopt a per-component brotli
+budget on the share of bytes attributable to per-breakpoint `@media
+(--<bp>)` blocks: any single component whose breakpoint share crosses
+**50%** of its own brotli size is treated as a signal to revisit this
+ADR, not a hard fail. The measurement runs automatically as part of the
+existing size-report workflow (sticky PR comment, refreshed on every
+push to the PR branch), so the budget is visible in the same place
+the size table already lives — not gated on someone remembering a
+manual command.
+
+## Why this and not one of the alternatives
+
+- **Measurement undercuts the issue's "structural cost" framing.** Across the
+  five components shipped today the breakpoint share is **17% of total brotli
+  bytes (826 / 4809)** and is **concentrated in layout primitives** — Stack
+  37%, Cluster 39%, Tooltip 12%, Button 9%, Modal 0%. Interactive components
+  pay near-zero; the cost does not scale uniformly as components are added.
+- **The raw-vs-brotli ratio is overstated.** The issue cited "roughly 10x"; the
+  measurement shows **2-4x** — raw bp share runs 31–75%, brotli runs 9–39%.
+  The compressor already collapses the near-identical per-breakpoint blocks.
+- **Build-time breakpoint configuration moves complexity to consumers.** The
+  generator would have to ingest a consumer-supplied set, the docs would have
+  to document the matrix, and `pnpm gen` would need a per-build invariant
+  check. The saving on layout primitives is real (~37%) but the surface lands
+  on every consumer for a feature most won't use.
+- **Wrapper-resolved inline custom properties trades CSS bytes for inline-style
+  bytes.** The layout primitives lose the `breakpoints × values` combinatorial
+  but every consumer's HTML gains inline `--_*` declarations. The frameworkless
+  (HTML+CSS-only) API gets worse, not better. The net byte saving is consumer-
+  specific.
+- **Per-breakpoint-set entry points or packages** add packaging complexity for
+  a saving that hasn't been requested by any consumer to date.
+- **A consumer-side strip step** only helps consumers with a build pipeline,
+  excluding the frameworkless path the project explicitly supports.
+- **A standalone `pnpm size:bp` script** would land but go unused: it's not
+  reflexive in the PR review path, and once it goes stale nobody notices.
+  Putting the number in the PR-comment table forces visibility on every push.
+
+## Consequences
+
+- The project keeps the current `@each $bp` source pattern and per-breakpoint
+  emission. No breaking change to the public CSS, no change to the wrappers,
+  no change to the codegen.
+- The size-report PR-comment workflow gains a per-component breakpoint-share
+  column. The sticky comment is created when a PR opens and refreshed on each
+  push to the PR branch, so a layout primitive crossing 50% surfaces as soon
+  as the offending change lands on the branch — not on the next time someone
+  runs a forgotten script.
+- The 50% threshold is a soft signal, not a CI failure. When a component
+  crosses it, this ADR is revisited with the new measurement; the threshold
+  exists so the conversation has a number, not so a PR is blocked.
+- The brotli share for a future layout primitive with many responsive props
+  is the most likely trigger. If a real consumer requests a smaller breakpoint
+  set (e.g. only `md` + `lg`), that request — not the speculative cost — is
+  the right driver to revisit, and either the build-time config or the
+  wrapper-resolved-inline-vars option becomes the right answer in that
+  specific context.
+
+## Measurement at the time of decision (2026-05-25)
+
+| Component | Brotli total | Brotli bp share | % bp |
+| --- | --- | --- | --- |
+| `button.css` | 1350 | 116 | 9% |
+| `cluster.css` | 757 | 295 | **39%** |
+| `modal.css` | 451 | 1 | 0% |
+| `stack.css` | 601 | 221 | **37%** |
+| `tooltip.css` | 1650 | 193 | 12% |
+| **Total** | **4809** | **826** | **17%** |

--- a/docs/ADR/README.md
+++ b/docs/ADR/README.md
@@ -21,6 +21,9 @@ a numbered, durable file.
 | [0011](0011-css-anchor-positioning-for-overlays.md) | CSS Anchor Positioning + Popover API for overlays | Accepted |
 | [0012](0012-wrapper-internal-seam.md) | Wrapper-internal seam: generated `_runtime.ts` + framework-conventional folders | Accepted |
 | [0013](0013-overlay-modality.md) | Overlay modality: `popover.modal`, focus-trap auto-activation, inert cascade | Proposed |
+| [0014](0014-scripts-layout-and-lint-runner.md) | Scripts layout and lint runner | Accepted |
+| [0015](0015-codegen-layout.md) | Codegen layout: target-first generators | Accepted |
+| [0016](0016-per-breakpoint-css-cost.md) | Per-breakpoint CSS cost: status quo with budget | Accepted |
 
 ## When to write one
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test:visual": "echo 'test:visual: lands at v0.2' && exit 0",
     "test:a11y": "echo 'test:a11y: lands at v0.2' && exit 0",
     "lint": "node scripts/lint/run.ts --all",
-    "gen": "pnpm --filter @teseor/codegen run gen && pnpm build:css && biome check --write --no-errors-on-unmatched .",
+    "gen": "pnpm build:css && pnpm --filter @teseor/codegen run gen && biome check --write --no-errors-on-unmatched .",
     "typecheck": "tsc --noEmit && pnpm -r --if-present run typecheck",
     "size": "size-limit",
     "migrate:specs": "node scripts/repo/migrate-specs.ts",
@@ -26,33 +26,6 @@
     "release": "changeset publish",
     "prepare": "lefthook install --force"
   },
-  "size-limit": [
-    {
-      "name": "@teseor/css (full bundle)",
-      "path": "packages/css/dist/teseor.css",
-      "limit": "8 kB"
-    },
-    {
-      "name": "@teseor/css/tokens.css",
-      "path": "packages/css/dist/tokens.css",
-      "limit": "4 kB"
-    },
-    {
-      "name": "@teseor/css/utilities.css",
-      "path": "packages/css/dist/utilities.css",
-      "limit": "2 kB"
-    },
-    {
-      "name": "@teseor/css/tailwind.css",
-      "path": "packages/css/dist/tailwind.css",
-      "limit": "6 kB"
-    },
-    {
-      "name": "@teseor/css/components/button.css",
-      "path": "packages/css/dist/components/button.css",
-      "limit": "4 kB"
-    }
-  ],
   "devDependencies": {
     "@biomejs/biome": "^2.4.15",
     "@changesets/changelog-git": "^0.2.1",

--- a/scripts/codegen/__tests__/gen-size-limit.test.ts
+++ b/scripts/codegen/__tests__/gen-size-limit.test.ts
@@ -39,11 +39,18 @@ describe("gen-size-limit", () => {
     const entries = await readSizeLimit();
     const specNames = await listSpecNames();
     const componentEntries = entries.filter((e) => e.path.startsWith(COMPONENT_PATH_PREFIX));
-    const expected = specNames.map((name) => ({
-      name: `@teseor/css/components/${name}.css`,
-      path: `${COMPONENT_PATH_PREFIX}${name}.css`,
-    }));
-    expect(componentEntries).toEqual(expected);
+    expect(componentEntries.map((e) => ({ name: e.name, path: e.path }))).toEqual(
+      specNames.map((name) => ({
+        name: `@teseor/css/components/${name}.css`,
+        path: `${COMPONENT_PATH_PREFIX}${name}.css`,
+      })),
+    );
+  });
+
+  test("preserves the Button per-component brotli budget", async () => {
+    const entries = await readSizeLimit();
+    const button = entries.find((e) => e.name === "@teseor/css/components/button.css");
+    expect(button?.limit).toBe("4 kB");
   });
 
   test("every entry resolves under packages/css/dist", async () => {

--- a/scripts/codegen/__tests__/gen-size-limit.test.ts
+++ b/scripts/codegen/__tests__/gen-size-limit.test.ts
@@ -1,0 +1,48 @@
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { describe, expect, test } from "vitest";
+
+const REPO_ROOT = resolve(import.meta.dirname, "..", "..", "..");
+const SIZE_LIMIT_PATH = resolve(REPO_ROOT, ".size-limit.json");
+
+type Entry = { name: string; path: string; limit?: string };
+
+async function readSizeLimit(): Promise<Entry[]> {
+  return JSON.parse(await readFile(SIZE_LIMIT_PATH, "utf8"));
+}
+
+describe("gen-size-limit", () => {
+  test("emits bundle entries first, then per-component entries in spec order", async () => {
+    const entries = await readSizeLimit();
+    const bundleNames = entries
+      .filter((e) => !e.path.startsWith("packages/css/dist/components/"))
+      .map((e) => e.name);
+    expect(bundleNames).toEqual([
+      "@teseor/css (full bundle)",
+      "@teseor/css/tokens.css",
+      "@teseor/css/utilities.css",
+      "@teseor/css/tailwind.css",
+    ]);
+  });
+
+  test("includes one entry per non-underscore spec under specs/", async () => {
+    const entries = await readSizeLimit();
+    const componentNames = entries
+      .filter((e) => e.path.startsWith("packages/css/dist/components/"))
+      .map((e) => e.name);
+    expect(componentNames).toEqual([
+      "@teseor/css/components/button.css",
+      "@teseor/css/components/cluster.css",
+      "@teseor/css/components/modal.css",
+      "@teseor/css/components/stack.css",
+      "@teseor/css/components/tooltip.css",
+    ]);
+  });
+
+  test("every entry has a matching dist path under packages/css/dist", async () => {
+    const entries = await readSizeLimit();
+    for (const entry of entries) {
+      expect(entry.path.startsWith("packages/css/dist/")).toBe(true);
+    }
+  });
+});

--- a/scripts/codegen/__tests__/gen-size-limit.test.ts
+++ b/scripts/codegen/__tests__/gen-size-limit.test.ts
@@ -1,23 +1,33 @@
-import { readFile } from "node:fs/promises";
+import { readdir, readFile } from "node:fs/promises";
 import { resolve } from "node:path";
 import { describe, expect, test } from "vitest";
 
 const REPO_ROOT = resolve(import.meta.dirname, "..", "..", "..");
 const SIZE_LIMIT_PATH = resolve(REPO_ROOT, ".size-limit.json");
+const SPECS_DIR = resolve(REPO_ROOT, "specs");
 
 type Entry = { name: string; path: string; limit?: string };
+
+const COMPONENT_PATH_PREFIX = "packages/css/dist/components/";
 
 async function readSizeLimit(): Promise<Entry[]> {
   return JSON.parse(await readFile(SIZE_LIMIT_PATH, "utf8"));
 }
 
+async function listSpecNames(): Promise<string[]> {
+  const entries = await readdir(SPECS_DIR);
+  return entries
+    .filter((f) => f.endsWith(".yaml") && !f.startsWith("_"))
+    .map((f) => f.slice(0, -5))
+    .sort();
+}
+
 describe("gen-size-limit", () => {
-  test("emits bundle entries first, then per-component entries in spec order", async () => {
+  test("emits the fixed bundle entries before any component entry", async () => {
     const entries = await readSizeLimit();
-    const bundleNames = entries
-      .filter((e) => !e.path.startsWith("packages/css/dist/components/"))
-      .map((e) => e.name);
-    expect(bundleNames).toEqual([
+    const firstComponentIdx = entries.findIndex((e) => e.path.startsWith(COMPONENT_PATH_PREFIX));
+    const bundleSlice = firstComponentIdx === -1 ? entries : entries.slice(0, firstComponentIdx);
+    expect(bundleSlice.map((e) => e.name)).toEqual([
       "@teseor/css (full bundle)",
       "@teseor/css/tokens.css",
       "@teseor/css/utilities.css",
@@ -25,21 +35,18 @@ describe("gen-size-limit", () => {
     ]);
   });
 
-  test("includes one entry per non-underscore spec under specs/", async () => {
+  test("emits one component entry per non-underscore spec, alphabetical", async () => {
     const entries = await readSizeLimit();
-    const componentNames = entries
-      .filter((e) => e.path.startsWith("packages/css/dist/components/"))
-      .map((e) => e.name);
-    expect(componentNames).toEqual([
-      "@teseor/css/components/button.css",
-      "@teseor/css/components/cluster.css",
-      "@teseor/css/components/modal.css",
-      "@teseor/css/components/stack.css",
-      "@teseor/css/components/tooltip.css",
-    ]);
+    const specNames = await listSpecNames();
+    const componentEntries = entries.filter((e) => e.path.startsWith(COMPONENT_PATH_PREFIX));
+    const expected = specNames.map((name) => ({
+      name: `@teseor/css/components/${name}.css`,
+      path: `${COMPONENT_PATH_PREFIX}${name}.css`,
+    }));
+    expect(componentEntries).toEqual(expected);
   });
 
-  test("every entry has a matching dist path under packages/css/dist", async () => {
+  test("every entry resolves under packages/css/dist", async () => {
     const entries = await readSizeLimit();
     for (const entry of entries) {
       expect(entry.path.startsWith("packages/css/dist/")).toBe(true);

--- a/scripts/codegen/src/generators/gen-docs.ts
+++ b/scripts/codegen/src/generators/gen-docs.ts
@@ -1,6 +1,7 @@
 import { mkdir, readdir, readFile, writeFile } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { brotliCompressSync, gzipSync } from "node:zlib";
 import { parse as parseYaml } from "yaml";
 import { flattenSpec } from "../lib/flatten.ts";
 import type { GeneratorContext, GeneratorReport } from "../registry.ts";
@@ -13,6 +14,21 @@ import { renderCompositeOverlayDocsPage } from "./gen-docs/kinds/composite-overl
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..", "..", "..");
 const SPECS_DIR = resolve(REPO_ROOT, "specs");
 const DOCS_PAGES_DIR = resolve(REPO_ROOT, "apps", "docs", "src", "pages", "components");
+const CSS_COMPONENTS_DIR = resolve(REPO_ROOT, "packages", "css", "dist", "components");
+
+async function readBundleSizes(name: string): Promise<DocsSpec["bundleSizes"]> {
+  try {
+    const text = await readFile(resolve(CSS_COMPONENTS_DIR, `${name}.css`), "utf8");
+    const buf = Buffer.from(text, "utf8");
+    return {
+      raw: buf.byteLength,
+      gzip: gzipSync(buf).byteLength,
+      brotli: brotliCompressSync(buf).byteLength,
+    };
+  } catch {
+    return undefined;
+  }
+}
 
 /** Dispatch to the kind-specific renderer for the spec's `kind:` field. */
 function renderDocsPage(spec: DocsSpec): string {
@@ -53,6 +69,7 @@ async function docsGenerator(ctx: GeneratorContext): Promise<GeneratorReport> {
   await mkdir(DOCS_PAGES_DIR, { recursive: true });
   for (const name of targets) {
     const spec = await loadSpec(name);
+    spec.bundleSizes = await readBundleSizes(name);
     const outPath = resolve(DOCS_PAGES_DIR, `${name}.astro`);
     await writeFile(outPath, renderDocsPage(spec), "utf8");
     filesWritten.push(outPath);

--- a/scripts/codegen/src/generators/gen-docs.ts
+++ b/scripts/codegen/src/generators/gen-docs.ts
@@ -17,6 +17,7 @@ const DOCS_PAGES_DIR = resolve(REPO_ROOT, "apps", "docs", "src", "pages", "compo
 const CSS_COMPONENTS_DIR = resolve(REPO_ROOT, "packages", "css", "dist", "components");
 
 async function readBundleSizes(name: string): Promise<DocsSpec["bundleSizes"]> {
+  // ENOENT: build:css not run / spec has no CSS — omit silently. Anything else fails loud.
   try {
     const text = await readFile(resolve(CSS_COMPONENTS_DIR, `${name}.css`), "utf8");
     const buf = Buffer.from(text, "utf8");
@@ -25,8 +26,9 @@ async function readBundleSizes(name: string): Promise<DocsSpec["bundleSizes"]> {
       gzip: gzipSync(buf).byteLength,
       brotli: brotliCompressSync(buf).byteLength,
     };
-  } catch {
-    return undefined;
+  } catch (err) {
+    if (err instanceof Error && "code" in err && err.code === "ENOENT") return undefined;
+    throw err;
   }
 }
 

--- a/scripts/codegen/src/generators/gen-docs/_shared/sections.test.ts
+++ b/scripts/codegen/src/generators/gen-docs/_shared/sections.test.ts
@@ -3,6 +3,7 @@ import type { DocsSpec } from "./sections.ts";
 import {
   hasFromChildrenPart,
   renderA11y,
+  renderBundleSize,
   renderConstraints,
   renderNamed,
   renderProps,
@@ -300,6 +301,32 @@ describe("renderA11y", () => {
     expect(out).toContain("Custom escape wording.");
     expect(out).not.toContain("Topmost-wins when multiple overlays are open.");
     expect(out).toContain("<code>Outside pointer-down</code>");
+  });
+});
+
+describe("renderBundleSize", () => {
+  test("returns empty string when bundleSizes is unset", () => {
+    expect(renderBundleSize(atomicSpec())).toBe("");
+  });
+
+  test("renders a one-row table with raw / gzip / brotli columns", () => {
+    const spec = atomicSpec({
+      name: "button",
+      bundleSizes: { raw: 8491, gzip: 1500, brotli: 1350 },
+    });
+    const out = renderBundleSize(spec);
+    expect(out).toContain("<h2>Bundle size</h2>");
+    expect(out).toContain("<th>Artifact</th>");
+    expect(out).toContain("<th>Raw</th>");
+    expect(out).toContain("<th>Gzip</th>");
+    expect(out).toContain("<th>Brotli</th>");
+    expect(out).toContain("8.29 KB");
+    expect(out).toContain("1.46 KB");
+    expect(out).toContain("1.32 KB");
+    expect(out).toContain("<code>@teseor/css/components/button.css</code>");
+    expect(out).toContain(
+      'href="https://github.com/teseor/teseor/blob/main/packages/css/src/components/button/button.css"',
+    );
   });
 });
 

--- a/scripts/codegen/src/generators/gen-docs/_shared/sections.ts
+++ b/scripts/codegen/src/generators/gen-docs/_shared/sections.ts
@@ -8,7 +8,31 @@ export type DocsSpec = Spec & {
   states?: Record<string, { description?: string }>;
   tokens?: Record<string, { fallback?: string; desc?: string }>;
   a11y?: { role?: string; keyboard?: Record<string, string> };
+  // Size of `packages/css/dist/components/<name>.css` injected by gen-docs.ts
+  // after build:css. Absent when dist hasn't been built yet.
+  bundleSizes?: { raw: number; gzip: number; brotli: number };
 };
+
+function formatKb(bytes: number): string {
+  return `${(bytes / 1024).toFixed(2)} KB`;
+}
+
+const REPO_BLOB_URL = "https://github.com/teseor/teseor/blob/main";
+
+export function renderBundleSize(spec: DocsSpec): string {
+  if (!spec.bundleSizes) return "";
+  const { raw, gzip, brotli } = spec.bundleSizes;
+  const source = `${REPO_BLOB_URL}/packages/css/src/components/${esc(spec.name)}/${esc(spec.name)}.css`;
+  const rows = [
+    [
+      `<a href="${source}"><code>@teseor/css/components/${esc(spec.name)}.css</code></a>`,
+      formatKb(raw),
+      formatKb(gzip),
+      formatKb(brotli),
+    ],
+  ];
+  return section("Bundle size", renderTable(["Artifact", "Raw", "Gzip", "Brotli"], rows));
+}
 
 // Universal overlay dismissal contract, wired in `useOverlay` via
 // `useDismissableLayer` for every spec with an `overlay:` block (PR #698).

--- a/scripts/codegen/src/generators/gen-docs/_shared/sections.ts
+++ b/scripts/codegen/src/generators/gen-docs/_shared/sections.ts
@@ -22,7 +22,9 @@ const REPO_BLOB_URL = "https://github.com/teseor/teseor/blob/main";
 export function renderBundleSize(spec: DocsSpec): string {
   if (!spec.bundleSizes) return "";
   const { raw, gzip, brotli } = spec.bundleSizes;
-  const source = `${REPO_BLOB_URL}/packages/css/src/components/${esc(spec.name)}/${esc(spec.name)}.css`;
+  // URL path segments need `encodeURIComponent`, not the HTML-escape `esc`.
+  const urlName = encodeURIComponent(spec.name);
+  const source = `${REPO_BLOB_URL}/packages/css/src/components/${urlName}/${urlName}.css`;
   const rows = [
     [
       `<a href="${source}"><code>@teseor/css/components/${esc(spec.name)}.css</code></a>`,

--- a/scripts/codegen/src/generators/gen-docs/kinds/atomic.ts
+++ b/scripts/codegen/src/generators/gen-docs/kinds/atomic.ts
@@ -4,6 +4,7 @@ import { renderExamples } from "../_shared/examples.ts";
 import type { DocsSpec } from "../_shared/sections.ts";
 import {
   renderA11y,
+  renderBundleSize,
   renderConstraints,
   renderNamed,
   renderProps,
@@ -25,6 +26,7 @@ export function renderAtomicDocsPage(spec: DocsSpec): string {
     renderTokens(spec),
     renderA11y(spec),
     renderConstraints(spec),
+    renderBundleSize(spec),
   ].filter((part) => part.length > 0);
 
   const imports = [

--- a/scripts/codegen/src/generators/gen-docs/kinds/composite-overlay.ts
+++ b/scripts/codegen/src/generators/gen-docs/kinds/composite-overlay.ts
@@ -4,6 +4,7 @@ import { renderExamples } from "../_shared/examples.ts";
 import type { DocsSpec } from "../_shared/sections.ts";
 import {
   renderA11y,
+  renderBundleSize,
   renderConstraints,
   renderNamed,
   renderProps,
@@ -33,6 +34,7 @@ export function renderCompositeOverlayDocsPage(spec: DocsSpec): string {
     renderTokens(spec),
     renderA11y(spec),
     renderConstraints(spec),
+    renderBundleSize(spec),
   ].filter((part) => part.length > 0);
 
   const imports = [

--- a/scripts/codegen/src/generators/gen-size-limit.ts
+++ b/scripts/codegen/src/generators/gen-size-limit.ts
@@ -41,12 +41,23 @@ async function listSpecNames(): Promise<string[]> {
     .sort();
 }
 
+// Per-component brotli budgets carried over from the previous hand-maintained
+// `size-limit` block. Unlisted specs ship without an explicit budget; the
+// PR-comment size table still reports their measurement.
+const COMPONENT_LIMITS: Record<string, string> = {
+  button: "4 kB",
+};
+
 async function sizeLimitGenerator(_ctx: GeneratorContext): Promise<GeneratorReport> {
   const componentNames = await listSpecNames();
-  const componentEntries = componentNames.map((name) => ({
-    name: `@teseor/css/components/${name}.css`,
-    path: `packages/css/dist/components/${name}.css`,
-  }));
+  const componentEntries = componentNames.map((name) => {
+    const entry: Record<string, string> = {
+      name: `@teseor/css/components/${name}.css`,
+      path: `packages/css/dist/components/${name}.css`,
+    };
+    if (COMPONENT_LIMITS[name]) entry.limit = COMPONENT_LIMITS[name];
+    return entry;
+  });
   const config = [...BUNDLE_ENTRIES, ...componentEntries];
   await writeFile(OUTPUT_PATH, `${JSON.stringify(config, null, 2)}\n`, "utf8");
   return {

--- a/scripts/codegen/src/generators/gen-size-limit.ts
+++ b/scripts/codegen/src/generators/gen-size-limit.ts
@@ -1,0 +1,58 @@
+import { readdir, writeFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import type { GeneratorContext, GeneratorReport } from "../registry.ts";
+import { registerGenerator } from "../registry.ts";
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..", "..", "..");
+const SPECS_DIR = resolve(REPO_ROOT, "specs");
+const OUTPUT_PATH = resolve(REPO_ROOT, ".size-limit.json");
+
+// Bundle-level entries are not per-component and live outside the spec list.
+// Their `path` references the dist output of `@teseor/css`.
+const BUNDLE_ENTRIES: Array<Record<string, string>> = [
+  {
+    name: "@teseor/css (full bundle)",
+    path: "packages/css/dist/teseor.css",
+    limit: "8 kB",
+  },
+  {
+    name: "@teseor/css/tokens.css",
+    path: "packages/css/dist/tokens.css",
+    limit: "4 kB",
+  },
+  {
+    name: "@teseor/css/utilities.css",
+    path: "packages/css/dist/utilities.css",
+    limit: "2 kB",
+  },
+  {
+    name: "@teseor/css/tailwind.css",
+    path: "packages/css/dist/tailwind.css",
+    limit: "6 kB",
+  },
+];
+
+async function listSpecNames(): Promise<string[]> {
+  const entries = await readdir(SPECS_DIR);
+  return entries
+    .filter((f) => f.endsWith(".yaml") && !f.startsWith("_"))
+    .map((f) => f.slice(0, -5))
+    .sort();
+}
+
+async function sizeLimitGenerator(_ctx: GeneratorContext): Promise<GeneratorReport> {
+  const componentNames = await listSpecNames();
+  const componentEntries = componentNames.map((name) => ({
+    name: `@teseor/css/components/${name}.css`,
+    path: `packages/css/dist/components/${name}.css`,
+  }));
+  const config = [...BUNDLE_ENTRIES, ...componentEntries];
+  await writeFile(OUTPUT_PATH, `${JSON.stringify(config, null, 2)}\n`, "utf8");
+  return {
+    filesWritten: [OUTPUT_PATH],
+    notes: [`size-limit: ${componentEntries.length} component entries emitted`],
+  };
+}
+
+registerGenerator("size-limit", sizeLimitGenerator);

--- a/scripts/codegen/src/generators/index.ts
+++ b/scripts/codegen/src/generators/index.ts
@@ -1,5 +1,6 @@
 import "./gen-contract.ts";
 import "./gen-docs.ts";
 import "./gen-react.ts";
+import "./gen-size-limit.ts";
 import "./gen-tests.ts";
 import "./gen-vue.ts";

--- a/scripts/repo/measure-bp-cost.ts
+++ b/scripts/repo/measure-bp-cost.ts
@@ -6,18 +6,23 @@ import { brotliCompressSync } from "node:zlib";
 const REPO_ROOT = resolve(import.meta.dirname, "../..");
 const COMPONENTS_DIR = resolve(REPO_ROOT, "packages/css/dist/components");
 
-// Strip `@media (--<bp>) { ... }` blocks (balanced-brace match) so the
-// brotli delta between "with breakpoints" and "without" is the share of
-// compressed bytes attributable to per-breakpoint emission.
+// Per-component dist preserves `@media (--<bp>)` (postcss-custom-media has
+// no alias source when building each component file); the full-bundle dist
+// expands them to `@media (min-width: <n>rem)`. Catch both so the measurement
+// stays correct if a build-pipeline change ever inlines tokens.css per component.
+const BREAKPOINT_MEDIA_RE =
+  /@media\s*\(\s*(?:--[a-z0-9-]+|min-width:\s*\d+(?:\.\d+)?(?:rem|px|em))\s*\)/;
+
 function stripBreakpointBlocks(text: string): string {
   const parts: string[] = [];
   let i = 0;
   while (i < text.length) {
-    const next = text.indexOf("@media (--", i);
-    if (next < 0) {
+    const match = BREAKPOINT_MEDIA_RE.exec(text.slice(i));
+    if (!match) {
       parts.push(text.slice(i));
       break;
     }
+    const next = i + (match.index ?? 0);
     parts.push(text.slice(i, next));
     const openBrace = text.indexOf("{", next);
     if (openBrace < 0) {

--- a/scripts/repo/measure-bp-cost.ts
+++ b/scripts/repo/measure-bp-cost.ts
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+import { readdirSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { brotliCompressSync } from "node:zlib";
+
+const REPO_ROOT = resolve(import.meta.dirname, "../..");
+const COMPONENTS_DIR = resolve(REPO_ROOT, "packages/css/dist/components");
+
+// Strip `@media (--<bp>) { ... }` blocks (balanced-brace match) so the
+// brotli delta between "with breakpoints" and "without" is the share of
+// compressed bytes attributable to per-breakpoint emission.
+function stripBreakpointBlocks(text: string): string {
+  const parts: string[] = [];
+  let i = 0;
+  while (i < text.length) {
+    const next = text.indexOf("@media (--", i);
+    if (next < 0) {
+      parts.push(text.slice(i));
+      break;
+    }
+    parts.push(text.slice(i, next));
+    const openBrace = text.indexOf("{", next);
+    if (openBrace < 0) {
+      parts.push(text.slice(next));
+      break;
+    }
+    let depth = 1;
+    let j = openBrace + 1;
+    while (j < text.length && depth > 0) {
+      const ch = text[j];
+      if (ch === "{") depth++;
+      else if (ch === "}") depth--;
+      j++;
+    }
+    i = j;
+  }
+  return parts.join("");
+}
+
+function brotliSize(text: string): number {
+  return brotliCompressSync(Buffer.from(text, "utf8")).byteLength;
+}
+
+type Row = { name: string; brotli: number; bpShare: number; bpPct: number };
+
+function main(): void {
+  const files = readdirSync(COMPONENTS_DIR)
+    .filter((f) => f.endsWith(".css"))
+    .sort();
+  const rows: Row[] = [];
+  for (const file of files) {
+    const path = resolve(COMPONENTS_DIR, file);
+    const text = readFileSync(path, "utf8");
+    const stripped = stripBreakpointBlocks(text);
+    const full = brotliSize(text);
+    const minus = brotliSize(stripped);
+    const delta = full - minus;
+    rows.push({
+      name: `@teseor/css/components/${file}`,
+      brotli: full,
+      bpShare: delta,
+      bpPct: full === 0 ? 0 : Math.round((delta / full) * 1000) / 10,
+    });
+  }
+  console.log(JSON.stringify(rows));
+}
+
+main();


### PR DESCRIPTION
## What

Four changes, all centred on making per-component CSS cost visible and self-maintaining.

1. **ADR-0016** — records the decision for #611: status quo on per-breakpoint emission, with a soft 50% per-component brotli budget. Brotli measurement on the five components today: 17% bundle-wide, concentrated in layout primitives (Stack 37%, Cluster 39%); interactive components pay near-zero (Modal 0%, Button 9%, Tooltip 12%).
2. **`.size-limit.json` is generated from the spec list.** The static `size-limit` array in `package.json` is gone; `pnpm gen` writes the canonical config (4 fixed bundle entries + one row per spec). Adding a component now requires one spec; the size table picks it up automatically.
3. **PR-comment shows per-component breakpoint share.** `scripts/repo/measure-bp-cost.ts` runs in CI; the sticky size-report comment grows a "Per-component breakpoint share" table with a ⚠ marker when a single component crosses the 50% threshold. Soft signal, not a gate.
4. **Docs pages show per-component bundle size.** Each component's docs page gets a `Bundle size` section (last on the page) with Raw / Gzip / Brotli columns and a link to the source CSS file in the repo. `pnpm gen` reorders to run `build:css` first so docs see the real dist.

## Why

The original issue framed per-breakpoint emission as a structural cost; the measurement shows it's concentrated, not uniform, and the compressor already handles most of it. The ADR documents that finding plus the soft budget. The size-config generation + PR-comment + docs surface make the budget reflexive: a future layout primitive that crosses 50% shows up in the PR-comment table on its own push, and the bot-comment size report stops drifting as new components land.

## Test plan

- [x] `pnpm typecheck`, `pnpm lint`, `pnpm test` all pass locally. 835 tests passing.
- [x] `pnpm gen` regenerates `.size-limit.json` (9 entries) + bundle-size sections on five `.astro` docs pages.
- [x] `pnpm size` reads `.size-limit.json` and reports all 5 components plus 4 bundle entries.
- [x] `node scripts/repo/audit-overrides.ts`-style verification: `node scripts/repo/measure-bp-cost.ts` outputs JSON matching the ADR's measurement table within 1 byte (Node `zlib.brotliCompressSync` vs system `brotli`).
- [x] Tooltip docs page bundle-size section renders correctly (11.55 KB raw / 1.97 KB gzip / 1.61 KB brotli with a GitHub source link).
- [ ] First CI run of size-report on this PR shows the breakpoint-share table with no ⚠ markers (Cluster 39% + Stack 37% are under the 50% threshold).

## Out of scope

- Wrapper bundle measurement (`@teseor/react`, `@teseor/vue`) — wrappers ship source-only today; per-component micro-bundle setup lands when wrappers go public at v3 with a build step.
- Linking the docs `Artifact` column to a dist URL on CDN (e.g. unpkg) — pre-publish, the source CSS link on GitHub is what's actually available; revisit at v3 launch.
- Industry comparison data (how does our Tooltip CSS compare to Tippy / Radix / Floating UI) — separate research work; can file a follow-up if useful.

Closes #611.