### PR TITLE
feat(codegen): forced-colors per-component docs + forced-color-adjust pairing

### DIFF
--- a/.changeset/783-forced-color-adjust-pair.md
+++ b/.changeset/783-forced-color-adjust-pair.md
@@ -1,0 +1,5 @@
+---
+"@teseor/css": patch
+---
+
+`postcss-teseor-floor` now pairs the synthesized `@media (forced-colors: active)` block with `forced-color-adjust: none`. Without it, browsers overlay their native-control rendering on top of our explicit system-color mapping for form elements (e.g. `<button>` ended up with a `ButtonFace` interior obscuring the label). The two are emitted as a unit since they only make sense together — the token mapping authorises the opt-out.

--- a/apps/docs/src/pages/components/button.astro
+++ b/apps/docs/src/pages/components/button.astro
@@ -150,6 +150,26 @@ import Base from "../../layouts/Base.astro";
       </table>
     </section>
     <section class="t-stack" data-gap="3">
+      <h2>Forced colors</h2>
+      <p>In Windows High Contrast mode, the component remaps these semantic tokens to CSS system colors. Custom-property inheritance carries the values to every reference in the subtree.</p>
+      <table>
+        <thead><tr><th>Token</th><th>Default</th><th>Forced-colors</th></tr></thead>
+        <tbody>
+        <tr><td><Code>--t-accent</Code></td><td><Code>oklch(65% 0.18 250deg)</Code></td><td><Code>ButtonText</Code></td></tr>
+        <tr><td><Code>--t-danger</Code></td><td><Code>oklch(62% 0.2 25deg)</Code></td><td><Code>ButtonText</Code></td></tr>
+        <tr><td><Code>--t-focus-ring</Code></td><td><Code>oklch(65% 0.18 250deg)</Code></td><td><Code>Highlight</Code></td></tr>
+        <tr><td><Code>--t-on-accent</Code></td><td><Code>oklch(100% 0 0deg)</Code></td><td><Code>ButtonFace</Code></td></tr>
+        <tr><td><Code>--t-on-danger</Code></td><td><Code>oklch(100% 0 0deg)</Code></td><td><Code>ButtonFace</Code></td></tr>
+        <tr><td><Code>--t-on-success</Code></td><td><Code>oklch(100% 0 0deg)</Code></td><td><Code>ButtonFace</Code></td></tr>
+        <tr><td><Code>--t-on-surface</Code></td><td><Code>oklch(18% 0 0deg)</Code></td><td><Code>CanvasText</Code></td></tr>
+        <tr><td><Code>--t-on-warning</Code></td><td><Code>oklch(0% 0 0deg)</Code></td><td><Code>ButtonFace</Code></td></tr>
+        <tr><td><Code>--t-success</Code></td><td><Code>oklch(65% 0.18 155deg)</Code></td><td><Code>ButtonText</Code></td></tr>
+        <tr><td><Code>--t-surface</Code></td><td><Code>oklch(97% 0 0deg)</Code></td><td><Code>Canvas</Code></td></tr>
+        <tr><td><Code>--t-warning</Code></td><td><Code>oklch(75% 0.18 80deg)</Code></td><td><Code>ButtonText</Code></td></tr>
+        </tbody>
+      </table>
+    </section>
+    <section class="t-stack" data-gap="3">
       <h2>Constraints</h2>
       <ul>
         <li>Link variant is text-colored; non-neutral intent fills have no surface to apply to.</li>

--- a/apps/docs/src/pages/components/button.astro
+++ b/apps/docs/src/pages/components/button.astro
@@ -181,7 +181,7 @@ import Base from "../../layouts/Base.astro";
       <table>
         <thead><tr><th>Artifact</th><th>Raw</th><th>Gzip</th><th>Brotli</th></tr></thead>
         <tbody>
-        <tr><td><a href="https://github.com/teseor/teseor/blob/main/packages/css/src/components/button/button.css"><Code>@teseor/css/components/button.css</Code></a></td><td>8.68 KB</td><td>1.68 KB</td><td>1.39 KB</td></tr>
+        <tr><td><a href="https://github.com/teseor/teseor/blob/main/packages/css/src/components/button/button.css"><Code>@teseor/css/components/button.css</Code></a></td><td>8.71 KB</td><td>1.68 KB</td><td>1.40 KB</td></tr>
         </tbody>
       </table>
     </section>

--- a/apps/docs/src/pages/components/code.astro
+++ b/apps/docs/src/pages/components/code.astro
@@ -45,7 +45,7 @@ import Base from "../../layouts/Base.astro";
       <table>
         <thead><tr><th>Artifact</th><th>Raw</th><th>Gzip</th><th>Brotli</th></tr></thead>
         <tbody>
-        <tr><td><a href="https://github.com/teseor/teseor/blob/main/packages/css/src/components/code/code.css"><Code>@teseor/css/components/code.css</Code></a></td><td>0.90 KB</td><td>0.43 KB</td><td>0.37 KB</td></tr>
+        <tr><td><a href="https://github.com/teseor/teseor/blob/main/packages/css/src/components/code/code.css"><Code>@teseor/css/components/code.css</Code></a></td><td>0.94 KB</td><td>0.45 KB</td><td>0.38 KB</td></tr>
         </tbody>
       </table>
     </section>

--- a/apps/docs/src/pages/components/code.astro
+++ b/apps/docs/src/pages/components/code.astro
@@ -31,6 +31,16 @@ import Base from "../../layouts/Base.astro";
       </table>
     </section>
     <section class="t-stack" data-gap="3">
+      <h2>Forced colors</h2>
+      <p>In Windows High Contrast mode, the component remaps these semantic tokens to CSS system colors. Custom-property inheritance carries the values to every reference in the subtree.</p>
+      <table>
+        <thead><tr><th>Token</th><th>Default</th><th>Forced-colors</th></tr></thead>
+        <tbody>
+        <tr><td><Code>--t-on-surface</Code></td><td><Code>oklch(18% 0 0deg)</Code></td><td><Code>CanvasText</Code></td></tr>
+        </tbody>
+      </table>
+    </section>
+    <section class="t-stack" data-gap="3">
       <h2>Bundle size</h2>
       <table>
         <thead><tr><th>Artifact</th><th>Raw</th><th>Gzip</th><th>Brotli</th></tr></thead>

--- a/apps/docs/src/pages/components/codeblock.astro
+++ b/apps/docs/src/pages/components/codeblock.astro
@@ -31,6 +31,16 @@ import Base from "../../layouts/Base.astro";
       </table>
     </section>
     <section class="t-stack" data-gap="3">
+      <h2>Forced colors</h2>
+      <p>In Windows High Contrast mode, the component remaps these semantic tokens to CSS system colors. Custom-property inheritance carries the values to every reference in the subtree.</p>
+      <table>
+        <thead><tr><th>Token</th><th>Default</th><th>Forced-colors</th></tr></thead>
+        <tbody>
+        <tr><td><Code>--t-on-surface</Code></td><td><Code>oklch(18% 0 0deg)</Code></td><td><Code>CanvasText</Code></td></tr>
+        </tbody>
+      </table>
+    </section>
+    <section class="t-stack" data-gap="3">
       <h2>Bundle size</h2>
       <table>
         <thead><tr><th>Artifact</th><th>Raw</th><th>Gzip</th><th>Brotli</th></tr></thead>

--- a/apps/docs/src/pages/components/codeblock.astro
+++ b/apps/docs/src/pages/components/codeblock.astro
@@ -45,7 +45,7 @@ import Base from "../../layouts/Base.astro";
       <table>
         <thead><tr><th>Artifact</th><th>Raw</th><th>Gzip</th><th>Brotli</th></tr></thead>
         <tbody>
-        <tr><td><a href="https://github.com/teseor/teseor/blob/main/packages/css/src/components/codeblock/codeblock.css"><Code>@teseor/css/components/codeblock.css</Code></a></td><td>1.08 KB</td><td>0.50 KB</td><td>0.41 KB</td></tr>
+        <tr><td><a href="https://github.com/teseor/teseor/blob/main/packages/css/src/components/codeblock/codeblock.css"><Code>@teseor/css/components/codeblock.css</Code></a></td><td>1.11 KB</td><td>0.51 KB</td><td>0.42 KB</td></tr>
         </tbody>
       </table>
     </section>

--- a/docs/architecture/three-tier-tokens.md
+++ b/docs/architecture/three-tier-tokens.md
@@ -142,6 +142,7 @@ The forced-colors block keeps tokens as the single source of truth across both m
   --_fill: var(--t-button-bg, var(--t-accent, oklch(65% 0.18 250deg)));
   /* …rest of the component declarations are unchanged */
   @media (forced-colors: active) {
+    forced-color-adjust: none;
     --t-accent:     ButtonText;
     --t-on-accent:  ButtonFace;
     --t-focus-ring: Highlight;
@@ -150,7 +151,11 @@ The forced-colors block keeps tokens as the single source of truth across both m
 }
 ```
 
-Custom-property inheritance propagates these values to every `var(--t-*)` reference inside `.t-button`, including its nested rules (`&:where([data-intent="primary"])`, `&:focus-visible`, …). Components don't get per-declaration mirroring — the cascade does the work. A component file that references only scale tokens (`--t-neutral-90`, `--t-space-4`) emits no block, because scale tokens don't change between branches. When `tokens.css` *is* also loaded, the synthesized block and the `:root` forced-colors branch carry the same value, so the result is identical — the block is only load-bearing when the per-component CSS is shipped alone. Consumers who want to override the forced-colors mapping for a specific component target the component class (e.g. `.my-app .t-button { --t-accent: HighlightText; }`) rather than `:root`, since the synthesized declaration is applied directly to the element and beats inherited `:root` values.
+Custom-property inheritance propagates these values to every `var(--t-*)` reference inside `.t-button`, including its nested rules (`&:where([data-intent="primary"])`, `&:focus-visible`, …). Components don't get per-declaration mirroring — the cascade does the work. A component file that references only scale tokens (`--t-neutral-90`, `--t-space-4`) emits no block, because scale tokens don't change between branches.
+
+The plugin always pairs the override with `forced-color-adjust: none` inside the same block. The two are a unit: without it, the UA layers its native-control rendering (a `ButtonFace` interior with `ButtonText` chrome) on top of the author's colors for form elements, which obliterates the component's appearance even though our token mapping is correct. The opt-out is safe because we've already remapped every relevant token to a system color in the same block — the UA isn't being asked to "trust author colors" but to "trust the explicit system-color mapping the author just wrote."
+
+When `tokens.css` *is* also loaded, the synthesized block and the `:root` forced-colors branch carry the same values, so the result is identical — the block is only load-bearing when the per-component CSS is shipped alone. Consumers who want to override the forced-colors mapping for a specific component target the component class (e.g. `.my-app .t-button { --t-accent: HighlightText; }`) rather than `:root`, since the synthesized declaration is applied directly to the element and beats inherited `:root` values.
 
 *On-X foreground aliases.* Every fill role pairs with a foreground alias for the text or icon that sits on top:
 

--- a/docs/architecture/three-tier-tokens.md
+++ b/docs/architecture/three-tier-tokens.md
@@ -135,6 +135,23 @@ Semantic color aliases (`--t-fg`, `--t-bg`, `--t-accent`, `--t-on-accent`, `--t-
 
 The forced-colors block keeps tokens as the single source of truth across both modes — themes can override either branch independently, components never write forced-colors fallbacks themselves. `postcss-teseor-floor` walks both branches when inlining literals (see ADR-0003 § "Forced-colors resolution").
 
+*Forced-colors floor.* When a consumer loads only a per-component file (`@teseor/css/components/button.css`) without `tokens.css`, the third-position literal that the plugin inlines is the *default-mode* value (e.g. `oklch(...)`). To keep the high-contrast mapping intact in that load case, the plugin also synthesizes a single nested `@media (forced-colors: active)` block at the component root that re-declares every semantic token the file references whose forced-colors literal differs from the default branch:
+
+```css
+.t-button {
+  --_fill: var(--t-button-bg, var(--t-accent, oklch(65% 0.18 250deg)));
+  /* …rest of the component declarations are unchanged */
+  @media (forced-colors: active) {
+    --t-accent:     ButtonText;
+    --t-on-accent:  ButtonFace;
+    --t-focus-ring: Highlight;
+    /* …only the semantic tokens this file actually references */
+  }
+}
+```
+
+Custom-property inheritance propagates these values to every `var(--t-*)` reference inside `.t-button`, including its nested rules (`&:where([data-intent="primary"])`, `&:focus-visible`, …). Components don't get per-declaration mirroring — the cascade does the work. A component file that references only scale tokens (`--t-neutral-90`, `--t-space-4`) emits no block, because scale tokens don't change between branches. When `tokens.css` *is* also loaded, the synthesized block and the `:root` forced-colors branch carry the same value, so the result is identical — the block is only load-bearing when the per-component CSS is shipped alone. Consumers who want to override the forced-colors mapping for a specific component target the component class (e.g. `.my-app .t-button { --t-accent: HighlightText; }`) rather than `:root`, since the synthesized declaration is applied directly to the element and beats inherited `:root` values.
+
 *On-X foreground aliases.* Every fill role pairs with a foreground alias for the text or icon that sits on top:
 
 | Fill role | Paired foreground |

--- a/packages/css/__tests__/build-output.test.ts
+++ b/packages/css/__tests__/build-output.test.ts
@@ -60,6 +60,7 @@ test("shipped component CSS inlines the literal resolved from tokens.css", () =>
 test("shipped component CSS carries a forced-colors token override", () => {
   const button = readFileSync(join(distDir, "components", "button.css"), "utf8");
   expect(button).toMatch(/@media \(forced-colors: active\)/);
+  expect(button).toContain("forced-color-adjust: none");
   expect(button).toContain("--t-accent: ButtonText");
   expect(button).toContain("--t-focus-ring: Highlight");
   expect(button).toContain("--t-surface: Canvas");

--- a/packages/css/postcss-teseor-floor.test.ts
+++ b/packages/css/postcss-teseor-floor.test.ts
@@ -149,6 +149,11 @@ describe("teseorFloor — forced-colors synthesis", () => {
     expect(out).toMatch(/\.t-button[\s\S]*@media \(forced-colors: active\)/);
   });
 
+  test("pairs the synthesised block with forced-color-adjust: none", () => {
+    const out = floorWithFC(".t-x { --_fill: var(--t-accent); }");
+    expect(out).toMatch(/@media \(forced-colors: active\)\s*{\s*forced-color-adjust:\s*none/);
+  });
+
   test("re-declares the upstream semantic token, not the component-private", () => {
     const out = floorWithFC(".t-x { --_fill: var(--t-accent); }");
     expect(out).toContain("--t-accent: ButtonText");

--- a/packages/css/postcss-teseor-floor.ts
+++ b/packages/css/postcss-teseor-floor.ts
@@ -18,6 +18,11 @@
  * subtree, so a per-component CSS shipped without `tokens.css` keeps its
  * high-contrast mapping (`--t-accent → ButtonText`, `--t-focus-ring →
  * Highlight`, …) without mirroring each component declaration.
+ *
+ * The synthesized block is paired with `forced-color-adjust: none` so the UA
+ * doesn't overlay its native-control rendering on top of our explicit token
+ * mapping. The pair is always emitted together — they only make sense as a
+ * unit (the override authorises us to opt out of the UA's auto-adjust).
  */
 import type { Container, Declaration, Plugin, Root, Rule } from "postcss";
 import postcss from "postcss";
@@ -263,6 +268,7 @@ export function teseorFloor(options: {
         name: "media",
         params: "(forced-colors: active)",
       });
+      mediaAtRule.append(postcss.decl({ prop: "forced-color-adjust", value: "none" }));
       for (const { prop, value } of overrides) {
         mediaAtRule.append(postcss.decl({ prop, value }));
       }

--- a/scripts/codegen/src/generators/gen-docs.ts
+++ b/scripts/codegen/src/generators/gen-docs.ts
@@ -3,6 +3,10 @@ import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { brotliCompressSync, gzipSync } from "node:zlib";
 import { parse as parseYaml } from "yaml";
+import {
+  buildForcedColorsTokenMap,
+  buildTokenMap,
+} from "../../../../packages/css/postcss-teseor-floor.ts";
 import { flattenSpec } from "../lib/flatten.ts";
 import type { GeneratorContext, GeneratorReport } from "../registry.ts";
 import { registerGenerator } from "../registry.ts";
@@ -14,12 +18,14 @@ import { renderCompositeOverlayDocsPage } from "./gen-docs/kinds/composite-overl
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..", "..", "..");
 const SPECS_DIR = resolve(REPO_ROOT, "specs");
 const DOCS_PAGES_DIR = resolve(REPO_ROOT, "apps", "docs", "src", "pages", "components");
-const CSS_COMPONENTS_DIR = resolve(REPO_ROOT, "packages", "css", "dist", "components");
+const CSS_COMPONENTS_DIST = resolve(REPO_ROOT, "packages", "css", "dist", "components");
+const CSS_COMPONENTS_SRC = resolve(REPO_ROOT, "packages", "css", "src", "components");
+const TOKENS_CSS = resolve(REPO_ROOT, "packages", "css", "src", "tokens.css");
 
 async function readBundleSizes(name: string): Promise<DocsSpec["bundleSizes"]> {
   // ENOENT: build:css not run / spec has no CSS — omit silently. Anything else fails loud.
   try {
-    const text = await readFile(resolve(CSS_COMPONENTS_DIR, `${name}.css`), "utf8");
+    const text = await readFile(resolve(CSS_COMPONENTS_DIST, `${name}.css`), "utf8");
     const buf = Buffer.from(text, "utf8");
     return {
       raw: buf.byteLength,
@@ -30,6 +36,34 @@ async function readBundleSizes(name: string): Promise<DocsSpec["bundleSizes"]> {
     if (err instanceof Error && "code" in err && err.code === "ENOENT") return undefined;
     throw err;
   }
+}
+
+const TOKEN_REF = /--t-[\w-]+/g;
+
+async function readForcedColors(
+  name: string,
+  tokens: Map<string, string>,
+  fcTokens: Map<string, string>,
+): Promise<DocsSpec["forcedColors"]> {
+  // ENOENT: spec has no CSS — omit silently. Anything else fails loud.
+  let css: string;
+  try {
+    css = await readFile(resolve(CSS_COMPONENTS_SRC, name, `${name}.css`), "utf8");
+  } catch (err) {
+    if (err instanceof Error && "code" in err && err.code === "ENOENT") return undefined;
+    throw err;
+  }
+  const referenced = new Set<string>();
+  for (const match of css.matchAll(TOKEN_REF)) referenced.add(match[0]);
+  const entries: NonNullable<DocsSpec["forcedColors"]> = [];
+  for (const token of [...referenced].sort()) {
+    const def = tokens.get(token);
+    const forced = fcTokens.get(token);
+    if (def !== undefined && forced !== undefined && def !== forced) {
+      entries.push({ token, default: def, forced });
+    }
+  }
+  return entries.length > 0 ? entries : undefined;
 }
 
 /** Dispatch to the kind-specific renderer for the spec's `kind:` field. */
@@ -68,10 +102,15 @@ async function docsGenerator(ctx: GeneratorContext): Promise<GeneratorReport> {
   const filesWritten: string[] = [];
   const notes: string[] = [];
 
+  const tokensCss = await readFile(TOKENS_CSS, "utf8");
+  const tokens = buildTokenMap(tokensCss);
+  const fcTokens = buildForcedColorsTokenMap(tokensCss);
+
   await mkdir(DOCS_PAGES_DIR, { recursive: true });
   for (const name of targets) {
     const spec = await loadSpec(name);
     spec.bundleSizes = await readBundleSizes(name);
+    spec.forcedColors = await readForcedColors(name, tokens, fcTokens);
     const outPath = resolve(DOCS_PAGES_DIR, `${name}.astro`);
     await writeFile(outPath, renderDocsPage(spec), "utf8");
     filesWritten.push(outPath);

--- a/scripts/codegen/src/generators/gen-docs/_shared/sections.test.ts
+++ b/scripts/codegen/src/generators/gen-docs/_shared/sections.test.ts
@@ -5,6 +5,7 @@ import {
   renderA11y,
   renderBundleSize,
   renderConstraints,
+  renderForcedColors,
   renderNamed,
   renderProps,
   renderStates,
@@ -327,6 +328,43 @@ describe("renderBundleSize", () => {
     expect(out).toContain(
       'href="https://github.com/teseor/teseor/blob/main/packages/css/src/components/button/button.css"',
     );
+  });
+});
+
+describe("renderForcedColors", () => {
+  test("returns empty string when forcedColors is unset", () => {
+    expect(renderForcedColors(atomicSpec())).toBe("");
+  });
+
+  test("returns empty string when forcedColors is an empty list", () => {
+    expect(renderForcedColors(atomicSpec({ forcedColors: [] }))).toBe("");
+  });
+
+  test("renders one row per token with default and forced literals", () => {
+    const spec = atomicSpec({
+      forcedColors: [
+        { token: "--t-accent", default: "oklch(65% 0.18 250deg)", forced: "ButtonText" },
+        { token: "--t-focus-ring", default: "oklch(65% 0.18 250deg)", forced: "Highlight" },
+      ],
+    });
+    const out = renderForcedColors(spec);
+    expect(out).toContain("<h2>Forced colors</h2>");
+    expect(out).toContain("<th>Token</th>");
+    expect(out).toContain("<th>Default</th>");
+    expect(out).toContain("<th>Forced-colors</th>");
+    expect(out).toContain("<Code>--t-accent</Code>");
+    expect(out).toContain("<Code>ButtonText</Code>");
+    expect(out).toContain("<Code>--t-focus-ring</Code>");
+    expect(out).toContain("<Code>Highlight</Code>");
+  });
+
+  test("renders an intro paragraph explaining the contract", () => {
+    const spec = atomicSpec({
+      forcedColors: [
+        { token: "--t-accent", default: "oklch(65% 0.18 250deg)", forced: "ButtonText" },
+      ],
+    });
+    expect(renderForcedColors(spec)).toContain("Windows High Contrast mode");
   });
 });
 

--- a/scripts/codegen/src/generators/gen-docs/_shared/sections.ts
+++ b/scripts/codegen/src/generators/gen-docs/_shared/sections.ts
@@ -11,6 +11,10 @@ export type DocsSpec = Spec & {
   // Size of `packages/css/dist/components/<name>.css` injected by gen-docs.ts
   // after build:css. Absent when dist hasn't been built yet.
   bundleSizes?: { raw: number; gzip: number; brotli: number };
+  // Semantic tokens the component references whose forced-colors literal
+  // differs from the default branch. Injected by gen-docs.ts. Absent when the
+  // component references no remapped semantic token (scale-only or no CSS).
+  forcedColors?: Array<{ token: string; default: string; forced: string }>;
 };
 
 function formatKb(bytes: number): string {
@@ -183,6 +187,21 @@ export function renderA11y(spec: DocsSpec): string {
     lines.push(renderTable(["Interaction", "Action"], rows));
   }
   return section("Accessibility", lines.join("\n"));
+}
+
+export function renderForcedColors(spec: DocsSpec): string {
+  if (!spec.forcedColors || spec.forcedColors.length === 0) return "";
+  const rows = spec.forcedColors.map(({ token, default: def, forced }) => [
+    `<Code>${esc(token)}</Code>`,
+    `<Code>${esc(def)}</Code>`,
+    `<Code>${esc(forced)}</Code>`,
+  ]);
+  const intro =
+    "      <p>In Windows High Contrast mode, the component remaps these semantic tokens to CSS system colors. Custom-property inheritance carries the values to every reference in the subtree.</p>";
+  return section(
+    "Forced colors",
+    [intro, renderTable(["Token", "Default", "Forced-colors"], rows)].join("\n"),
+  );
 }
 
 export function renderConstraints(spec: DocsSpec): string {

--- a/scripts/codegen/src/generators/gen-docs/kinds/atomic.ts
+++ b/scripts/codegen/src/generators/gen-docs/kinds/atomic.ts
@@ -6,6 +6,7 @@ import {
   renderA11y,
   renderBundleSize,
   renderConstraints,
+  renderForcedColors,
   renderNamed,
   renderProps,
   renderStates,
@@ -25,6 +26,7 @@ export function renderAtomicDocsPage(spec: DocsSpec): string {
     renderStates(spec),
     renderTokens(spec),
     renderA11y(spec),
+    renderForcedColors(spec),
     renderConstraints(spec),
     renderBundleSize(spec),
   ].filter((part) => part.length > 0);

--- a/scripts/codegen/src/generators/gen-docs/kinds/composite-overlay.ts
+++ b/scripts/codegen/src/generators/gen-docs/kinds/composite-overlay.ts
@@ -6,6 +6,7 @@ import {
   renderA11y,
   renderBundleSize,
   renderConstraints,
+  renderForcedColors,
   renderNamed,
   renderProps,
   renderStates,
@@ -33,6 +34,7 @@ export function renderCompositeOverlayDocsPage(spec: DocsSpec): string {
     renderStates(spec),
     renderTokens(spec),
     renderA11y(spec),
+    renderForcedColors(spec),
     renderConstraints(spec),
     renderBundleSize(spec),
   ].filter((part) => part.length > 0);


### PR DESCRIPTION
## What

Three changes that complete the forced-colors floor story from #780:

1. **`postcss-teseor-floor` pairs the synthesised override with `forced-color-adjust: none`.** Without it, browsers overlay their native-control rendering (a `ButtonFace`-filled interior with `ButtonText` chrome) on top of our explicit system-color mapping for form elements. Visible symptom: in Chrome's forced-colors emulator the button rendered as a solid `ButtonText` block with the label obscured. The two declarations are emitted as a unit since they only make sense together — the explicit token mapping authorises the opt-out.
2. **`gen-docs` — per-component table.** Every component spec gets a `forcedColors` field listing the semantic tokens it references whose forced-colors literal differs from the default branch. A new `renderForcedColors` section renders a `Token / Default / Forced-colors` table on every page that needs one. Built from `packages/css/src/components/<name>/<name>.css` + the two token maps from `postcss-teseor-floor`, so the table auto-tracks reality.
3. **`docs/architecture/three-tier-tokens.md` § Colors.** Short integrator-facing explainer of the synthesis: when the floor matters, what the shipped block looks like (including the `forced-color-adjust: none` pairing), how custom-property inheritance does the work, how consumers override the mapping per component.

Visible result on the docs site: Button gets an 11-row table covering accent / danger / success / warning / surface / focus-ring and their `--t-on-*` pairs; Code and Codeblock get a 1-row table for `--t-on-surface → CanvasText`; layout-only components (Stack, Cluster) and components that bind directly to scale tokens (Tooltip, Modal) get no section.

## Why

Post-#780 the floor synthesis is observable in dist but invisible on the docs site, and the synthesis itself was incomplete for form elements where the UA's native-control rendering won by default. (2) and (3) surface the contract; (1) makes the visible rendering actually match it.

## Test plan

- `pnpm vitest run` — 865 passing. New coverage: `pairs the synthesised block with forced-color-adjust: none` in the plugin tests, `forced-color-adjust: none` in the dist acid test, four tests on `renderForcedColors` (empty list, multi-token render, intro paragraph, missing field).
- `pnpm gen` — astro pages for button / code / codeblock regenerate with the new section.
- `pnpm lint` — clean.
- Manual: Chrome → DevTools → Rendering → Emulate `forced-colors: active`. Buttons now render with `ButtonText` background and `ButtonFace` label as intended, not the obscured native-button overlay.

## Out of scope

- A dedicated explainer page on the docs site (`/accessibility/forced-colors`) — the architecture markdown lives in the dev-docs tree for now; promoting to the site is a separate ask once we have a non-component pages structure.
- A visual snapshot under `forced-colors: active` per component — lands with `test:visual` at v0.2.
- Driving Tooltip / Modal through semantic aliases so they pick up forced-colors remapping — separate concern.

Closes #782.