### PR TITLE
feat(scripts): add script-entry-point lint rule

### DIFF
--- a/scripts/lint/cross-file/config-paths.ts
+++ b/scripts/lint/cross-file/config-paths.ts
@@ -1,14 +1,14 @@
-// Every `scripts/<path>` reference in `.claude/settings.json` and
-// `.github/workflows/*.yml` must point at a file that exists. Substring
-// scan — the surfaces mix hook commands, workflow `run:` lines, and
-// permission patterns.
+// Every `scripts/<path>` reference in `.claude/settings.json`, `package.json`,
+// `lefthook.yml`, and `.github/workflows/*.yml` must point at a file that
+// exists. Substring scan — the surfaces mix hook commands, workflow `run:`
+// lines, npm scripts, and permission patterns.
 import { existsSync, readFileSync, statSync } from "node:fs";
 import { resolve } from "node:path";
 import { lsFiles } from "../../lib/enumerate.ts";
 import { REPO_ROOT } from "../../lib/paths.ts";
 import type { ViolationDetail, WorkspaceCheck } from "../registry.ts";
 
-const CONFIG_FILES = [".claude/settings.json"] as const;
+const CONFIG_FILES = [".claude/settings.json", "package.json", "lefthook.yml"] as const;
 const WORKFLOW_PATHSPEC = ".github/workflows/*.yml";
 
 const TRIGGERS = [...CONFIG_FILES, WORKFLOW_PATHSPEC] as const;

--- a/scripts/lint/cross-file/config-paths.ts
+++ b/scripts/lint/cross-file/config-paths.ts
@@ -59,5 +59,5 @@ export const rule: WorkspaceCheck = {
   kind: "workspace",
   triggers: TRIGGERS,
   run: checkConfigPaths,
-  hint: "Update `.claude/settings.json` and `.github/workflows/*.yml` after every scripts/ rename.",
+  hint: "Update `.claude/settings.json`, `package.json`, `lefthook.yml`, and `.github/workflows/*.yml` after every scripts/ rename.",
 };

--- a/scripts/lint/cross-file/script-entry-point.test.ts
+++ b/scripts/lint/cross-file/script-entry-point.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from "vitest";
+import { extractInvocations, isImportOnly } from "./script-entry-point.ts";
+
+describe("extractInvocations", () => {
+  it("extracts a plain `node scripts/<path>` invocation", () => {
+    expect(extractInvocations("run: node scripts/repo/audit-overrides.ts")).toEqual([
+      "scripts/repo/audit-overrides.ts",
+    ]);
+  });
+
+  it("strips trailing punctuation from quoted commands", () => {
+    expect(extractInvocations('"node scripts/lint/run.ts --all"')).toEqual(["scripts/lint/run.ts"]);
+  });
+
+  it("ignores `scripts/` substrings not preceded by `node`", () => {
+    expect(extractInvocations('"Bash(node scripts/foo.ts:*)" "see scripts/bar.ts"')).toEqual([
+      "scripts/foo.ts",
+    ]);
+  });
+
+  it("returns multiple distinct invocations from one source", () => {
+    const source = `
+      run: node scripts/hooks/commit-msg.js {1}
+      run: node scripts/lint/run.ts --all
+    `;
+    expect(extractInvocations(source).sort()).toEqual([
+      "scripts/hooks/commit-msg.js",
+      "scripts/lint/run.ts",
+    ]);
+  });
+
+  it("deduplicates repeated invocations", () => {
+    const source = "node scripts/a.ts; node scripts/a.ts";
+    expect(extractInvocations(source)).toEqual(["scripts/a.ts"]);
+  });
+
+  it("returns an empty list when nothing matches", () => {
+    expect(extractInvocations('"permissions": { "allow": ["Bash(git status:*)"] }')).toEqual([]);
+  });
+});
+
+describe("isImportOnly", () => {
+  it("flags a file that only exports a `rule` object", () => {
+    const source = [
+      'import { readFileSync } from "node:fs";',
+      'import type { WorkspaceCheck } from "../registry.ts";',
+      "function check() { return []; }",
+      'export const rule: WorkspaceCheck = { kind: "workspace", triggers: [], run: check };',
+    ].join("\n");
+    expect(isImportOnly(source)).toBe(true);
+  });
+
+  it("accepts a top-level `main();` call", () => {
+    const source = [
+      'import { foo } from "./foo.ts";',
+      "function main() { foo(); }",
+      "main();",
+    ].join("\n");
+    expect(isImportOnly(source)).toBe(false);
+  });
+
+  it("accepts a top-level `main().catch(...)` chain", () => {
+    const source = [
+      "async function main() {}",
+      "main().catch((err) => { process.exit(1); });",
+    ].join("\n");
+    expect(isImportOnly(source)).toBe(false);
+  });
+
+  it("accepts an entry-point guard via `process.argv`", () => {
+    const source = [
+      'import { fileURLToPath } from "node:url";',
+      "function main() {}",
+      "if (process.argv[1] === fileURLToPath(import.meta.url)) {",
+      "  main();",
+      "}",
+    ].join("\n");
+    expect(isImportOnly(source)).toBe(false);
+  });
+
+  it("accepts direct `process.argv` parsing at top level", () => {
+    const source = [
+      'const mode = process.argv.find((a) => a.startsWith("--mode="));',
+      "function run() {}",
+    ].join("\n");
+    expect(isImportOnly(source)).toBe(false);
+  });
+
+  it("accepts top-level `await`", () => {
+    const source = ['import { read } from "./read.ts";', "await read();"].join("\n");
+    expect(isImportOnly(source)).toBe(false);
+  });
+
+  it("ignores a `main()` reference inside a comment", () => {
+    const source = [
+      "// call main() to start",
+      "function main() {}",
+      "export const rule = { run: main };",
+    ].join("\n");
+    expect(isImportOnly(source)).toBe(true);
+  });
+
+  it("ignores a `main()` reference inside a block comment", () => {
+    const source = [
+      "/*",
+      " * main();",
+      " */",
+      "function main() {}",
+      "export const rule = { run: main };",
+    ].join("\n");
+    expect(isImportOnly(source)).toBe(true);
+  });
+
+  it("does not treat `if (...)` as a top-level call", () => {
+    const source = ["function main() {}", "if (false) { main(); }"].join("\n");
+    // Heuristic: `if` is a keyword, not a call. The `main()` inside the
+    // block is indented — not at column 0. Conservatively flagged as
+    // import-only, but in practice every CLI we have pairs `if (process.argv...)`
+    // with the `process.argv` literal that already triggers the early return.
+    expect(isImportOnly(source)).toBe(true);
+  });
+});

--- a/scripts/lint/cross-file/script-entry-point.test.ts
+++ b/scripts/lint/cross-file/script-entry-point.test.ts
@@ -125,6 +125,15 @@ describe("isImportOnly", () => {
     expect(isImportOnly(source)).toBe(true);
   });
 
+  it("flags an import-only file even when trailing inline comments mention `process.argv`", () => {
+    const source = [
+      'import type { WorkspaceCheck } from "../registry.ts"; // see process.argv usage elsewhere',
+      "function check() { return []; } // also: import.meta",
+      'export const rule: WorkspaceCheck = { kind: "workspace", triggers: [], run: check };',
+    ].join("\n");
+    expect(isImportOnly(source)).toBe(true);
+  });
+
   it("does not treat `if (...)` as a top-level call", () => {
     const source = ["function main() {}", "if (false) { main(); }"].join("\n");
     // Heuristic: `if` is a keyword, not a call. The `main()` inside the

--- a/scripts/lint/cross-file/script-entry-point.test.ts
+++ b/scripts/lint/cross-file/script-entry-point.test.ts
@@ -111,6 +111,20 @@ describe("isImportOnly", () => {
     expect(isImportOnly(source)).toBe(true);
   });
 
+  it("flags an import-only file even when comments mention `process.argv`", () => {
+    const source = [
+      "/**",
+      " * Lint rule. Files matching this shape have no `process.argv` reference",
+      " * and no `import.meta` — they would silently no-op as a CLI.",
+      " */",
+      "// inline comment also mentions process.argv and import.meta.url",
+      'import type { WorkspaceCheck } from "../registry.ts";',
+      "function check() { return []; }",
+      'export const rule: WorkspaceCheck = { kind: "workspace", triggers: [], run: check };',
+    ].join("\n");
+    expect(isImportOnly(source)).toBe(true);
+  });
+
   it("does not treat `if (...)` as a top-level call", () => {
     const source = ["function main() {}", "if (false) { main(); }"].join("\n");
     // Heuristic: `if` is a keyword, not a call. The `main()` inside the

--- a/scripts/lint/cross-file/script-entry-point.ts
+++ b/scripts/lint/cross-file/script-entry-point.ts
@@ -36,9 +36,11 @@ export function extractInvocations(source: string): string[] {
  *  are acceptable; the goal is catching the obvious regression where a file
  *  exports `rule` and runs nothing on direct invocation. */
 export function isImportOnly(source: string): boolean {
-  if (source.includes("process.argv")) return false;
-  if (source.includes("import.meta")) return false;
+  // Strip comments first: a JSDoc line mentioning `process.argv` (this very
+  // file does) would otherwise mask an import-only body.
   const stripped = source.replace(/\/\*[\s\S]*?\*\//g, "").replace(/^\s*\/\/.*$/gm, "");
+  if (stripped.includes("process.argv")) return false;
+  if (stripped.includes("import.meta")) return false;
   // Line at column 0 beginning with an identifier (optionally `.foo` chains)
   // followed by `(`, or with top-level `await`. Excludes leading keywords
   // that take parens but aren't calls (`if`, `for`, `function`, etc.).
@@ -69,7 +71,7 @@ function checkScriptEntryPoint(): ViolationDetail[] {
       if (target === DISPATCHER) continue;
       if (!target.endsWith(".ts")) continue;
       const abs = resolve(REPO_ROOT, target);
-      if (!existsSync(abs)) continue; // config-paths reports missing targets
+      if (!existsSync(abs)) continue; // config-paths reports missing targets across the same surfaces
       let body: string;
       try {
         body = readFileSync(abs, "utf8");

--- a/scripts/lint/cross-file/script-entry-point.ts
+++ b/scripts/lint/cross-file/script-entry-point.ts
@@ -1,0 +1,97 @@
+// Every `node scripts/<x>.ts` invocation in `.github/workflows/*.yml`,
+// `.claude/settings.json`, `package.json`, and `lefthook.yml` must target a
+// file that actually runs when invoked. A lint rule file (exports `rule`, no
+// `main()`, no entry-point guard) silently no-ops when run directly — the
+// regression that motivated this check after #731.
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { lsFiles } from "../../lib/enumerate.ts";
+import { REPO_ROOT } from "../../lib/paths.ts";
+import type { ViolationDetail, WorkspaceCheck } from "../registry.ts";
+
+const CONFIG_FILES = [".claude/settings.json", "package.json", "lefthook.yml"] as const;
+const WORKFLOW_PATHSPEC = ".github/workflows/*.yml";
+
+const TRIGGERS = [...CONFIG_FILES, WORKFLOW_PATHSPEC] as const;
+
+// The unified dispatcher: its entry point lives in `main()` guarded by
+// `process.argv[1] === fileURLToPath(import.meta.url)`. Allowlisted so the
+// heuristic doesn't need to chase that exact shape.
+const DISPATCHER = "scripts/lint/run.ts";
+
+/** Targets of `node <path>` invocations (`<path>` starts with `scripts/`).
+ *  Trailing punctuation from quoting / permission patterns is stripped. */
+export function extractInvocations(source: string): string[] {
+  const out = new Set<string>();
+  for (const match of source.matchAll(/\bnode\s+(scripts\/[\w./-]+)/g)) {
+    const raw = match[1] ?? "";
+    const trimmed = raw.replace(/[.,)*:"]+$/, "");
+    if (trimmed.length > "scripts/".length) out.add(trimmed);
+  }
+  return [...out];
+}
+
+/** A TS file is "import-only" if it has no `process.argv` / `import.meta`
+ *  reference and no top-level call expression. Heuristic — false negatives
+ *  are acceptable; the goal is catching the obvious regression where a file
+ *  exports `rule` and runs nothing on direct invocation. */
+export function isImportOnly(source: string): boolean {
+  if (source.includes("process.argv")) return false;
+  if (source.includes("import.meta")) return false;
+  const stripped = source.replace(/\/\*[\s\S]*?\*\//g, "").replace(/^\s*\/\/.*$/gm, "");
+  // Line at column 0 beginning with an identifier (optionally `.foo` chains)
+  // followed by `(`, or with top-level `await`. Excludes leading keywords
+  // that take parens but aren't calls (`if`, `for`, `function`, etc.).
+  const TOP_LEVEL_CALL =
+    /^(?!(?:import|export|function|class|const|let|var|if|for|while|switch|try|do|type|interface|enum|abstract|declare|namespace|module|return|throw|else|finally|catch)\b)([a-zA-Z_$][\w$]*(?:\.[\w$]+)*\s*\(|await\s)/m;
+  return !TOP_LEVEL_CALL.test(stripped);
+}
+
+function listConfigFiles(): string[] {
+  const out: string[] = [];
+  for (const rel of CONFIG_FILES) {
+    if (existsSync(resolve(REPO_ROOT, rel))) out.push(rel);
+  }
+  out.push(...lsFiles([WORKFLOW_PATHSPEC], REPO_ROOT));
+  return out;
+}
+
+function checkScriptEntryPoint(): ViolationDetail[] {
+  const out: ViolationDetail[] = [];
+  for (const rel of listConfigFiles()) {
+    let source: string;
+    try {
+      source = readFileSync(resolve(REPO_ROOT, rel), "utf8");
+    } catch {
+      continue;
+    }
+    for (const target of extractInvocations(source)) {
+      if (target === DISPATCHER) continue;
+      if (!target.endsWith(".ts")) continue;
+      const abs = resolve(REPO_ROOT, target);
+      if (!existsSync(abs)) continue; // config-paths reports missing targets
+      let body: string;
+      try {
+        body = readFileSync(abs, "utf8");
+      } catch {
+        continue;
+      }
+      if (isImportOnly(body)) {
+        out.push({
+          file: rel,
+          message: `\`node ${target}\` invokes an import-only TS file; the step will silently no-op.`,
+        });
+      }
+    }
+  }
+  return out;
+}
+
+export const rule: WorkspaceCheck = {
+  kind: "workspace",
+  triggers: TRIGGERS,
+  run: checkScriptEntryPoint,
+  hint:
+    "Either add an entry-point guard / top-level call to the script, " +
+    "dispatch it via `node scripts/lint/run.ts --<rule>`, or remove the invocation.",
+};

--- a/scripts/lint/cross-file/script-entry-point.ts
+++ b/scripts/lint/cross-file/script-entry-point.ts
@@ -38,7 +38,7 @@ export function extractInvocations(source: string): string[] {
 export function isImportOnly(source: string): boolean {
   // Strip comments first: a JSDoc line mentioning `process.argv` (this very
   // file does) would otherwise mask an import-only body.
-  const stripped = source.replace(/\/\*[\s\S]*?\*\//g, "").replace(/^\s*\/\/.*$/gm, "");
+  const stripped = source.replace(/\/\*[\s\S]*?\*\//g, "").replace(/\/\/.*$/gm, "");
   if (stripped.includes("process.argv")) return false;
   if (stripped.includes("import.meta")) return false;
   // Line at column 0 beginning with an identifier (optionally `.foo` chains)

--- a/scripts/lint/cross-file/script-entry-point.ts
+++ b/scripts/lint/cross-file/script-entry-point.ts
@@ -12,7 +12,10 @@ import type { ViolationDetail, WorkspaceCheck } from "../registry.ts";
 const CONFIG_FILES = [".claude/settings.json", "package.json", "lefthook.yml"] as const;
 const WORKFLOW_PATHSPEC = ".github/workflows/*.yml";
 
-const TRIGGERS = [...CONFIG_FILES, WORKFLOW_PATHSPEC] as const;
+// Triggers include the *targets* (`scripts/**/*.ts`) too: a script that
+// changes shape to become import-only is the regression we're trying to catch,
+// even when no config invoking it changes in the same commit.
+const TRIGGERS = [...CONFIG_FILES, WORKFLOW_PATHSPEC, "scripts/**/*.ts"] as const;
 
 // The unified dispatcher: its entry point lives in `main()` guarded by
 // `process.argv[1] === fileURLToPath(import.meta.url)`. Allowlisted so the

--- a/scripts/lint/registry.ts
+++ b/scripts/lint/registry.ts
@@ -19,6 +19,7 @@ import { rule as exportsResolve } from "./cross-file/exports-resolve.ts";
 import { rule as labelSync } from "./cross-file/label-sync.ts";
 import { rule as scriptAggregators } from "./cross-file/script-aggregators.ts";
 import { rule as scriptCatalog } from "./cross-file/script-catalog.ts";
+import { rule as scriptEntryPoint } from "./cross-file/script-entry-point.ts";
 import { rule as changeset } from "./diff-aware/changeset.ts";
 import { rule as codegenTests } from "./diff-aware/codegen-tests.ts";
 import { rule as componentCss } from "./file-rules/component-css.ts";
@@ -128,6 +129,7 @@ export const REGISTRY: Readonly<Record<string, Check>> = {
   "transitionable-property": transitionableProperty,
   "script-aggregators": scriptAggregators,
   "script-catalog": scriptCatalog,
+  "script-entry-point": scriptEntryPoint,
   "exports-resolve": exportsResolve,
   "doc-paths": docPaths,
   "contract-snapshots": contractSnapshots,


### PR DESCRIPTION
## What

New cross-file workspace check `script-entry-point` that fails when any `node scripts/<x>.ts` invocation in `.github/workflows/*.yml`, `.claude/settings.json`, `package.json`, or `lefthook.yml` targets an import-only TS file. The dispatcher `scripts/lint/run.ts` is allowlisted.

## Why

After #731 the sync-labels workflow ran `node scripts/lint/cross-file/label-sync.ts` and the step succeeded silently because the file is now import-only (exports `rule`, no `main()`, no entry-point guard). `config-paths` catches stale paths but not this class — the file exists, has no main, runs as a no-op CLI.

## Test plan

- [x] `node scripts/lint/run.ts --script-entry-point` → clean against current repo.
- [x] `pnpm exec vitest run scripts/lint/cross-file/script-entry-point.test.ts` → 15 passing.
- [x] Smoke against real files: `isImportOnly` returns `true` for `label-sync.ts`, `false` for `run.ts`, `sync-labels.ts`, `audit-overrides.ts`, `migrate-specs.ts`.
- [x] `pnpm lint` → clean.
- [x] `pnpm test` → 880 passing.

## Out of scope

- Adding entry-point guards retroactively to existing CLI scripts (the heuristic already accepts them all).
- Extending the rule to `.js` invocations or to other config surfaces.

Closes #735