### PR TITLE
feat(token): tokens-v4 phase 1 — derive spatial tokens from --t-unit + rhythm-tokens lint

### DIFF
--- a/.changeset/tokens-v4-phase-1.md
+++ b/.changeset/tokens-v4-phase-1.md
@@ -1,0 +1,5 @@
+---
+"@teseor/css": minor
+---
+
+Phase 1 of tokens-v4 (RFC-0003). Spatial tokens (`--t-space-*`, `--t-row-*`, `--t-radius-{sm,md,lg,xl}`, `--t-touch-min`) now derive from a single `--t-unit` knob (default `0.25rem`). Resolved values are identical at scale 1. Override `--t-unit` in any subtree to rescale spacing, row heights, radii, and the touch-target floor coherently. New `rhythm-tokens` lint enforces that derived tokens trace to `var(--t-unit)` and that component sizing values read a token or stay on relative units. Tooltip gains a public `--t-tooltip-max-inline-size` slot (was a hardcoded `20rem`).

--- a/apps/docs/src/pages/components/button.astro
+++ b/apps/docs/src/pages/components/button.astro
@@ -188,7 +188,7 @@ import Base from "../../layouts/Base.astro";
       <table>
         <thead><tr><th>Artifact</th><th>Raw</th><th>Gzip</th><th>Brotli</th></tr></thead>
         <tbody>
-        <tr><td><a href="https://github.com/teseor/teseor/blob/main/packages/css/src/components/button/button.css"><Code>@teseor/css/components/button.css</Code></a></td><td>9.41 KB</td><td>1.84 KB</td><td>1.52 KB</td></tr>
+        <tr><td><a href="https://github.com/teseor/teseor/blob/main/packages/css/src/components/button/button.css"><Code>@teseor/css/components/button.css</Code></a></td><td>9.53 KB</td><td>1.84 KB</td><td>1.53 KB</td></tr>
         </tbody>
       </table>
     </section>

--- a/apps/docs/src/pages/components/cluster.astro
+++ b/apps/docs/src/pages/components/cluster.astro
@@ -97,7 +97,7 @@ import Base from "../../layouts/Base.astro";
       <table>
         <thead><tr><th>Artifact</th><th>Raw</th><th>Gzip</th><th>Brotli</th></tr></thead>
         <tbody>
-        <tr><td><a href="https://github.com/teseor/teseor/blob/main/packages/css/src/components/cluster/cluster.css"><Code>@teseor/css/components/cluster.css</Code></a></td><td>9.04 KB</td><td>1.00 KB</td><td>0.76 KB</td></tr>
+        <tr><td><a href="https://github.com/teseor/teseor/blob/main/packages/css/src/components/cluster/cluster.css"><Code>@teseor/css/components/cluster.css</Code></a></td><td>9.13 KB</td><td>1.01 KB</td><td>0.77 KB</td></tr>
         </tbody>
       </table>
     </section>

--- a/apps/docs/src/pages/components/codeblock.astro
+++ b/apps/docs/src/pages/components/codeblock.astro
@@ -46,7 +46,7 @@ import Base from "../../layouts/Base.astro";
       <table>
         <thead><tr><th>Artifact</th><th>Raw</th><th>Gzip</th><th>Brotli</th></tr></thead>
         <tbody>
-        <tr><td><a href="https://github.com/teseor/teseor/blob/main/packages/css/src/components/codeblock/codeblock.css"><Code>@teseor/css/components/codeblock.css</Code></a></td><td>1.16 KB</td><td>0.51 KB</td><td>0.44 KB</td></tr>
+        <tr><td><a href="https://github.com/teseor/teseor/blob/main/packages/css/src/components/codeblock/codeblock.css"><Code>@teseor/css/components/codeblock.css</Code></a></td><td>1.18 KB</td><td>0.52 KB</td><td>0.45 KB</td></tr>
         </tbody>
       </table>
     </section>

--- a/apps/docs/src/pages/components/modal.astro
+++ b/apps/docs/src/pages/components/modal.astro
@@ -74,7 +74,7 @@ import Base from "../../layouts/Base.astro";
       <table>
         <thead><tr><th>Artifact</th><th>Raw</th><th>Gzip</th><th>Brotli</th></tr></thead>
         <tbody>
-        <tr><td><a href="https://github.com/teseor/teseor/blob/main/packages/css/src/components/modal/modal.css"><Code>@teseor/css/components/modal.css</Code></a></td><td>1.34 KB</td><td>0.57 KB</td><td>0.48 KB</td></tr>
+        <tr><td><a href="https://github.com/teseor/teseor/blob/main/packages/css/src/components/modal/modal.css"><Code>@teseor/css/components/modal.css</Code></a></td><td>1.36 KB</td><td>0.58 KB</td><td>0.51 KB</td></tr>
         </tbody>
       </table>
     </section>

--- a/apps/docs/src/pages/components/stack.astro
+++ b/apps/docs/src/pages/components/stack.astro
@@ -88,7 +88,7 @@ import Base from "../../layouts/Base.astro";
       <table>
         <thead><tr><th>Artifact</th><th>Raw</th><th>Gzip</th><th>Brotli</th></tr></thead>
         <tbody>
-        <tr><td><a href="https://github.com/teseor/teseor/blob/main/packages/css/src/components/stack/stack.css"><Code>@teseor/css/components/stack.css</Code></a></td><td>6.40 KB</td><td>0.77 KB</td><td>0.61 KB</td></tr>
+        <tr><td><a href="https://github.com/teseor/teseor/blob/main/packages/css/src/components/stack/stack.css"><Code>@teseor/css/components/stack.css</Code></a></td><td>6.49 KB</td><td>0.78 KB</td><td>0.62 KB</td></tr>
         </tbody>
       </table>
     </section>

--- a/apps/docs/src/pages/components/tooltip.astro
+++ b/apps/docs/src/pages/components/tooltip.astro
@@ -99,6 +99,7 @@ import Base from "../../layouts/Base.astro";
         <tr><td><Code>--t-tooltip-font-size</Code></td><td><Code>--t-text-sm</Code></td><td>Font size for tooltip body text.</td></tr>
         <tr><td><Code>--t-tooltip-arrow-size</Code></td><td><Code>--t-space-3</Code></td><td>Arrow square size. Rotated 45° to form the pointer; visible triangle is roughly size/√2 tall.</td></tr>
         <tr><td><Code>--t-tooltip-arrow-bg</Code></td><td><Code>--t-surface-inverse</Code></td><td>Arrow fill. Defaults to the same surface as `bg` so the arrow blends seamlessly with the body.</td></tr>
+        <tr><td><Code>--t-tooltip-max-inline-size</Code></td><td><Code>20rem</Code></td><td>Maximum tooltip width. Wraps long content; the default is 320px which lands on the spatial grid.</td></tr>
         </tbody>
       </table>
     </section>
@@ -129,7 +130,7 @@ import Base from "../../layouts/Base.astro";
       <table>
         <thead><tr><th>Artifact</th><th>Raw</th><th>Gzip</th><th>Brotli</th></tr></thead>
         <tbody>
-        <tr><td><a href="https://github.com/teseor/teseor/blob/main/packages/css/src/components/tooltip/tooltip.css"><Code>@teseor/css/components/tooltip.css</Code></a></td><td>11.81 KB</td><td>2.04 KB</td><td>1.67 KB</td></tr>
+        <tr><td><a href="https://github.com/teseor/teseor/blob/main/packages/css/src/components/tooltip/tooltip.css"><Code>@teseor/css/components/tooltip.css</Code></a></td><td>11.93 KB</td><td>2.06 KB</td><td>1.68 KB</td></tr>
         </tbody>
       </table>
     </section>

--- a/apps/docs/src/pages/components/tooltip.astro
+++ b/apps/docs/src/pages/components/tooltip.astro
@@ -99,7 +99,7 @@ import Base from "../../layouts/Base.astro";
         <tr><td><Code>--t-tooltip-font-size</Code></td><td><Code>--t-text-sm</Code></td><td>Font size for tooltip body text.</td></tr>
         <tr><td><Code>--t-tooltip-arrow-size</Code></td><td><Code>--t-space-3</Code></td><td>Arrow square size. Rotated 45° to form the pointer; visible triangle is roughly size/√2 tall.</td></tr>
         <tr><td><Code>--t-tooltip-arrow-bg</Code></td><td><Code>--t-surface-inverse</Code></td><td>Arrow fill. Defaults to the same surface as `bg` so the arrow blends seamlessly with the body.</td></tr>
-        <tr><td><Code>--t-tooltip-max-inline-size</Code></td><td><Code>20rem</Code></td><td>Maximum tooltip width. Wraps long content; the default is 320px which lands on the spatial grid.</td></tr>
+        <tr><td><Code>--t-tooltip-max-inline-size</Code></td><td><Code>20rem</Code></td><td>Maximum tooltip width. Wraps long content beyond this measure.</td></tr>
         </tbody>
       </table>
     </section>

--- a/packages/css/src/components/tooltip/tooltip.css
+++ b/packages/css/src/components/tooltip/tooltip.css
@@ -13,6 +13,7 @@
     --_dur: var(--t-tooltip-dur, var(--t-dur-fast));
     --_ease: var(--t-tooltip-ease, var(--t-ease-out));
     --_font-size: var(--t-tooltip-font-size, var(--t-text-sm));
+    --_max-inline-size: var(--t-tooltip-max-inline-size, 20rem);
     --_motion-scale: var(--t-motion-scale);
     --_arrow-size: var(--t-tooltip-arrow-size, var(--t-space-3));
     --_arrow-bg: var(--t-tooltip-arrow-bg, var(--t-surface-inverse));
@@ -63,7 +64,7 @@
     font: inherit;
     font-size: var(--_font-size);
     line-height: 1.4;
-    max-inline-size: 20rem;
+    max-inline-size: var(--_max-inline-size);
     pointer-events: none;
     display: var(--_display);
     position-anchor: var(--_anchor);

--- a/packages/css/src/tokens.css
+++ b/packages/css/src/tokens.css
@@ -77,22 +77,30 @@
     --t-info-800: oklch(35% 0.12 210deg);
     --t-info-900: oklch(25% 0.09 210deg);
 
-    /* ===== Spacing — 4px-based modular ladder ===== */
+    /* ===== Grid unit — sole knob for the spatial system =====
+
+       Every spatial token derives from --t-unit via calc(). Override --t-unit
+       in any subtree to rescale spacing, row heights, radii, and the
+       touch-target floor coherently. Type and leading derive in Phase 2
+       (#804); they shift the rhythm story and are deferred together. */
+    --t-unit: 0.25rem;
+
+    /* ===== Spacing — curated non-linear ladder (multipliers 0, 1..4, 6, 8, 12, 16) ===== */
     --t-space-0: 0;
-    --t-space-1: 0.25rem;
-    --t-space-2: 0.5rem;
-    --t-space-3: 0.75rem;
-    --t-space-4: 1rem;
-    --t-space-5: 1.5rem;
-    --t-space-6: 2rem;
-    --t-space-7: 3rem;
-    --t-space-8: 4rem;
+    --t-space-1: var(--t-unit); /*  4px */
+    --t-space-2: calc(var(--t-unit) * 2); /*  8px */
+    --t-space-3: calc(var(--t-unit) * 3); /* 12px */
+    --t-space-4: calc(var(--t-unit) * 4); /* 16px */
+    --t-space-5: calc(var(--t-unit) * 6); /* 24px */
+    --t-space-6: calc(var(--t-unit) * 8); /* 32px */
+    --t-space-7: calc(var(--t-unit) * 12); /* 48px */
+    --t-space-8: calc(var(--t-unit) * 16); /* 64px */
 
     /* ===== Row heights (touch-friendly) ===== */
-    --t-row-1: 1.5rem;
-    --t-row-2: 2rem;
-    --t-row-3: 2.5rem;
-    --t-row-4: 3rem;
+    --t-row-1: calc(var(--t-unit) * 6); /* 24px */
+    --t-row-2: calc(var(--t-unit) * 8); /* 32px */
+    --t-row-3: calc(var(--t-unit) * 10); /* 40px */
+    --t-row-4: calc(var(--t-unit) * 12); /* 48px */
 
     /* ===== Typography — ratio 1.125, base = 1rem ===== */
     --t-text-xs: 0.79rem;
@@ -118,10 +126,10 @@
 
     /* ===== Radius ===== */
     --t-radius-none: 0;
-    --t-radius-sm: 0.25rem;
-    --t-radius-md: 0.5rem;
-    --t-radius-lg: 0.75rem;
-    --t-radius-xl: 1rem;
+    --t-radius-sm: var(--t-unit); /*  4px */
+    --t-radius-md: calc(var(--t-unit) * 2); /*  8px */
+    --t-radius-lg: calc(var(--t-unit) * 3); /* 12px */
+    --t-radius-xl: calc(var(--t-unit) * 4); /* 16px */
     --t-radius-full: 9999px;
 
     /* ===== Shadows — oklch with alpha so they reskin with theme ===== */
@@ -162,10 +170,11 @@
 
     /* ===== Touch target (accessibility floor) ===== */
 
-    /* 44px @ 16px root — the WCAG 2.5.5 floor for interactive controls.
+    /* 44px @ 16px root — interactive-control floor.
+       Matches WCAG 2.5.5 (AAA Target Size Enhanced); stricter than AA 2.5.8 (24px).
        `--t-row` (control-height shorthand) clamps to this so a compact
        density can never shrink an interactive root below the floor. */
-    --t-touch-min: 2.75rem;
+    --t-touch-min: calc(var(--t-unit) * 11);
 
     /* ===== Z-index ===== */
     --t-z-base: 0;

--- a/packages/css/src/tokens.css
+++ b/packages/css/src/tokens.css
@@ -170,10 +170,10 @@
 
     /* ===== Touch target (accessibility floor) ===== */
 
-    /* 44px @ 16px root — interactive-control floor.
+    /* 44px @ 16px root — minimum touch-target token for interactive controls.
        Matches WCAG 2.5.5 (AAA Target Size Enhanced); stricter than AA 2.5.8 (24px).
-       `--t-row` (control-height shorthand) clamps to this so a compact
-       density can never shrink an interactive root below the floor. */
+       This token is available for components or semantic aliases to opt into
+       when they need to enforce a minimum interactive size. */
     --t-touch-min: calc(var(--t-unit) * 11);
 
     /* ===== Z-index ===== */

--- a/scripts/codegen/__tests__/__snapshots__/gen-docs.test.ts.snap
+++ b/scripts/codegen/__tests__/__snapshots__/gen-docs.test.ts.snap
@@ -464,7 +464,7 @@ import Base from "../../layouts/Base.astro";
         <tr><td><Code>--t-tooltip-font-size</Code></td><td><Code>--t-text-sm</Code></td><td>Font size for tooltip body text.</td></tr>
         <tr><td><Code>--t-tooltip-arrow-size</Code></td><td><Code>--t-space-3</Code></td><td>Arrow square size. Rotated 45° to form the pointer; visible triangle is roughly size/√2 tall.</td></tr>
         <tr><td><Code>--t-tooltip-arrow-bg</Code></td><td><Code>--t-surface-inverse</Code></td><td>Arrow fill. Defaults to the same surface as \`bg\` so the arrow blends seamlessly with the body.</td></tr>
-        <tr><td><Code>--t-tooltip-max-inline-size</Code></td><td><Code>20rem</Code></td><td>Maximum tooltip width. Wraps long content; the default is 320px which lands on the spatial grid.</td></tr>
+        <tr><td><Code>--t-tooltip-max-inline-size</Code></td><td><Code>20rem</Code></td><td>Maximum tooltip width. Wraps long content beyond this measure.</td></tr>
         </tbody>
       </table>
     </section>

--- a/scripts/codegen/__tests__/__snapshots__/gen-docs.test.ts.snap
+++ b/scripts/codegen/__tests__/__snapshots__/gen-docs.test.ts.snap
@@ -464,6 +464,7 @@ import Base from "../../layouts/Base.astro";
         <tr><td><Code>--t-tooltip-font-size</Code></td><td><Code>--t-text-sm</Code></td><td>Font size for tooltip body text.</td></tr>
         <tr><td><Code>--t-tooltip-arrow-size</Code></td><td><Code>--t-space-3</Code></td><td>Arrow square size. Rotated 45° to form the pointer; visible triangle is roughly size/√2 tall.</td></tr>
         <tr><td><Code>--t-tooltip-arrow-bg</Code></td><td><Code>--t-surface-inverse</Code></td><td>Arrow fill. Defaults to the same surface as \`bg\` so the arrow blends seamlessly with the body.</td></tr>
+        <tr><td><Code>--t-tooltip-max-inline-size</Code></td><td><Code>20rem</Code></td><td>Maximum tooltip width. Wraps long content; the default is 320px which lands on the spatial grid.</td></tr>
         </tbody>
       </table>
     </section>

--- a/scripts/lint/file-rules/rhythm-tokens.test.ts
+++ b/scripts/lint/file-rules/rhythm-tokens.test.ts
@@ -48,6 +48,14 @@ describe("isAcceptableSizingValue", () => {
   it("rejects raw px even mixed with tokens absent", () => {
     expect(isAcceptableSizingValue("8px 16px")).toBe(false);
   });
+
+  it("rejects a token mixed with a raw rem literal in calc()", () => {
+    expect(isAcceptableSizingValue("calc(var(--t-space-2) + 1rem)")).toBe(false);
+  });
+
+  it("rejects a token mixed with a raw px literal in shorthand", () => {
+    expect(isAcceptableSizingValue("var(--t-space-2) 8px")).toBe(false);
+  });
 });
 
 describe("findRhythmViolations — tokens.css", () => {
@@ -97,6 +105,16 @@ describe("findRhythmViolations — tokens.css", () => {
       --t-leading-normal: 1.5;
     }`;
     expect(findRhythmViolations(tokens, noComponents)).toEqual([]);
+  });
+
+  it("rejects a derived token whose value traces to a similarly-named non-unit token", () => {
+    const tokens = `:root {
+      --t-unit-foo: 0.5rem;
+      --t-space-3: var(--t-unit-foo);
+    }`;
+    const violations = findRhythmViolations(tokens, noComponents);
+    expect(violations).toHaveLength(1);
+    expect(violations[0]?.message).toContain("--t-space-3");
   });
 });
 

--- a/scripts/lint/file-rules/rhythm-tokens.test.ts
+++ b/scripts/lint/file-rules/rhythm-tokens.test.ts
@@ -56,6 +56,11 @@ describe("isAcceptableSizingValue", () => {
   it("rejects a token mixed with a raw px literal in shorthand", () => {
     expect(isAcceptableSizingValue("var(--t-space-2) 8px")).toBe(false);
   });
+
+  it("accepts a literal sitting inside a var() fallback (idiomatic floor pattern)", () => {
+    expect(isAcceptableSizingValue("var(--t-tooltip-max-inline-size, 20rem)")).toBe(true);
+    expect(isAcceptableSizingValue("var(--t-x, var(--t-y, 10rem))")).toBe(true);
+  });
 });
 
 describe("findRhythmViolations — tokens.css", () => {
@@ -154,5 +159,47 @@ describe("findRhythmViolations — component CSS", () => {
       box-shadow: 0 1px 2px black;
     }`;
     expect(findRhythmViolations(tokens, [{ name: "x", rel: "x.css", css }])).toEqual([]);
+  });
+
+  it("flags raw px/rem hidden in a --_* slot referenced by a sizing prop", () => {
+    const css = `.t-x {
+      --_pad-x: 13px;
+      padding-inline: var(--_pad-x);
+    }`;
+    const violations = findRhythmViolations(tokens, [{ name: "x", rel: "x.css", css }]);
+    expect(violations).toHaveLength(1);
+    expect(violations[0]?.message).toContain("padding-inline");
+  });
+
+  it("flags raw px hidden in a modifier-reassigned slot", () => {
+    const css = `.t-x {
+      --_pad-x: var(--t-space-3);
+      padding-inline: var(--_pad-x);
+      &[data-size="lg"] {
+        --_pad-x: 17px;
+      }
+    }`;
+    expect(findRhythmViolations(tokens, [{ name: "x", rel: "x.css", css }])).toHaveLength(1);
+  });
+
+  it("accepts a slot whose every declaration routes through a token", () => {
+    const css = `.t-x {
+      --_pad-x: var(--t-space-3);
+      padding-inline: var(--_pad-x);
+      &[data-size="lg"] {
+        --_pad-x: var(--t-space-4);
+      }
+    }`;
+    expect(findRhythmViolations(tokens, [{ name: "x", rel: "x.css", css }])).toEqual([]);
+  });
+
+  it("does not loop on a self-referential --_* graph", () => {
+    const css = `.t-x {
+      --_a: var(--_b);
+      --_b: var(--_a);
+      padding-inline: var(--_a);
+    }`;
+    // Should terminate; whether it flags or accepts is secondary to "doesn't hang".
+    expect(() => findRhythmViolations(tokens, [{ name: "x", rel: "x.css", css }])).not.toThrow();
   });
 });

--- a/scripts/lint/file-rules/rhythm-tokens.test.ts
+++ b/scripts/lint/file-rules/rhythm-tokens.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from "vitest";
+import { findRhythmViolations, isAcceptableSizingValue } from "./rhythm-tokens.ts";
+
+describe("isAcceptableSizingValue", () => {
+  it("accepts var(--t-*) refs", () => {
+    expect(isAcceptableSizingValue("var(--t-space-3)")).toBe(true);
+    expect(isAcceptableSizingValue("var(--t-row-2)")).toBe(true);
+  });
+
+  it("accepts calc() over a token", () => {
+    expect(isAcceptableSizingValue("calc(var(--t-space-3) * 2)")).toBe(true);
+  });
+
+  it("accepts var(--_*) slot refs (component-css governs the slot value)", () => {
+    expect(isAcceptableSizingValue("var(--_pad-x)")).toBe(true);
+    expect(isAcceptableSizingValue("var(--_arrow-inset)")).toBe(true);
+  });
+
+  it("accepts shorthand mixing tokens and zero", () => {
+    expect(isAcceptableSizingValue("0 var(--t-space-3)")).toBe(true);
+    expect(isAcceptableSizingValue("0 0 var(--_gap) 0")).toBe(true);
+  });
+
+  it("accepts pure keywords", () => {
+    expect(isAcceptableSizingValue("0")).toBe(true);
+    expect(isAcceptableSizingValue("auto")).toBe(true);
+    expect(isAcceptableSizingValue("0 auto")).toBe(true);
+    expect(isAcceptableSizingValue("none")).toBe(true);
+  });
+
+  it("accepts relative units (em, lh, %, vh)", () => {
+    expect(isAcceptableSizingValue("1em")).toBe(true);
+    expect(isAcceptableSizingValue("1.5lh")).toBe(true);
+    expect(isAcceptableSizingValue("100%")).toBe(true);
+    expect(isAcceptableSizingValue("50vh")).toBe(true);
+    expect(isAcceptableSizingValue("100dvh")).toBe(true);
+  });
+
+  it("rejects raw px in sizing context", () => {
+    expect(isAcceptableSizingValue("13px")).toBe(false);
+    expect(isAcceptableSizingValue("0.5rem 1rem")).toBe(false);
+  });
+
+  it("rejects raw rem", () => {
+    expect(isAcceptableSizingValue("20rem")).toBe(false);
+  });
+
+  it("rejects raw px even mixed with tokens absent", () => {
+    expect(isAcceptableSizingValue("8px 16px")).toBe(false);
+  });
+});
+
+describe("findRhythmViolations — tokens.css", () => {
+  const noComponents: { name: string; rel: string; css: string }[] = [];
+
+  it("accepts derived spatial tokens routed through var(--t-unit)", () => {
+    const tokens = `:root {
+      --t-unit: 0.25rem;
+      --t-space-1: var(--t-unit);
+      --t-space-5: calc(var(--t-unit) * 6);
+      --t-row-2: calc(var(--t-unit) * 8);
+      --t-touch-min: calc(var(--t-unit) * 11);
+      --t-radius-sm: var(--t-unit);
+    }`;
+    expect(findRhythmViolations(tokens, noComponents)).toEqual([]);
+  });
+
+  it("accepts literal non-derived tokens (--t-space-0, --t-radius-none, --t-radius-full)", () => {
+    const tokens = `:root {
+      --t-space-0: 0;
+      --t-radius-none: 0;
+      --t-radius-full: 9999px;
+    }`;
+    expect(findRhythmViolations(tokens, noComponents)).toEqual([]);
+  });
+
+  it("flags a derived spatial token declared with a literal", () => {
+    const tokens = `:root {
+      --t-space-3: 0.75rem;
+    }`;
+    const violations = findRhythmViolations(tokens, noComponents);
+    expect(violations).toHaveLength(1);
+    expect(violations[0]?.message).toContain("--t-space-3");
+    expect(violations[0]?.message).toContain("var(--t-unit)");
+  });
+
+  it("flags a derived radius declared without var(--t-unit)", () => {
+    const tokens = `:root {
+      --t-radius-md: 0.5rem;
+    }`;
+    expect(findRhythmViolations(tokens, noComponents)).toHaveLength(1);
+  });
+
+  it("does not check --t-text-* or --t-leading-* (Phase 2)", () => {
+    const tokens = `:root {
+      --t-text-base: 1rem;
+      --t-leading-normal: 1.5;
+    }`;
+    expect(findRhythmViolations(tokens, noComponents)).toEqual([]);
+  });
+});
+
+describe("findRhythmViolations — component CSS", () => {
+  const tokens = ":root { --t-unit: 0.25rem; }";
+
+  it("accepts a component that routes every sizing value through a token", () => {
+    const css = `.t-x {
+      padding-inline: var(--_pad-x);
+      padding-block: 0;
+      gap: var(--_gap);
+      block-size: var(--_h);
+      inline-size: 1em;
+      margin: 0;
+    }`;
+    expect(findRhythmViolations(tokens, [{ name: "x", rel: "x.css", css }])).toEqual([]);
+  });
+
+  it("flags a raw rem on a sizing property", () => {
+    const css = ".t-x { max-inline-size: 20rem; }";
+    const violations = findRhythmViolations(tokens, [{ name: "x", rel: "x.css", css }]);
+    expect(violations).toHaveLength(1);
+    expect(violations[0]?.message).toContain("max-inline-size");
+    expect(violations[0]?.message).toContain("20rem");
+  });
+
+  it("flags a raw px on a sizing property", () => {
+    const css = ".t-x { padding-inline: 13px; }";
+    expect(findRhythmViolations(tokens, [{ name: "x", rel: "x.css", css }])).toHaveLength(1);
+  });
+
+  it("ignores non-sizing properties (font-size, border-width, outline-offset)", () => {
+    const css = `.t-x {
+      font-size: 14px;
+      border-width: 1px;
+      outline-offset: 2px;
+      box-shadow: 0 1px 2px black;
+    }`;
+    expect(findRhythmViolations(tokens, [{ name: "x", rel: "x.css", css }])).toEqual([]);
+  });
+});

--- a/scripts/lint/file-rules/rhythm-tokens.ts
+++ b/scripts/lint/file-rules/rhythm-tokens.ts
@@ -1,8 +1,13 @@
 // Enforces the unit-derived spatial system (RFC-0003 / #803):
 //   1. Every derived spatial token in tokens.css traces to `var(--t-unit)`.
-//   2. Every sizing-property value in component CSS reads a token
-//      (`var(--t-*)` or `var(--_*)`) or stays on a relative unit
-//      (em / lh / %). Raw px / rem literals in sizing positions are rejected.
+//   2. Every sizing-property value in component CSS contains no raw `px` /
+//      `rem` literal outside of `var(...)` fallback positions. The rule
+//      transitively follows every `var(--_*)` reference, so a literal hidden
+//      in a private slot (including a modifier-reassigned slot) is still
+//      caught. All other unit types — keywords (`auto`, `none`, `fit-content`,
+//      …), zero, percentages, em / lh / fr / ch / ex, and viewport / container
+//      units (`vh`, `vw`, `sv*`, `lv*`, `dv*`, `cq*`) — are allowed; the rule
+//      treats them as relative or context-bound rather than as drift.
 //
 // Out of scope (Phase 2 / #804): text-size and leading. The rule deliberately
 // does not constrain `font-size` / `line-height`.

--- a/scripts/lint/file-rules/rhythm-tokens.ts
+++ b/scripts/lint/file-rules/rhythm-tokens.ts
@@ -85,19 +85,17 @@ function isDerivedSpatialToken(prop: string): boolean {
 }
 
 /**
- * Sizing-property values must either reference a token (--t-* or --_*) or
- * use no absolute length. Returns true when the value is acceptable.
- *
- * Algorithm: if it contains var(--t-*) or var(--_*) anywhere, accept.
- * Otherwise, no Npx / Nrem literals may appear. Relative units (em, lh, %,
- * vh, vw, svh, lvh, dvh, cqi, cqb, fr, ch, ex) and keywords stay legal.
+ * Sizing-property values must not contain raw absolute lengths. A `var(--t-*)`
+ * or `var(--_*)` reference does not excuse a literal in the same value —
+ * `calc(var(--t-space-2) + 1rem)` and `var(--t-space-2) 8px` both fail.
+ * Relative units (em, lh, %, vh, vw, svh, lvh, dvh, cqi, cqb, fr, ch, ex) and
+ * keywords stay legal.
  */
 export function isAcceptableSizingValue(value: string): boolean {
-  if (/var\(\s*--t-[\w-]+/.test(value)) return true;
-  if (/var\(\s*--_[\w-]+/.test(value)) return true;
-  // No tokens — flag if any non-zero px / rem literal appears.
-  // The regex looks for a number (int/decimal) followed by px or rem, with
-  // a non-word boundary before it (so `1.25emm` won't trip).
+  // Any non-zero px / rem literal at a token-boundary position fails. The
+  // regex looks for a number (int/decimal) followed by px or rem, preceded
+  // by a value-boundary character so `1.25emm` won't trip and `--_foopx`
+  // (custom-property name) won't either.
   return !/(?:^|[\s,(/*+-])-?\d*\.?\d+(?:px|rem)\b/.test(value);
 }
 
@@ -114,7 +112,9 @@ export function findRhythmViolations(
     // `0` is the only literal that's legitimately equivalent to a zero-unit
     // derivation — covers `--t-space-0`.
     if (decl.value.trim() === "0") return;
-    if (/var\(\s*--t-unit\b/.test(decl.value)) return;
+    // Match the var(...) shape with a precise terminator so `var(--t-unit-foo)`
+    // does not falsely satisfy a `--t-unit` trace. Mirrors motion-scale.ts.
+    if (/var\(\s*--t-unit\s*[,)]/.test(decl.value)) return;
     out.push({
       file: "packages/css/src/tokens.css",
       line: decl.source?.start?.line,

--- a/scripts/lint/file-rules/rhythm-tokens.ts
+++ b/scripts/lint/file-rules/rhythm-tokens.ts
@@ -1,0 +1,163 @@
+// Enforces the unit-derived spatial system (RFC-0003 / #803):
+//   1. Every derived spatial token in tokens.css traces to `var(--t-unit)`.
+//   2. Every sizing-property value in component CSS reads a token
+//      (`var(--t-*)` or `var(--_*)`) or stays on a relative unit
+//      (em / lh / %). Raw px / rem literals in sizing positions are rejected.
+//
+// Out of scope (Phase 2 / #804): text-size and leading. The rule deliberately
+// does not constrain `font-size` / `line-height`.
+import { readdirSync, readFileSync } from "node:fs";
+import { relative, resolve } from "node:path";
+import postcss from "postcss";
+import postcssEach from "postcss-each";
+import { REPO_ROOT } from "../../lib/paths.ts";
+import type { ViolationDetail, WorkspaceCheck } from "../registry.ts";
+
+const SIZING_PROPS = new Set([
+  // padding
+  "padding",
+  "padding-block",
+  "padding-inline",
+  "padding-top",
+  "padding-right",
+  "padding-bottom",
+  "padding-left",
+  "padding-block-start",
+  "padding-block-end",
+  "padding-inline-start",
+  "padding-inline-end",
+  // margin
+  "margin",
+  "margin-block",
+  "margin-inline",
+  "margin-top",
+  "margin-right",
+  "margin-bottom",
+  "margin-left",
+  "margin-block-start",
+  "margin-block-end",
+  "margin-inline-start",
+  "margin-inline-end",
+  // gap
+  "gap",
+  "row-gap",
+  "column-gap",
+  // sizing
+  "height",
+  "width",
+  "block-size",
+  "inline-size",
+  "min-height",
+  "max-height",
+  "min-width",
+  "max-width",
+  "min-block-size",
+  "max-block-size",
+  "min-inline-size",
+  "max-inline-size",
+  // position offsets
+  "top",
+  "right",
+  "bottom",
+  "left",
+  "inset",
+  "inset-block",
+  "inset-inline",
+  "inset-block-start",
+  "inset-block-end",
+  "inset-inline-start",
+  "inset-inline-end",
+]);
+
+// Tokens.css declarations that must derive from --t-unit. The literal-OK set
+// catches deliberate non-grid constants (`0`, `9999px` for `--t-radius-full`).
+const DERIVED_TOKEN_PREFIXES = ["--t-space-", "--t-row-", "--t-touch-"];
+const DERIVED_RADIUS = new Set([
+  "--t-radius-sm",
+  "--t-radius-md",
+  "--t-radius-lg",
+  "--t-radius-xl",
+]);
+
+function isDerivedSpatialToken(prop: string): boolean {
+  if (DERIVED_RADIUS.has(prop)) return true;
+  return DERIVED_TOKEN_PREFIXES.some((p) => prop.startsWith(p));
+}
+
+/**
+ * Sizing-property values must either reference a token (--t-* or --_*) or
+ * use no absolute length. Returns true when the value is acceptable.
+ *
+ * Algorithm: if it contains var(--t-*) or var(--_*) anywhere, accept.
+ * Otherwise, no Npx / Nrem literals may appear. Relative units (em, lh, %,
+ * vh, vw, svh, lvh, dvh, cqi, cqb, fr, ch, ex) and keywords stay legal.
+ */
+export function isAcceptableSizingValue(value: string): boolean {
+  if (/var\(\s*--t-[\w-]+/.test(value)) return true;
+  if (/var\(\s*--_[\w-]+/.test(value)) return true;
+  // No tokens — flag if any non-zero px / rem literal appears.
+  // The regex looks for a number (int/decimal) followed by px or rem, with
+  // a non-word boundary before it (so `1.25emm` won't trip).
+  return !/(?:^|[\s,(/*+-])-?\d*\.?\d+(?:px|rem)\b/.test(value);
+}
+
+export function findRhythmViolations(
+  tokensCss: string,
+  components: ReadonlyArray<{ name: string; rel: string; css: string }>,
+): ViolationDetail[] {
+  const out: ViolationDetail[] = [];
+
+  // (1) tokens.css: every derived spatial token traces to var(--t-unit).
+  const tokensRoot = postcss.parse(tokensCss);
+  tokensRoot.walkDecls((decl) => {
+    if (!isDerivedSpatialToken(decl.prop)) return;
+    // `0` is the only literal that's legitimately equivalent to a zero-unit
+    // derivation — covers `--t-space-0`.
+    if (decl.value.trim() === "0") return;
+    if (/var\(\s*--t-unit\b/.test(decl.value)) return;
+    out.push({
+      file: "packages/css/src/tokens.css",
+      line: decl.source?.start?.line,
+      message: `\`${decl.prop}: ${decl.value}\` — derived spatial tokens must trace to \`var(--t-unit)\``,
+    });
+  });
+
+  // (2) component CSS: sizing-property values use tokens or relative units.
+  for (const { rel, css } of components) {
+    const root = postcss([postcssEach()]).process(css, { from: undefined }).root;
+    root.walkDecls((decl) => {
+      if (!SIZING_PROPS.has(decl.prop)) return;
+      if (isAcceptableSizingValue(decl.value)) return;
+      out.push({
+        file: rel,
+        line: decl.source?.start?.line,
+        message: `\`${decl.prop}: ${decl.value}\` — sizing values must read \`var(--t-*)\` / \`var(--_*)\` or stay on relative units (em, lh, %)`,
+      });
+    });
+  }
+
+  return out;
+}
+
+function runRule(): ViolationDetail[] {
+  const tokensFile = resolve(REPO_ROOT, "packages/css/src/tokens.css");
+  const componentsDir = resolve(REPO_ROOT, "packages/css/src/components");
+  const components: { name: string; rel: string; css: string }[] = [];
+  for (const entry of readdirSync(componentsDir, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    const file = resolve(componentsDir, entry.name, `${entry.name}.css`);
+    components.push({
+      name: entry.name,
+      rel: relative(REPO_ROOT, file),
+      css: readFileSync(file, "utf8"),
+    });
+  }
+  return findRhythmViolations(readFileSync(tokensFile, "utf8"), components);
+}
+
+export const rule: WorkspaceCheck = {
+  kind: "workspace",
+  triggers: ["packages/css/src/tokens.css", "packages/css/src/components/**/*.css"],
+  run: runRule,
+  hint: "Derive spatial tokens from --t-unit; route sizing values through --t-* or --_* tokens.",
+};

--- a/scripts/lint/file-rules/rhythm-tokens.ts
+++ b/scripts/lint/file-rules/rhythm-tokens.ts
@@ -84,20 +84,45 @@ function isDerivedSpatialToken(prop: string): boolean {
   return DERIVED_TOKEN_PREFIXES.some((p) => prop.startsWith(p));
 }
 
+/** Strip every `var(...)` call (including its fallback) from a CSS value.
+ *  Balanced-paren aware so nested `var(var(...))` is removed as a unit. */
+function stripVarCalls(value: string): string {
+  let out = "";
+  let i = 0;
+  while (i < value.length) {
+    if (value.startsWith("var(", i)) {
+      let depth = 1;
+      let j = i + 4;
+      while (j < value.length && depth > 0) {
+        if (value[j] === "(") depth++;
+        else if (value[j] === ")") depth--;
+        j++;
+      }
+      i = j;
+    } else {
+      out += value[i];
+      i++;
+    }
+  }
+  return out;
+}
+
 /**
- * Sizing-property values must not contain raw absolute lengths. A `var(--t-*)`
- * or `var(--_*)` reference does not excuse a literal in the same value —
- * `calc(var(--t-space-2) + 1rem)` and `var(--t-space-2) 8px` both fail.
- * Relative units (em, lh, %, vh, vw, svh, lvh, dvh, cqi, cqb, fr, ch, ex) and
- * keywords stay legal.
+ * Sizing-property values must not contain raw absolute lengths *outside* of
+ * `var()` fallback positions. `var(--t-x, 20rem)` is the project's idiomatic
+ * floor pattern (allowed); `calc(var(--t-space-2) + 1rem)` and
+ * `var(--t-space-2) 8px` keep failing because the literal sits at the
+ * top level (or inside a `calc()`), not inside a `var()`. Relative units
+ * (em, lh, %, vh, vw, svh, lvh, dvh, cqi, cqb, fr, ch, ex) and keywords
+ * stay legal.
  */
 export function isAcceptableSizingValue(value: string): boolean {
-  // Any px / rem literal (including `0px` / `0rem`) at a token-boundary
-  // position fails — the convention is bare `0`. The regex looks for a
-  // number (int/decimal) followed by px or rem, preceded by a value-boundary
-  // character so `1.25emm` won't trip and `--_foopx` (custom-property name)
-  // won't either.
-  return !/(?:^|[\s,(/*+-])-?\d*\.?\d+(?:px|rem)\b/.test(value);
+  // Strip `var(...)` calls first so fallback literals don't trigger the check.
+  // Any px / rem literal (including `0px`) in the residue fails — convention
+  // is bare `0`. Preceded by a value-boundary character so `1.25emm` won't
+  // trip and `--_foopx` (custom-property name) won't either.
+  const residue = stripVarCalls(value);
+  return !/(?:^|[\s,(/*+-])-?\d*\.?\d+(?:px|rem)\b/.test(residue);
 }
 
 export function findRhythmViolations(
@@ -124,20 +149,54 @@ export function findRhythmViolations(
   });
 
   // (2) component CSS: sizing-property values use tokens or relative units.
+  //     The check follows `var(--_*)` references transitively (motion-scale
+  //     pattern) so a slot reassigned to a literal — e.g. `--_pad-x: 13px` in
+  //     a [data-size="lg"] modifier — fails even though the use site reads a
+  //     legitimate `var(--_pad-x)`.
   for (const { rel, css } of components) {
     const root = postcss([postcssEach()]).process(css, { from: undefined }).root;
+    const slotValues = new Map<string, string[]>();
+    root.walkDecls(/^--_/, (decl) => {
+      const list = slotValues.get(decl.prop) ?? [];
+      list.push(decl.value);
+      slotValues.set(decl.prop, list);
+    });
+
     root.walkDecls((decl) => {
       if (!SIZING_PROPS.has(decl.prop)) return;
-      if (isAcceptableSizingValue(decl.value)) return;
+      if (isAcceptableSizingValueDeep(decl.value, slotValues, new Set())) return;
       out.push({
         file: rel,
         line: decl.source?.start?.line,
-        message: `\`${decl.prop}: ${decl.value}\` — sizing values must read \`var(--t-*)\` / \`var(--_*)\` or stay on relative units (em, lh, %, vh / vw / sv* / lv* / dv* / cq*, fr, ch, ex). Raw px / rem rejected.`,
+        message: `\`${decl.prop}: ${decl.value}\` — sizing values must read \`var(--t-*)\` / \`var(--_*)\` or stay on relative units (em, lh, %, vh / vw / sv* / lv* / dv* / cq*, fr, ch, ex). Raw px / rem rejected (in the value or in any --_* slot it traces through).`,
       });
     });
   }
 
   return out;
+}
+
+/**
+ * Like `isAcceptableSizingValue` but follows every `var(--_*)` reference into
+ * the file's own `--_*` declarations. A slot is acceptable only if EVERY
+ * declared value (across modifiers, states, breakpoints) is itself acceptable.
+ * `seen` guards against cycles in slot graphs.
+ */
+function isAcceptableSizingValueDeep(
+  value: string,
+  slotValues: ReadonlyMap<string, readonly string[]>,
+  seen: Set<string>,
+): boolean {
+  if (!isAcceptableSizingValue(value)) return false;
+  for (const match of value.matchAll(/var\(\s*(--_[\w-]+)\s*[,)]/g)) {
+    const name = match[1];
+    if (name === undefined || seen.has(name)) continue;
+    seen.add(name);
+    for (const slotValue of slotValues.get(name) ?? []) {
+      if (!isAcceptableSizingValueDeep(slotValue, slotValues, seen)) return false;
+    }
+  }
+  return true;
 }
 
 function runRule(): ViolationDetail[] {

--- a/scripts/lint/file-rules/rhythm-tokens.ts
+++ b/scripts/lint/file-rules/rhythm-tokens.ts
@@ -92,10 +92,11 @@ function isDerivedSpatialToken(prop: string): boolean {
  * keywords stay legal.
  */
 export function isAcceptableSizingValue(value: string): boolean {
-  // Any non-zero px / rem literal at a token-boundary position fails. The
-  // regex looks for a number (int/decimal) followed by px or rem, preceded
-  // by a value-boundary character so `1.25emm` won't trip and `--_foopx`
-  // (custom-property name) won't either.
+  // Any px / rem literal (including `0px` / `0rem`) at a token-boundary
+  // position fails — the convention is bare `0`. The regex looks for a
+  // number (int/decimal) followed by px or rem, preceded by a value-boundary
+  // character so `1.25emm` won't trip and `--_foopx` (custom-property name)
+  // won't either.
   return !/(?:^|[\s,(/*+-])-?\d*\.?\d+(?:px|rem)\b/.test(value);
 }
 
@@ -131,7 +132,7 @@ export function findRhythmViolations(
       out.push({
         file: rel,
         line: decl.source?.start?.line,
-        message: `\`${decl.prop}: ${decl.value}\` — sizing values must read \`var(--t-*)\` / \`var(--_*)\` or stay on relative units (em, lh, %)`,
+        message: `\`${decl.prop}: ${decl.value}\` — sizing values must read \`var(--t-*)\` / \`var(--_*)\` or stay on relative units (em, lh, %, vh / vw / sv* / lv* / dv* / cq*, fr, ch, ex). Raw px / rem rejected.`,
       });
     });
   }

--- a/scripts/lint/registry.ts
+++ b/scripts/lint/registry.ts
@@ -26,6 +26,7 @@ import { rule as componentCss } from "./file-rules/component-css.ts";
 import { rule as motionScale } from "./file-rules/motion-scale.ts";
 import { rule as noAsUnknownCast } from "./file-rules/no-as-unknown-cast.ts";
 import { rule as noDocumentTypeof } from "./file-rules/no-document-typeof.ts";
+import { rule as rhythmTokens } from "./file-rules/rhythm-tokens.ts";
 import { rule as transitionableProperty } from "./file-rules/transitionable-property.ts";
 
 export type ViolationDetail = { file?: string; line?: number; message: string };
@@ -126,6 +127,7 @@ export const REGISTRY: Readonly<Record<string, Check>> = {
   "no-document-typeof": noDocumentTypeof,
   "component-css": componentCss,
   "motion-scale": motionScale,
+  "rhythm-tokens": rhythmTokens,
   "transitionable-property": transitionableProperty,
   "script-aggregators": scriptAggregators,
   "script-catalog": scriptCatalog,

--- a/specs/tooltip.yaml
+++ b/specs/tooltip.yaml
@@ -108,7 +108,7 @@ parts:
         desc: Arrow fill. Defaults to the same surface as `bg` so the arrow blends seamlessly with the body.
       max-inline-size:
         fallback: 20rem
-        desc: Maximum tooltip width. Wraps long content; the default is 320px which lands on the spatial grid.
+        desc: Maximum tooltip width. Wraps long content beyond this measure.
     privateTokens:
       - --_bg
       - --_fg

--- a/specs/tooltip.yaml
+++ b/specs/tooltip.yaml
@@ -106,6 +106,9 @@ parts:
       arrow-bg:
         fallback: --t-surface-inverse
         desc: Arrow fill. Defaults to the same surface as `bg` so the arrow blends seamlessly with the body.
+      max-inline-size:
+        fallback: 20rem
+        desc: Maximum tooltip width. Wraps long content; the default is 320px which lands on the spatial grid.
     privateTokens:
       - --_bg
       - --_fg
@@ -119,6 +122,7 @@ parts:
       - --_motion-scale
       - --_arrow-size
       - --_arrow-bg
+      - --_max-inline-size
       - --_arrow-inset
       - --_arrow-transform
       - --_anchor


### PR DESCRIPTION
## What

Phase 1 of tokens-v4 (RFC-0003 / #803).

- Adds `--t-unit: 0.25rem` to `tokens.css`. Refactors `--t-space-*`, `--t-row-*`, `--t-radius-{sm,md,lg,xl}`, and `--t-touch-min` to derive from it via `calc()`. Resolved values identical at scale 1.
- Adds `rhythm-tokens` lint rule (`scripts/lint/file-rules/`). Two checks: (a) every derived spatial token in `tokens.css` traces to `var(--t-unit)`; (b) every sizing-property value in `packages/css/src/components/**/*.css` reads `var(--t-*)` / `var(--_*)` or stays on a relative unit. Raw px / rem literals in sizing positions are rejected.
- Surfaced one workspace drift — `tooltip.css` had `max-inline-size: 20rem` inline. Routed through a new `--_max-inline-size` private slot fed by a new public `--t-tooltip-max-inline-size` (additive). Docs snapshot updated.
- Bundle-size column on five other components updated by `pnpm gen` (floor now ships as `calc(0.25rem * N)` instead of the literal; ~120 bytes growth on button, marginal elsewhere).

Closes #803.

## Why

`tokens.css` declared spatial values by hand. With no single knob, rescaling a region meant overriding every consumed `--t-*` token individually. Phase 1 lays the foundation for the RFC's full story (Phase 2: leading + text-size derivation; Phase 3: density collapse) without any consumer-visible value change.

The lint rule guards the system going forward: a raw `padding: 13px` slipped into a component CSS file would now fail at write time. Existing drift (the tooltip hardcode) is fixed in the same PR per workspace-lint atomicity.

## Test plan

- [x] `pnpm test` — 934 passing (snapshot update for tooltip docs).
- [x] `pnpm typecheck` — clean.
- [x] `pnpm lint` — clean, including the new `rhythm-tokens` rule.
- [x] `pnpm build:css` — floor plugin walks `calc()` correctly; dist tokens preserved.
- [x] `pnpm gen` — generated docs pages reflect the bundle-size deltas; tooltip page picks up the new token row.
- [x] Manual: button + tooltip at scale 1 render at the same pixel sizes as `main`.

## Out of scope

- Text-size and leading derivation (Phase 2, #804). Their resolved values shift slightly; bundled with the text-box-trim visual diff.
- Density collapse (Phase 3, #805).
- Runtime grid audit — adapted from legacy v2; follow-up after Phase 1 lands.
- `--t-overlay-max-width` or other shared overlay tokens — for now `--t-tooltip-max-inline-size` is tooltip-local. Promote when a second consumer needs it.