### PR TITLE
feat(css): synthesize forced-colors floor in postcss-teseor-floor

### DIFF
--- a/.changeset/609-forced-colors-floor.md
+++ b/.changeset/609-forced-colors-floor.md
@@ -1,0 +1,5 @@
+---
+"@teseor/css": minor
+---
+
+`postcss-teseor-floor` now walks the `@media (forced-colors: active)` branch of `tokens.css` and synthesizes a nested forced-colors block on every component declaration whose chain resolves to a different system-color literal. A per-component CSS shipped without `tokens.css` now keeps its high-contrast mapping (e.g. `--t-accent → ButtonText`, `--t-focus-ring → Highlight`) in Windows High Contrast instead of falling back to the default-mode `oklch(...)` literal.

--- a/.changeset/609-forced-colors-floor.md
+++ b/.changeset/609-forced-colors-floor.md
@@ -2,4 +2,4 @@
 "@teseor/css": minor
 ---
 
-`postcss-teseor-floor` now walks the `@media (forced-colors: active)` branch of `tokens.css` and synthesizes a nested forced-colors block on every component declaration whose chain resolves to a different system-color literal. A per-component CSS shipped without `tokens.css` now keeps its high-contrast mapping (e.g. `--t-accent → ButtonText`, `--t-focus-ring → Highlight`) in Windows High Contrast instead of falling back to the default-mode `oklch(...)` literal.
+`postcss-teseor-floor` now walks the `@media (forced-colors: active)` branch of `tokens.css` and emits a single nested forced-colors block at each component root that re-declares every semantic token the file references whose forced-colors literal differs from the default branch. Custom-property inheritance carries the system-color values (`--t-accent → ButtonText`, `--t-focus-ring → Highlight`, `--t-surface → Canvas`, …) to every reference in the subtree, so a per-component CSS shipped without `tokens.css` keeps its high-contrast mapping in Windows High Contrast instead of falling back to the default-mode `oklch(...)` literal.

--- a/apps/docs/src/pages/components/button.astro
+++ b/apps/docs/src/pages/components/button.astro
@@ -161,7 +161,7 @@ import Base from "../../layouts/Base.astro";
       <table>
         <thead><tr><th>Artifact</th><th>Raw</th><th>Gzip</th><th>Brotli</th></tr></thead>
         <tbody>
-        <tr><td><a href="https://github.com/teseor/teseor/blob/main/packages/css/src/components/button/button.css"><Code>@teseor/css/components/button.css</Code></a></td><td>8.29 KB</td><td>1.58 KB</td><td>1.32 KB</td></tr>
+        <tr><td><a href="https://github.com/teseor/teseor/blob/main/packages/css/src/components/button/button.css"><Code>@teseor/css/components/button.css</Code></a></td><td>9.28 KB</td><td>1.70 KB</td><td>1.42 KB</td></tr>
         </tbody>
       </table>
     </section>

--- a/apps/docs/src/pages/components/button.astro
+++ b/apps/docs/src/pages/components/button.astro
@@ -161,7 +161,7 @@ import Base from "../../layouts/Base.astro";
       <table>
         <thead><tr><th>Artifact</th><th>Raw</th><th>Gzip</th><th>Brotli</th></tr></thead>
         <tbody>
-        <tr><td><a href="https://github.com/teseor/teseor/blob/main/packages/css/src/components/button/button.css"><Code>@teseor/css/components/button.css</Code></a></td><td>9.28 KB</td><td>1.70 KB</td><td>1.42 KB</td></tr>
+        <tr><td><a href="https://github.com/teseor/teseor/blob/main/packages/css/src/components/button/button.css"><Code>@teseor/css/components/button.css</Code></a></td><td>8.68 KB</td><td>1.68 KB</td><td>1.39 KB</td></tr>
         </tbody>
       </table>
     </section>

--- a/apps/docs/src/pages/components/code.astro
+++ b/apps/docs/src/pages/components/code.astro
@@ -35,7 +35,7 @@ import Base from "../../layouts/Base.astro";
       <table>
         <thead><tr><th>Artifact</th><th>Raw</th><th>Gzip</th><th>Brotli</th></tr></thead>
         <tbody>
-        <tr><td><a href="https://github.com/teseor/teseor/blob/main/packages/css/src/components/code/code.css"><Code>@teseor/css/components/code.css</Code></a></td><td>0.93 KB</td><td>0.43 KB</td><td>0.37 KB</td></tr>
+        <tr><td><a href="https://github.com/teseor/teseor/blob/main/packages/css/src/components/code/code.css"><Code>@teseor/css/components/code.css</Code></a></td><td>0.90 KB</td><td>0.43 KB</td><td>0.37 KB</td></tr>
         </tbody>
       </table>
     </section>

--- a/apps/docs/src/pages/components/code.astro
+++ b/apps/docs/src/pages/components/code.astro
@@ -35,7 +35,7 @@ import Base from "../../layouts/Base.astro";
       <table>
         <thead><tr><th>Artifact</th><th>Raw</th><th>Gzip</th><th>Brotli</th></tr></thead>
         <tbody>
-        <tr><td><a href="https://github.com/teseor/teseor/blob/main/packages/css/src/components/code/code.css"><Code>@teseor/css/components/code.css</Code></a></td><td>0.83 KB</td><td>0.40 KB</td><td>0.35 KB</td></tr>
+        <tr><td><a href="https://github.com/teseor/teseor/blob/main/packages/css/src/components/code/code.css"><Code>@teseor/css/components/code.css</Code></a></td><td>0.93 KB</td><td>0.43 KB</td><td>0.37 KB</td></tr>
         </tbody>
       </table>
     </section>

--- a/apps/docs/src/pages/components/codeblock.astro
+++ b/apps/docs/src/pages/components/codeblock.astro
@@ -35,7 +35,7 @@ import Base from "../../layouts/Base.astro";
       <table>
         <thead><tr><th>Artifact</th><th>Raw</th><th>Gzip</th><th>Brotli</th></tr></thead>
         <tbody>
-        <tr><td><a href="https://github.com/teseor/teseor/blob/main/packages/css/src/components/codeblock/codeblock.css"><Code>@teseor/css/components/codeblock.css</Code></a></td><td>1.00 KB</td><td>0.46 KB</td><td>0.38 KB</td></tr>
+        <tr><td><a href="https://github.com/teseor/teseor/blob/main/packages/css/src/components/codeblock/codeblock.css"><Code>@teseor/css/components/codeblock.css</Code></a></td><td>1.11 KB</td><td>0.50 KB</td><td>0.41 KB</td></tr>
         </tbody>
       </table>
     </section>

--- a/apps/docs/src/pages/components/codeblock.astro
+++ b/apps/docs/src/pages/components/codeblock.astro
@@ -35,7 +35,7 @@ import Base from "../../layouts/Base.astro";
       <table>
         <thead><tr><th>Artifact</th><th>Raw</th><th>Gzip</th><th>Brotli</th></tr></thead>
         <tbody>
-        <tr><td><a href="https://github.com/teseor/teseor/blob/main/packages/css/src/components/codeblock/codeblock.css"><Code>@teseor/css/components/codeblock.css</Code></a></td><td>1.11 KB</td><td>0.50 KB</td><td>0.41 KB</td></tr>
+        <tr><td><a href="https://github.com/teseor/teseor/blob/main/packages/css/src/components/codeblock/codeblock.css"><Code>@teseor/css/components/codeblock.css</Code></a></td><td>1.08 KB</td><td>0.50 KB</td><td>0.41 KB</td></tr>
         </tbody>
       </table>
     </section>

--- a/docs/ADR/0003-postcss-build-step.md
+++ b/docs/ADR/0003-postcss-build-step.md
@@ -48,22 +48,30 @@ The plugin reads `tokens.css`, walks each `--t-*` chain to its terminal literal,
 
 `tokens.css` declares semantic color aliases twice: once at `:root` (default mode) and once inside `@media (forced-colors: active)` mapping to CSS system colors. See `architecture/three-tier-tokens.md` § "Colors" for the exact block.
 
-The plugin walks `var()`-chains **twice** — once against the default tokens, once against the forced-colors branch. For each component declaration that references a semantic alias which has a different value in the forced-colors branch, the plugin emits:
+The plugin builds two token maps from `tokens.css` — the default `:root` map and the forced-colors-overlaid map. It then collects every `--t-*` name a component file references and, for each one that resolves to a different literal in the two maps, emits a single nested `@media (forced-colors: active)` block at the component root that re-declares the *upstream semantic token*:
 
 ```css
 /* AUTHORED */
-.t-button { background: var(--_bg); }
+.t-button {
+  --_fill: var(--t-button-bg, var(--t-accent));
+  /* …other declarations using --t-accent, --t-focus-ring, --t-surface… */
+}
 
 /* SHIPPED */
-.t-button { background: var(--_bg); }
-@media (forced-colors: active) {
-  .t-button {
-    --_bg: var(--t-button-bg, var(--t-accent, ButtonText));
+.t-button {
+  --_fill: var(--t-button-bg, var(--t-accent, oklch(65% 0.18 250deg)));
+  @media (forced-colors: active) {
+    --t-accent: ButtonText;
+    --t-focus-ring: Highlight;
+    --t-surface: Canvas;
+    /* …only the semantic tokens this component actually references */
   }
 }
 ```
 
-The default-mode declaration keeps its oklch literal floor; the forced-colors block re-declares the component-private with the system-color literal floor. Components never hand-write `@media (forced-colors: active)` blocks for color overrides — the plugin synthesizes them from the token contract. Components may still hand-write forced-colors blocks for *non-color* concerns (e.g. `outline-width`, `forced-color-adjust: none`) where the rule isn't expressible through token literals.
+Custom-property inheritance propagates those system-color values to every `var()` reference inside the component subtree. The default-mode declarations keep their oklch literal floor; the third-position fallback never fires in forced-colors because `--t-accent` is now defined on the component root. One block per component covers every nested rule, every variant, every state — no per-declaration mirroring.
+
+Components never hand-write `@media (forced-colors: active)` blocks for color overrides — the plugin synthesizes them from the token contract. Components may still hand-write forced-colors blocks for *non-color* concerns (e.g. `outline-width`, `forced-color-adjust: none`) where the rule isn't expressible through token literals.
 
 ## Why not SCSS
 

--- a/packages/css/__tests__/build-output.test.ts
+++ b/packages/css/__tests__/build-output.test.ts
@@ -57,6 +57,13 @@ test("shipped component CSS inlines the literal resolved from tokens.css", () =>
   expect(button).toContain("var(--t-accent, oklch(65% 0.18 250deg))");
 });
 
+test("shipped component CSS carries a forced-colors floor for color tokens", () => {
+  const button = readFileSync(join(distDir, "components", "button.css"), "utf8");
+  expect(button).toMatch(/@media \(forced-colors: active\)/);
+  expect(button).toContain("var(--t-accent, ButtonText)");
+  expect(button).toContain("var(--t-focus-ring, Highlight)");
+});
+
 test("motion.css ships keyframes and a reduced-motion block", () => {
   const motion = readFileSync(join(distDir, "motion.css"), "utf8");
   expect(motion).toContain("@keyframes spin");

--- a/packages/css/__tests__/build-output.test.ts
+++ b/packages/css/__tests__/build-output.test.ts
@@ -57,11 +57,12 @@ test("shipped component CSS inlines the literal resolved from tokens.css", () =>
   expect(button).toContain("var(--t-accent, oklch(65% 0.18 250deg))");
 });
 
-test("shipped component CSS carries a forced-colors floor for color tokens", () => {
+test("shipped component CSS carries a forced-colors token override", () => {
   const button = readFileSync(join(distDir, "components", "button.css"), "utf8");
   expect(button).toMatch(/@media \(forced-colors: active\)/);
-  expect(button).toContain("var(--t-accent, ButtonText)");
-  expect(button).toContain("var(--t-focus-ring, Highlight)");
+  expect(button).toContain("--t-accent: ButtonText");
+  expect(button).toContain("--t-focus-ring: Highlight");
+  expect(button).toContain("--t-surface: Canvas");
 });
 
 test("motion.css ships keyframes and a reduced-motion block", () => {

--- a/packages/css/build.mjs
+++ b/packages/css/build.mjs
@@ -6,7 +6,7 @@ import postcss from "postcss";
 import postcssCustomMedia from "postcss-custom-media";
 import postcssEach from "postcss-each";
 import postcssImport from "postcss-import";
-import { buildTokenMap, teseorFloor } from "./postcss-teseor-floor.ts";
+import { buildForcedColorsTokenMap, buildTokenMap, teseorFloor } from "./postcss-teseor-floor.ts";
 
 const ROOT = dirname(fileURLToPath(import.meta.url));
 const SRC = resolve(ROOT, "src");
@@ -35,17 +35,16 @@ const TOP_LEVEL_ENTRIES = [
 
 // Pass 1 expands @import/@each/@custom-media. Pass 2 (postcss-teseor-floor)
 // then sees concrete var() chains and appends each token's literal floor.
-async function buildOne(inputPath, outputPath, tokens) {
+async function buildOne(inputPath, outputPath, tokens, forcedColorsTokens) {
   const css = await readFile(inputPath, "utf8");
   const expanded = await postcss([postcssImport(), postcssEach(), postcssCustomMedia()]).process(
     css,
     { from: inputPath, to: outputPath, map: false },
   );
-  const floored = await postcss([teseorFloor({ tokens })]).process(expanded.css, {
-    from: inputPath,
-    to: outputPath,
-    map: false,
-  });
+  const floored = await postcss([teseorFloor({ tokens, forcedColorsTokens })]).process(
+    expanded.css,
+    { from: inputPath, to: outputPath, map: false },
+  );
   for (const warn of [...expanded.warnings(), ...floored.warnings()]) {
     process.stderr.write(`build-css ${inputPath}: ${warn.toString()}\n`);
   }
@@ -64,11 +63,13 @@ async function listComponents() {
 
 async function main() {
   await mkdir(DIST, { recursive: true });
-  const tokens = buildTokenMap(await readFile(resolve(SRC, "tokens.css"), "utf8"));
+  const tokensCss = await readFile(resolve(SRC, "tokens.css"), "utf8");
+  const tokens = buildTokenMap(tokensCss);
+  const forcedColorsTokens = buildForcedColorsTokenMap(tokensCss);
   for (const entry of TOP_LEVEL_ENTRIES) {
     const inputPath = resolve(SRC, entry.from);
     const outputPath = resolve(DIST, entry.to);
-    await buildOne(inputPath, outputPath, tokens);
+    await buildOne(inputPath, outputPath, tokens, forcedColorsTokens);
     process.stdout.write(`build-css: ${entry.from} -> dist/${entry.to}\n`);
   }
 
@@ -78,7 +79,7 @@ async function main() {
     for (const name of components) {
       const inputPath = resolve(COMPONENTS_SRC, name, `${name}.css`);
       const outputPath = resolve(COMPONENTS_DIST, `${name}.css`);
-      await buildOne(inputPath, outputPath, tokens);
+      await buildOne(inputPath, outputPath, tokens, forcedColorsTokens);
       process.stdout.write(
         `build-css: components/${name}/${name}.css -> dist/components/${name}.css\n`,
       );

--- a/packages/css/postcss-teseor-floor.test.ts
+++ b/packages/css/postcss-teseor-floor.test.ts
@@ -4,11 +4,15 @@ import { buildForcedColorsTokenMap, buildTokenMap, teseorFloor } from "./postcss
 
 const tokens = new Map([
   ["--t-accent", "oklch(65% 0.18 250deg)"],
+  ["--t-focus-ring", "oklch(65% 0.18 250deg)"],
+  ["--t-surface", "oklch(97% 0 0deg)"],
   ["--t-space-2", "0.5rem"],
 ]);
 
 const forcedColorsTokens = new Map([
   ["--t-accent", "ButtonText"],
+  ["--t-focus-ring", "Highlight"],
+  ["--t-surface", "Canvas"],
   ["--t-space-2", "0.5rem"],
 ]);
 
@@ -133,65 +137,73 @@ describe("teseorFloor", () => {
 });
 
 describe("teseorFloor — forced-colors synthesis", () => {
-  test("emits a nested forced-colors block when the chain resolves differently", () => {
-    const out = floorWithFC(".t-x { color: var(--t-accent); }");
-    expect(out).toContain("color: var(--t-accent, oklch(65% 0.18 250deg))");
-    expect(out).toMatch(
-      /@media \(forced-colors: active\)\s*{\s*color: var\(--t-accent, ButtonText\)/,
-    );
-  });
-
-  test("synthesizes for the inner token of a two-level chain", () => {
-    const out = floorWithFC(".t-x { color: var(--t-button-fg, var(--t-accent)); }");
-    expect(out).toContain("color: var(--t-button-fg, var(--t-accent, oklch(65% 0.18 250deg)))");
-    expect(out).toContain("var(--t-button-fg, var(--t-accent, ButtonText))");
-  });
-
-  test("emits no forced-colors block when the chain resolves identically", () => {
-    const out = floorWithFC(".t-x { gap: var(--t-space-2); }");
-    expect(out).toContain("var(--t-space-2, 0.5rem)");
-    expect(out).not.toContain("forced-colors");
-  });
-
-  test("emits no forced-colors block for declarations without any --t-* reference", () => {
-    const out = floorWithFC(".t-x { color: red; }");
-    expect(out).not.toContain("forced-colors");
-  });
-
-  test("does not nest a forced-colors block inside a hand-written forced-colors block", () => {
+  test("emits one nested forced-colors block at the component root", () => {
     const out = floorWithFC(`
-      @media (forced-colors: active) {
-        .t-x { color: var(--t-accent); }
+      .t-button {
+        --_fill: var(--t-accent);
+        &:where([data-intent="primary"]) { --_fill: var(--t-accent); }
+        &:focus-visible { outline: 2px solid var(--t-focus-ring); }
       }
     `);
-    expect(out).toContain("var(--t-accent, ButtonText)");
-    // exactly one @media occurrence: the hand-written one, no nested copy
     expect(out.match(/@media \(forced-colors: active\)/g)?.length).toBe(1);
+    expect(out).toMatch(/\.t-button[\s\S]*@media \(forced-colors: active\)/);
   });
 
-  test("uses the forced-colors map for flooring inside a hand-written forced-colors block", () => {
-    const out = floorWithFC(`
-      @media (forced-colors: active) {
-        .t-x { color: var(--t-accent); }
-      }
-    `);
-    expect(out).toContain("var(--t-accent, ButtonText)");
-    expect(out).not.toContain("oklch(65% 0.18 250deg)");
+  test("re-declares the upstream semantic token, not the component-private", () => {
+    const out = floorWithFC(".t-x { --_fill: var(--t-accent); }");
+    expect(out).toContain("--t-accent: ButtonText");
+    expect(out).not.toContain("--_fill: var(--t-accent, ButtonText)");
   });
 
-  test("appends overrides at the same nesting level as the original declaration", () => {
+  test("includes every differing token the file references", () => {
     const out = floorWithFC(`
       .t-x {
         color: var(--t-accent);
-        &:hover { background: var(--t-accent); }
+        background: var(--t-surface);
+        outline: 2px solid var(--t-focus-ring);
       }
     `);
-    // both the root rule and the &:hover nested rule get their own forced-colors block
-    expect(out.match(/@media \(forced-colors: active\)/g)?.length).toBe(2);
+    expect(out).toContain("--t-accent: ButtonText");
+    expect(out).toContain("--t-surface: Canvas");
+    expect(out).toContain("--t-focus-ring: Highlight");
   });
 
-  test("is a no-op when no forced-colors token map is provided", () => {
+  test("omits tokens whose forced-colors literal matches the default", () => {
+    const out = floorWithFC(".t-x { gap: var(--t-space-2); }");
+    expect(out).not.toContain("forced-colors");
+  });
+
+  test("emits no block when the file references no differing token", () => {
+    const out = floorWithFC(".t-x { gap: var(--t-space-2); padding: var(--t-space-2); }");
+    expect(out).not.toContain("forced-colors");
+  });
+
+  test("emits no block when no forced-colors token map is given", () => {
     const out = floor(".t-x { color: var(--t-accent); }");
     expect(out).not.toContain("forced-colors");
+  });
+
+  test("does not duplicate overrides when a token is referenced from many decls", () => {
+    const out = floorWithFC(`
+      .t-x {
+        --_a: var(--t-accent);
+        --_b: var(--t-accent);
+        &:hover { --_a: var(--t-accent); }
+      }
+    `);
+    expect(out.match(/--t-accent: ButtonText/g)?.length).toBe(1);
+  });
+
+  test("targets the first rule in the file, even when wrapped in @layer", () => {
+    const out = floorWithFC(`
+      @layer components.tokens {
+        .t-button { --_fill: var(--t-accent); }
+      }
+      @layer components.styles {
+        .t-button { color: var(--_fill); }
+      }
+    `);
+    const tokensLayer = out.split("@layer components.styles")[0];
+    expect(tokensLayer).toMatch(/@media \(forced-colors: active\)/);
   });
 });

--- a/packages/css/postcss-teseor-floor.test.ts
+++ b/packages/css/postcss-teseor-floor.test.ts
@@ -1,14 +1,25 @@
 import postcss from "postcss";
 import { describe, expect, test } from "vitest";
-import { buildTokenMap, teseorFloor } from "./postcss-teseor-floor.ts";
+import { buildForcedColorsTokenMap, buildTokenMap, teseorFloor } from "./postcss-teseor-floor.ts";
 
 const tokens = new Map([
   ["--t-accent", "oklch(65% 0.18 250deg)"],
   ["--t-space-2", "0.5rem"],
 ]);
 
+const forcedColorsTokens = new Map([
+  ["--t-accent", "ButtonText"],
+  ["--t-space-2", "0.5rem"],
+]);
+
 function floor(css: string): string {
   return postcss([teseorFloor({ tokens })]).process(css, { from: undefined }).css;
+}
+
+function floorWithFC(css: string): string {
+  return postcss([teseorFloor({ tokens, forcedColorsTokens })]).process(css, {
+    from: undefined,
+  }).css;
 }
 
 describe("buildTokenMap", () => {
@@ -48,6 +59,51 @@ describe("buildTokenMap", () => {
   });
 });
 
+describe("buildForcedColorsTokenMap", () => {
+  const tokensCss = `
+    @layer tokens.scale {
+      :root {
+        --t-accent-500: oklch(65% 0.18 250deg);
+        --t-space-2: 0.5rem;
+      }
+    }
+    @layer tokens.semantic {
+      :root {
+        --t-accent: var(--t-accent-500);
+        --t-focus-ring: var(--t-accent-500);
+      }
+      @media (forced-colors: active) {
+        :root {
+          --t-accent: ButtonText;
+          --t-focus-ring: Highlight;
+        }
+      }
+    }
+  `;
+
+  test("applies the forced-colors override", () => {
+    expect(buildForcedColorsTokenMap(tokensCss).get("--t-accent")).toBe("ButtonText");
+  });
+
+  test("applies the override for every token in the branch", () => {
+    expect(buildForcedColorsTokenMap(tokensCss).get("--t-focus-ring")).toBe("Highlight");
+  });
+
+  test("leaves a token without a forced-colors entry unchanged", () => {
+    expect(buildForcedColorsTokenMap(tokensCss).get("--t-space-2")).toBe("0.5rem");
+  });
+
+  test("ignores compound forced-colors queries", () => {
+    const compound = `
+      :root { --t-accent: oklch(65% 0.18 250deg); }
+      @media (forced-colors: active) and (prefers-color-scheme: dark) {
+        :root { --t-accent: ButtonText; }
+      }
+    `;
+    expect(buildForcedColorsTokenMap(compound).get("--t-accent")).toBe("oklch(65% 0.18 250deg)");
+  });
+});
+
 describe("teseorFloor", () => {
   test("appends a literal floor to a fallback-less token reference", () => {
     expect(floor(".t-x { gap: var(--t-space-2); }")).toContain("var(--t-space-2, 0.5rem)");
@@ -73,5 +129,69 @@ describe("teseorFloor", () => {
 
   test("throws when a token is not declared in tokens.css", () => {
     expect(() => floor(".t-x { color: var(--t-missing); }")).toThrow(/not declared in tokens\.css/);
+  });
+});
+
+describe("teseorFloor — forced-colors synthesis", () => {
+  test("emits a nested forced-colors block when the chain resolves differently", () => {
+    const out = floorWithFC(".t-x { color: var(--t-accent); }");
+    expect(out).toContain("color: var(--t-accent, oklch(65% 0.18 250deg))");
+    expect(out).toMatch(
+      /@media \(forced-colors: active\)\s*{\s*color: var\(--t-accent, ButtonText\)/,
+    );
+  });
+
+  test("synthesizes for the inner token of a two-level chain", () => {
+    const out = floorWithFC(".t-x { color: var(--t-button-fg, var(--t-accent)); }");
+    expect(out).toContain("color: var(--t-button-fg, var(--t-accent, oklch(65% 0.18 250deg)))");
+    expect(out).toContain("var(--t-button-fg, var(--t-accent, ButtonText))");
+  });
+
+  test("emits no forced-colors block when the chain resolves identically", () => {
+    const out = floorWithFC(".t-x { gap: var(--t-space-2); }");
+    expect(out).toContain("var(--t-space-2, 0.5rem)");
+    expect(out).not.toContain("forced-colors");
+  });
+
+  test("emits no forced-colors block for declarations without any --t-* reference", () => {
+    const out = floorWithFC(".t-x { color: red; }");
+    expect(out).not.toContain("forced-colors");
+  });
+
+  test("does not nest a forced-colors block inside a hand-written forced-colors block", () => {
+    const out = floorWithFC(`
+      @media (forced-colors: active) {
+        .t-x { color: var(--t-accent); }
+      }
+    `);
+    expect(out).toContain("var(--t-accent, ButtonText)");
+    // exactly one @media occurrence: the hand-written one, no nested copy
+    expect(out.match(/@media \(forced-colors: active\)/g)?.length).toBe(1);
+  });
+
+  test("uses the forced-colors map for flooring inside a hand-written forced-colors block", () => {
+    const out = floorWithFC(`
+      @media (forced-colors: active) {
+        .t-x { color: var(--t-accent); }
+      }
+    `);
+    expect(out).toContain("var(--t-accent, ButtonText)");
+    expect(out).not.toContain("oklch(65% 0.18 250deg)");
+  });
+
+  test("appends overrides at the same nesting level as the original declaration", () => {
+    const out = floorWithFC(`
+      .t-x {
+        color: var(--t-accent);
+        &:hover { background: var(--t-accent); }
+      }
+    `);
+    // both the root rule and the &:hover nested rule get their own forced-colors block
+    expect(out.match(/@media \(forced-colors: active\)/g)?.length).toBe(2);
+  });
+
+  test("is a no-op when no forced-colors token map is provided", () => {
+    const out = floor(".t-x { color: var(--t-accent); }");
+    expect(out).not.toContain("forced-colors");
   });
 });

--- a/packages/css/postcss-teseor-floor.ts
+++ b/packages/css/postcss-teseor-floor.ts
@@ -9,19 +9,26 @@
  * The literal lives once in `tokens.css`; the build copies it into the third
  * `var()` position. `--_*` private references are left alone — they resolve
  * through their own floored `components.tokens` declaration.
+ *
+ * When `forcedColorsTokens` is provided, the plugin also synthesizes a nested
+ * `@media (forced-colors: active)` block re-declaring any property whose floor
+ * would differ in Windows High Contrast mode — `tokens.css` declares the same
+ * semantic alias twice (default `:root` + forced-colors branch), and the
+ * synthesized block carries the system-color literal so a per-component file
+ * keeps its high-contrast mapping when shipped alone.
  */
-import type { Container, Declaration, Plugin, Root } from "postcss";
+import type { AtRule, Container, Declaration, Plugin, Root, Rule } from "postcss";
 import postcss from "postcss";
 import valueParser from "postcss-value-parser";
 
-type Node = valueParser.Node;
+type ValueNode = valueParser.Node;
 
 const TOKEN_PREFIX = "--t-";
 const PRIVATE_PREFIX = "--_";
 const CONDITIONAL_AT_RULES = new Set(["media", "supports", "container"]);
 
 /** Value of the first `word` child, or undefined when there is none. */
-function firstWord(nodes: Node[]): string | undefined {
+function firstWord(nodes: ValueNode[]): string | undefined {
   for (const node of nodes) {
     if (node.type === "word") {
       return node.value;
@@ -31,8 +38,13 @@ function firstWord(nodes: Node[]): string | undefined {
 }
 
 /** Index of the top-level `,` separating a `var()`'s name from its fallback. */
-function commaIndex(nodes: Node[]): number {
+function commaIndex(nodes: ValueNode[]): number {
   return nodes.findIndex((node) => node.type === "div" && node.value === ",");
+}
+
+/** Matches `@media (forced-colors: active)` with no extra conditions. */
+function isForcedColorsActive(params: string): boolean {
+  return /^\s*\(\s*forced-colors\s*:\s*active\s*\)\s*$/.test(params);
 }
 
 /**
@@ -56,9 +68,33 @@ function collectDefaultTokens(container: Container, raw: Map<string, string>): v
   });
 }
 
+/**
+ * Overlay `--t-*` declarations from every `@media (forced-colors: active)`
+ * `:root` branch onto `raw`. Compound queries (e.g. `(forced-colors: active)
+ * and (prefers-color-scheme: dark)`) are skipped — only pure forced-colors
+ * overrides count, since a compound query's value only applies under those
+ * extra conditions, not under bare forced-colors mode.
+ */
+function collectForcedColorsOverrides(container: Container, raw: Map<string, string>): void {
+  container.walkAtRules("media", (atRule) => {
+    if (!isForcedColorsActive(atRule.params)) return;
+    atRule.walkRules(":root", (rootRule) => {
+      rootRule.walkDecls((decl) => {
+        if (decl.prop.startsWith(TOKEN_PREFIX)) {
+          raw.set(decl.prop, decl.value);
+        }
+      });
+    });
+  });
+}
+
 /** Replace every `var()` whose token resolves in `raw` with its terminal value. */
-function resolveNodes(nodes: Node[], raw: Map<string, string>, seen: Set<string>): Node[] {
-  const out: Node[] = [];
+function resolveNodes(
+  nodes: ValueNode[],
+  raw: Map<string, string>,
+  seen: Set<string>,
+): ValueNode[] {
+  const out: ValueNode[] = [];
   for (const node of nodes) {
     if (node.type !== "function") {
       out.push(node);
@@ -85,10 +121,7 @@ function resolveNodes(nodes: Node[], raw: Map<string, string>, seen: Set<string>
   return out;
 }
 
-/** Resolve `tokens.css` into a `--t-*` → terminal-literal map. */
-export function buildTokenMap(tokensCss: string): Map<string, string> {
-  const raw = new Map<string, string>();
-  collectDefaultTokens(postcss.parse(tokensCss), raw);
+function resolveAll(raw: Map<string, string>): Map<string, string> {
   const resolved = new Map<string, string>();
   for (const [name, value] of raw) {
     resolved.set(
@@ -99,8 +132,32 @@ export function buildTokenMap(tokensCss: string): Map<string, string> {
   return resolved;
 }
 
+/** Resolve `tokens.css` into a `--t-*` → terminal-literal map (default branch). */
+export function buildTokenMap(tokensCss: string): Map<string, string> {
+  const raw = new Map<string, string>();
+  collectDefaultTokens(postcss.parse(tokensCss), raw);
+  return resolveAll(raw);
+}
+
+/**
+ * Resolve `tokens.css` into a `--t-*` → terminal-literal map for forced-colors
+ * mode: starts from the default `:root` and applies `@media (forced-colors:
+ * active)` overrides before walking chains.
+ */
+export function buildForcedColorsTokenMap(tokensCss: string): Map<string, string> {
+  const raw = new Map<string, string>();
+  const parsed = postcss.parse(tokensCss);
+  collectDefaultTokens(parsed, raw);
+  collectForcedColorsOverrides(parsed, raw);
+  return resolveAll(raw);
+}
+
 /** Append a literal fallback to every fallback-less `--t-*` reference. */
-function floorNodes(nodes: Node[], tokens: Map<string, string>, unresolved: Set<string>): Node[] {
+function floorNodes(
+  nodes: ValueNode[],
+  tokens: Map<string, string>,
+  unresolved: Set<string>,
+): ValueNode[] {
   return nodes.map((node) => {
     if (node.type !== "function") {
       return node;
@@ -129,32 +186,79 @@ function floorNodes(nodes: Node[], tokens: Map<string, string>, unresolved: Set<
   });
 }
 
+function floorValue(value: string, tokens: Map<string, string>, unresolved: Set<string>): string {
+  return valueParser.stringify(floorNodes(valueParser(value).nodes, tokens, unresolved));
+}
+
 /**
  * PostCSS plugin. Run last, after import/each/custom-media have expanded the
  * CSS, so every `var()` reference is concrete.
  */
-export function teseorFloor(options: { tokens: Map<string, string> }): Plugin {
-  const { tokens } = options;
+export function teseorFloor(options: {
+  tokens: Map<string, string>;
+  forcedColorsTokens?: Map<string, string>;
+}): Plugin {
+  const { tokens, forcedColorsTokens } = options;
   return {
     postcssPlugin: "postcss-teseor-floor",
     Once(root: Root) {
       const unresolved = new Set<string>();
       let firstUnresolved: Declaration | undefined;
-      root.walkDecls((decl) => {
-        if (decl.prop.startsWith(TOKEN_PREFIX) || !decl.value.includes("var(")) {
-          return;
+
+      function walk(container: Container, inForcedColors: boolean): void {
+        const overrides: { prop: string; value: string }[] = [];
+        const children = (container.nodes ?? []).slice();
+
+        for (const node of children) {
+          if (node.type === "decl") {
+            const decl = node as Declaration;
+            if (decl.prop.startsWith(TOKEN_PREFIX) || !decl.value.includes("var(")) {
+              continue;
+            }
+            const originalValue = decl.value;
+            const activeTokens = inForcedColors && forcedColorsTokens ? forcedColorsTokens : tokens;
+            const before = unresolved.size;
+            const floored = floorValue(originalValue, activeTokens, unresolved);
+            if (unresolved.size > before && firstUnresolved === undefined) {
+              firstUnresolved = decl;
+            }
+            if (floored !== originalValue) {
+              decl.value = floored;
+            }
+            if (forcedColorsTokens && !inForcedColors) {
+              const fcFloored = floorValue(originalValue, forcedColorsTokens, unresolved);
+              if (fcFloored !== floored) {
+                overrides.push({ prop: decl.prop, value: fcFloored });
+              }
+            }
+          } else if (node.type === "rule") {
+            walk(node as Rule, inForcedColors);
+          } else if (node.type === "atrule") {
+            const atRule = node as AtRule;
+            const enters = atRule.name === "media" && isForcedColorsActive(atRule.params);
+            walk(atRule, inForcedColors || enters);
+          }
         }
-        const before = unresolved.size;
-        const floored = valueParser.stringify(
-          floorNodes(valueParser(decl.value).nodes, tokens, unresolved),
-        );
-        if (unresolved.size > before && firstUnresolved === undefined) {
-          firstUnresolved = decl;
+
+        if (
+          container.type === "rule" &&
+          overrides.length > 0 &&
+          !inForcedColors &&
+          forcedColorsTokens
+        ) {
+          const mediaAtRule = postcss.atRule({
+            name: "media",
+            params: "(forced-colors: active)",
+          });
+          for (const { prop, value } of overrides) {
+            mediaAtRule.append(postcss.decl({ prop, value }));
+          }
+          (container as Rule).append(mediaAtRule);
         }
-        if (floored !== decl.value) {
-          decl.value = floored;
-        }
-      });
+      }
+
+      walk(root, false);
+
       if (firstUnresolved !== undefined) {
         throw firstUnresolved.error(
           `cannot resolve a literal floor for ${[...unresolved].join(", ")} — not declared in tokens.css`,

--- a/packages/css/postcss-teseor-floor.ts
+++ b/packages/css/postcss-teseor-floor.ts
@@ -10,14 +10,16 @@
  * `var()` position. `--_*` private references are left alone — they resolve
  * through their own floored `components.tokens` declaration.
  *
- * When `forcedColorsTokens` is provided, the plugin also synthesizes a nested
- * `@media (forced-colors: active)` block re-declaring any property whose floor
- * would differ in Windows High Contrast mode — `tokens.css` declares the same
- * semantic alias twice (default `:root` + forced-colors branch), and the
- * synthesized block carries the system-color literal so a per-component file
- * keeps its high-contrast mapping when shipped alone.
+ * When `forcedColorsTokens` is provided, the plugin emits a single nested
+ * `@media (forced-colors: active)` block at the component root that
+ * re-declares every semantic token the file references whose forced-colors
+ * literal differs from the default branch. Custom-property inheritance
+ * propagates those system-color values to every `var()` reference in the
+ * subtree, so a per-component CSS shipped without `tokens.css` keeps its
+ * high-contrast mapping (`--t-accent → ButtonText`, `--t-focus-ring →
+ * Highlight`, …) without mirroring each component declaration.
  */
-import type { AtRule, Container, Declaration, Plugin, Root, Rule } from "postcss";
+import type { Container, Declaration, Plugin, Root, Rule } from "postcss";
 import postcss from "postcss";
 import valueParser from "postcss-value-parser";
 
@@ -26,6 +28,7 @@ type ValueNode = valueParser.Node;
 const TOKEN_PREFIX = "--t-";
 const PRIVATE_PREFIX = "--_";
 const CONDITIONAL_AT_RULES = new Set(["media", "supports", "container"]);
+const TOKEN_REF = /--t-[\w-]+/g;
 
 /** Value of the first `word` child, or undefined when there is none. */
 function firstWord(nodes: ValueNode[]): string | undefined {
@@ -190,6 +193,18 @@ function floorValue(value: string, tokens: Map<string, string>, unresolved: Set<
   return valueParser.stringify(floorNodes(valueParser(value).nodes, tokens, unresolved));
 }
 
+/** First Rule in document order, descending into wrapping at-rules (`@layer`). */
+function firstRule(container: Container): Rule | undefined {
+  for (const node of container.nodes ?? []) {
+    if (node.type === "rule") return node;
+    if (node.type === "atrule") {
+      const nested = firstRule(node);
+      if (nested) return nested;
+    }
+  }
+  return undefined;
+}
+
 /**
  * PostCSS plugin. Run last, after import/each/custom-media have expanded the
  * CSS, so every `var()` reference is concrete.
@@ -204,66 +219,54 @@ export function teseorFloor(options: {
     Once(root: Root) {
       const unresolved = new Set<string>();
       let firstUnresolved: Declaration | undefined;
+      const referenced = new Set<string>();
 
-      function walk(container: Container, inForcedColors: boolean): void {
-        const overrides: { prop: string; value: string }[] = [];
-        const children = (container.nodes ?? []).slice();
-
-        for (const node of children) {
-          if (node.type === "decl") {
-            const decl = node as Declaration;
-            if (decl.prop.startsWith(TOKEN_PREFIX) || !decl.value.includes("var(")) {
-              continue;
-            }
-            const originalValue = decl.value;
-            const activeTokens = inForcedColors && forcedColorsTokens ? forcedColorsTokens : tokens;
-            const before = unresolved.size;
-            const floored = floorValue(originalValue, activeTokens, unresolved);
-            if (unresolved.size > before && firstUnresolved === undefined) {
-              firstUnresolved = decl;
-            }
-            if (floored !== originalValue) {
-              decl.value = floored;
-            }
-            if (forcedColorsTokens && !inForcedColors) {
-              const fcFloored = floorValue(originalValue, forcedColorsTokens, unresolved);
-              if (fcFloored !== floored) {
-                overrides.push({ prop: decl.prop, value: fcFloored });
-              }
-            }
-          } else if (node.type === "rule") {
-            walk(node as Rule, inForcedColors);
-          } else if (node.type === "atrule") {
-            const atRule = node as AtRule;
-            const enters = atRule.name === "media" && isForcedColorsActive(atRule.params);
-            walk(atRule, inForcedColors || enters);
-          }
+      root.walkDecls((decl) => {
+        if (decl.prop.startsWith(TOKEN_PREFIX) || !decl.value.includes("var(")) {
+          return;
         }
-
-        if (
-          container.type === "rule" &&
-          overrides.length > 0 &&
-          !inForcedColors &&
-          forcedColorsTokens
-        ) {
-          const mediaAtRule = postcss.atRule({
-            name: "media",
-            params: "(forced-colors: active)",
-          });
-          for (const { prop, value } of overrides) {
-            mediaAtRule.append(postcss.decl({ prop, value }));
-          }
-          (container as Rule).append(mediaAtRule);
+        for (const match of decl.value.matchAll(TOKEN_REF)) {
+          referenced.add(match[0]);
         }
-      }
-
-      walk(root, false);
+        const before = unresolved.size;
+        const floored = floorValue(decl.value, tokens, unresolved);
+        if (unresolved.size > before && firstUnresolved === undefined) {
+          firstUnresolved = decl;
+        }
+        if (floored !== decl.value) {
+          decl.value = floored;
+        }
+      });
 
       if (firstUnresolved !== undefined) {
         throw firstUnresolved.error(
           `cannot resolve a literal floor for ${[...unresolved].join(", ")} — not declared in tokens.css`,
         );
       }
+
+      if (!forcedColorsTokens) return;
+
+      const overrides: { prop: string; value: string }[] = [];
+      for (const name of referenced) {
+        const def = tokens.get(name);
+        const fc = forcedColorsTokens.get(name);
+        if (def !== undefined && fc !== undefined && def !== fc) {
+          overrides.push({ prop: name, value: fc });
+        }
+      }
+      if (overrides.length === 0) return;
+
+      const target = firstRule(root);
+      if (!target) return;
+
+      const mediaAtRule = postcss.atRule({
+        name: "media",
+        params: "(forced-colors: active)",
+      });
+      for (const { prop, value } of overrides) {
+        mediaAtRule.append(postcss.decl({ prop, value }));
+      }
+      target.append(mediaAtRule);
     },
   };
 }


### PR DESCRIPTION
## What

`postcss-teseor-floor` now builds a second token map from `tokens.css`'s `@media (forced-colors: active)` `:root` branch, and after flooring a component file with the default-mode literal, emits a *single* nested `@media (forced-colors: active)` block at the component root listing every semantic token the file references whose forced-colors literal differs from the default branch.

For button:

```css
.t-button {
  --_fill: var(--t-button-bg, var(--t-accent, oklch(65% 0.18 250deg)));
  /* …rest of the declarations are unchanged */
  @media (forced-colors: active) {
    --t-accent: ButtonText;
    --t-on-accent: ButtonFace;
    --t-surface: Canvas;
    --t-on-surface: CanvasText;
    --t-success: ButtonText;
    --t-on-success: ButtonFace;
    --t-warning: ButtonText;
    --t-on-warning: ButtonFace;
    --t-danger: ButtonText;
    --t-on-danger: ButtonFace;
    --t-focus-ring: Highlight;
  }
}
```

Custom-property inheritance carries the system-color values to every `var(--t-*)` reference in the subtree, so a per-component CSS file shipped standalone keeps its high-contrast mapping without any per-declaration mirroring.

## Why

A per-component CSS shipped without `tokens.css` previously fell back to the default-mode `oklch(…)` literal in Windows High Contrast, losing the curated `--t-accent → ButtonText`, `--t-focus-ring → Highlight`, `--t-surface → Canvas` mappings that `tokens.css` declares in its forced-colors branch.

This shape was chosen over the per-declaration override the ADR initially sketched because it produces a smaller, simpler artifact: one `@media` block per component instead of N, and the plugin needs only one pass to collect referenced tokens. ADR-0003 §"Forced-colors resolution" updated to reflect.

## Test plan

- `pnpm vitest run packages/css` — 28 passing, including 9 tests on the synthesis path: single-block emission, scope at the component root, dedup across decls, no block when no differing token is referenced, no block when no forced-colors map is given, `@layer`-wrapped target rule.
- `pnpm lint` — clean.
- `pnpm build:css` — emits forced-colors blocks for the three components that reference semantic color tokens (button, code, codeblock).
- Acid test in `__tests__/build-output.test.ts` locks `--t-accent: ButtonText`, `--t-focus-ring: Highlight`, `--t-surface: Canvas` into the shipped button.

Bundle-size impact (button, raw / gzip / brotli):
- baseline (main): 8.29 / 1.58 / 1.32 KB
- this PR: 8.68 / 1.68 / 1.39 KB (+5% raw, +6% gzip)

## Out of scope

- Component CSS that references neutral *scale* tokens (`--t-neutral-90`, etc.) directly instead of semantic aliases (`--t-fg`, `--t-surface`) — those don't change in forced-colors mode, so the plugin emits nothing. Driving Tooltip / Modal through semantic aliases is a separate concern.
- Hand-written forced-colors blocks for non-color concerns (`outline-width`, `forced-color-adjust`) stay in component source.

Closes #609.