### PR TITLE
feat(token): tokens-v4 phase 2 — derived text + round() leading + text-box-trim

### DIFF
--- a/.changeset/tokens-v4-phase-2.md
+++ b/.changeset/tokens-v4-phase-2.md
@@ -1,0 +1,5 @@
+---
+"@teseor/css": minor
+---
+
+Phase 2 of tokens-v4 (RFC-0003). Text-size scale moves to `--t-unit`-multiples and leading derives from font-size via `round(up, 1em × ratio, var(--t-unit))`. Visual diff: text rows now land on the 4px grid at every step (was `text-base` only by coincidence). Sub-pixel resolved values become whole-pixel — `--t-text-xs` 12.64 → 12, `--t-text-2xl` 22.72 → 24, `--t-text-3xl` 25.6 → 32. `--t-leading-{tight,normal,loose}` are no longer constants — they resolve relative to the current font-size. Body text (`p`, `li`, `dd`, `blockquote`) opts into `text-box-trim: trim-both` under `@supports` so `padding-block` produces the visually-expected gap. Tooltip gains a public `--t-tooltip-leading` slot replacing its hardcoded `line-height: 1.4`.

--- a/apps/docs/src/pages/components/button.astro
+++ b/apps/docs/src/pages/components/button.astro
@@ -188,7 +188,7 @@ import Base from "../../layouts/Base.astro";
       <table>
         <thead><tr><th>Artifact</th><th>Raw</th><th>Gzip</th><th>Brotli</th></tr></thead>
         <tbody>
-        <tr><td><a href="https://github.com/teseor/teseor/blob/main/packages/css/src/components/button/button.css"><Code>@teseor/css/components/button.css</Code></a></td><td>9.53 KB</td><td>1.84 KB</td><td>1.53 KB</td></tr>
+        <tr><td><a href="https://github.com/teseor/teseor/blob/main/packages/css/src/components/button/button.css"><Code>@teseor/css/components/button.css</Code></a></td><td>9.56 KB</td><td>1.84 KB</td><td>1.53 KB</td></tr>
         </tbody>
       </table>
     </section>

--- a/apps/docs/src/pages/components/tooltip.astro
+++ b/apps/docs/src/pages/components/tooltip.astro
@@ -97,6 +97,7 @@ import Base from "../../layouts/Base.astro";
         <tr><td><Code>--t-tooltip-dur</Code></td><td><Code>--t-dur-fast</Code></td><td>Entry and exit duration.</td></tr>
         <tr><td><Code>--t-tooltip-ease</Code></td><td><Code>--t-ease-out</Code></td><td>Entry and exit easing.</td></tr>
         <tr><td><Code>--t-tooltip-font-size</Code></td><td><Code>--t-text-sm</Code></td><td>Font size for tooltip body text.</td></tr>
+        <tr><td><Code>--t-tooltip-leading</Code></td><td><Code>--t-leading-normal</Code></td><td>Line-height. Derives from font-size and snaps to the unit grid via `round()`.</td></tr>
         <tr><td><Code>--t-tooltip-arrow-size</Code></td><td><Code>--t-space-3</Code></td><td>Arrow square size. Rotated 45° to form the pointer; visible triangle is roughly size/√2 tall.</td></tr>
         <tr><td><Code>--t-tooltip-arrow-bg</Code></td><td><Code>--t-surface-inverse</Code></td><td>Arrow fill. Defaults to the same surface as `bg` so the arrow blends seamlessly with the body.</td></tr>
         <tr><td><Code>--t-tooltip-max-inline-size</Code></td><td><Code>20rem</Code></td><td>Maximum tooltip width. Wraps long content beyond this measure.</td></tr>
@@ -130,7 +131,7 @@ import Base from "../../layouts/Base.astro";
       <table>
         <thead><tr><th>Artifact</th><th>Raw</th><th>Gzip</th><th>Brotli</th></tr></thead>
         <tbody>
-        <tr><td><a href="https://github.com/teseor/teseor/blob/main/packages/css/src/components/tooltip/tooltip.css"><Code>@teseor/css/components/tooltip.css</Code></a></td><td>11.93 KB</td><td>2.06 KB</td><td>1.68 KB</td></tr>
+        <tr><td><a href="https://github.com/teseor/teseor/blob/main/packages/css/src/components/tooltip/tooltip.css"><Code>@teseor/css/components/tooltip.css</Code></a></td><td>12.06 KB</td><td>2.09 KB</td><td>1.72 KB</td></tr>
         </tbody>
       </table>
     </section>

--- a/packages/css/src/base.css
+++ b/packages/css/src/base.css
@@ -79,4 +79,21 @@
     outline: 2px solid var(--t-focus-ring);
     outline-offset: 2px;
   }
+
+  /* text-box-trim strips the half-leading above the cap and below the baseline
+     so `padding-block` produces the visually-expected gap. Without it, rhythm
+     is approximate even when the leading lands on the grid. Scoped to body
+     prose elements where the trim is unambiguously desired; headings keep
+     their natural metrics for the `text-wrap: balance` story. Baseline 2025;
+     `@supports` gates the fallback. */
+  @supports (text-box-trim: trim-both) {
+    :where(p, li, dd, blockquote) {
+      text-box-trim: trim-both;
+      /* stylelint-disable-next-line declaration-property-value-no-unknown --
+         stylelint's CSS value database does not yet recognise `cap` for
+         text-box-edge; the value is valid per the CSS Inline Layout spec
+         (Baseline 2025). */
+      text-box-edge: cap;
+    }
+  }
 }

--- a/packages/css/src/components/tooltip/tooltip.css
+++ b/packages/css/src/components/tooltip/tooltip.css
@@ -13,6 +13,7 @@
     --_dur: var(--t-tooltip-dur, var(--t-dur-fast));
     --_ease: var(--t-tooltip-ease, var(--t-ease-out));
     --_font-size: var(--t-tooltip-font-size, var(--t-text-sm));
+    --_leading: var(--t-tooltip-leading, var(--t-leading-normal));
     --_max-inline-size: var(--t-tooltip-max-inline-size, 20rem);
     --_motion-scale: var(--t-motion-scale);
     --_arrow-size: var(--t-tooltip-arrow-size, var(--t-space-3));
@@ -63,7 +64,7 @@
     border-radius: var(--_radius);
     font: inherit;
     font-size: var(--_font-size);
-    line-height: 1.4;
+    line-height: var(--_leading);
     max-inline-size: var(--_max-inline-size);
     pointer-events: none;
     display: var(--_display);

--- a/packages/css/src/tokens.css
+++ b/packages/css/src/tokens.css
@@ -102,17 +102,26 @@
     --t-row-3: calc(var(--t-unit) * 10); /* 40px */
     --t-row-4: calc(var(--t-unit) * 12); /* 48px */
 
-    /* ===== Typography — ratio 1.125, base = 1rem ===== */
-    --t-text-xs: 0.79rem;
-    --t-text-sm: 0.89rem;
-    --t-text-base: 1rem;
-    --t-text-lg: 1.125rem;
-    --t-text-xl: 1.27rem;
-    --t-text-2xl: 1.42rem;
-    --t-text-3xl: 1.6rem;
-    --t-leading-tight: 1.2;
-    --t-leading-normal: 1.5;
-    --t-leading-loose: 1.75;
+    /* ===== Typography — derived from --t-unit (Phase 2 of tokens-v4) =====
+
+       Sizes are unit-multiples. Half-multipliers on `sm` and `lg` resolve to
+       14px and 18px — off the 4px grid as glyph boxes, but the line box lands
+       on grid because leading is unit-multiple. Integer multipliers everywhere
+       else. */
+    --t-text-xs: calc(var(--t-unit) * 3); /* 12px */
+    --t-text-sm: calc(var(--t-unit) * 3.5); /* 14px */
+    --t-text-base: calc(var(--t-unit) * 4); /* 16px */
+    --t-text-lg: calc(var(--t-unit) * 4.5); /* 18px */
+    --t-text-xl: calc(var(--t-unit) * 5); /* 20px */
+    --t-text-2xl: calc(var(--t-unit) * 6); /* 24px */
+    --t-text-3xl: calc(var(--t-unit) * 8); /* 32px */
+
+    /* Leading derives from font-size and snaps up to the next --t-unit step,
+       so every rendered text row lands on the grid regardless of font size.
+       `round()` is Baseline 2024. */
+    --t-leading-tight: round(up, calc(1em * 1.25), var(--t-unit));
+    --t-leading-normal: round(up, calc(1em * 1.5), var(--t-unit));
+    --t-leading-loose: round(up, calc(1em * 1.75), var(--t-unit));
     --t-font-sans: ui-sans-serif, system-ui, -apple-system, blinkmacsystemfont, "Segoe UI", roboto,
       "Helvetica Neue", arial, sans-serif;
     --t-font-mono: ui-monospace, "SF Mono", menlo, monaco, consolas, "Liberation Mono",

--- a/scripts/codegen/__tests__/__snapshots__/gen-docs.test.ts.snap
+++ b/scripts/codegen/__tests__/__snapshots__/gen-docs.test.ts.snap
@@ -462,6 +462,7 @@ import Base from "../../layouts/Base.astro";
         <tr><td><Code>--t-tooltip-dur</Code></td><td><Code>--t-dur-fast</Code></td><td>Entry and exit duration.</td></tr>
         <tr><td><Code>--t-tooltip-ease</Code></td><td><Code>--t-ease-out</Code></td><td>Entry and exit easing.</td></tr>
         <tr><td><Code>--t-tooltip-font-size</Code></td><td><Code>--t-text-sm</Code></td><td>Font size for tooltip body text.</td></tr>
+        <tr><td><Code>--t-tooltip-leading</Code></td><td><Code>--t-leading-normal</Code></td><td>Line-height. Derives from font-size and snaps to the unit grid via \`round()\`.</td></tr>
         <tr><td><Code>--t-tooltip-arrow-size</Code></td><td><Code>--t-space-3</Code></td><td>Arrow square size. Rotated 45° to form the pointer; visible triangle is roughly size/√2 tall.</td></tr>
         <tr><td><Code>--t-tooltip-arrow-bg</Code></td><td><Code>--t-surface-inverse</Code></td><td>Arrow fill. Defaults to the same surface as \`bg\` so the arrow blends seamlessly with the body.</td></tr>
         <tr><td><Code>--t-tooltip-max-inline-size</Code></td><td><Code>20rem</Code></td><td>Maximum tooltip width. Wraps long content beyond this measure.</td></tr>

--- a/specs/tooltip.yaml
+++ b/specs/tooltip.yaml
@@ -100,6 +100,9 @@ parts:
       font-size:
         fallback: --t-text-sm
         desc: Font size for tooltip body text.
+      leading:
+        fallback: --t-leading-normal
+        desc: Line-height. Derives from font-size and snaps to the unit grid via `round()`.
       arrow-size:
         fallback: --t-space-3
         desc: Arrow square size. Rotated 45° to form the pointer; visible triangle is roughly size/√2 tall.
@@ -119,6 +122,7 @@ parts:
       - --_dur
       - --_ease
       - --_font-size
+      - --_leading
       - --_motion-scale
       - --_arrow-size
       - --_arrow-bg


### PR DESCRIPTION
**Stacked on #812** (Phase 1). Targets `feat/tokens-v4-phase-1`; GitHub will auto-rebase the base to `main` when #812 lands.

## What

Phase 2 of tokens-v4 (RFC-0003 / #804).

- **Text scale** moves from harmonic ratios (`1.125ⁿ`) to `--t-unit`-multiples. Half-multipliers on `sm` and `lg` (×3.5, ×4.5 → 14px / 18px) stay off the 4px grid as *glyph boxes*; line boxes land on the grid because leading is now unit-multiple. Integer multipliers everywhere else.
- **Leading** derives from font-size via `round(up, calc(1em * ratio), var(--t-unit))`. `tight` (×1.25), `normal` (×1.5), `loose` (×1.75) all snap to the next unit step regardless of the font size they're applied to. `--t-leading-loose` retained for Tailwind preset compat (RFC missed this).
- **`text-box-trim`** added to body prose (`p, li, dd, blockquote`) under `@supports`. Strips half-leading so `padding-block` produces the visually-expected gap.
- **Tooltip** gains a public `--t-tooltip-leading` slot fed by `--t-leading-normal`, replacing the hardcoded `line-height: 1.4`. Other components left alone — button's `line-height: 1` is intentional; codeblock's `1.5` is fine as-is.

Closes #804.

## Why

Phase 1 (#812) made spatial tokens derive from `--t-unit` but left text and leading on their old form. The result was inconsistent: spacing and row heights snapped to the grid; text rows snapped only at `text-base` and drifted at every other step. Phase 2 closes the gap so vertical rhythm is a structural property of the system, not a wish.

The text-size resolved-value shifts are intentional and were deferred from Phase 1 explicitly so the visual diff lands in one reviewable PR. Concrete deltas at scale 1 (16px root):

| Token | Was | Now |
|---|---|---|
| `--t-text-xs` | 12.64px | 12px |
| `--t-text-sm` | 14.24px | 14px |
| `--t-text-base` | 16px | 16px |
| `--t-text-lg` | 18px | 18px |
| `--t-text-xl` | 20.32px | 20px |
| `--t-text-2xl` | 22.72px | 24px |
| `--t-text-3xl` | 25.6px | 32px |

`text-3xl` is the biggest jump (25.6 → 32 = 8px = unit × 2). The `2xl` jump (22.72 → 24) restores the "musical" interval to a clean 4px-grid step.

## Test plan

- [x] `pnpm test` — 942 passing (one snapshot updated: tooltip docs page picks up new `leading` row).
- [x] `pnpm typecheck` — clean.
- [x] `pnpm lint` — clean, including `rhythm-tokens` (text-related tokens stay out-of-scope for that rule per Phase 1 contract).
- [x] `pnpm build:css` — `round()` walks through `postcss-teseor-floor` without issue; dist contains the resolved formula.
- [x] `pnpm gen` — docs regenerated; tooltip page picks up new token row.
- [ ] Visual: docs site rendered locally to confirm `text-3xl` and `2xl` step changes look intentional (reviewer should eyeball).

## Out of scope

- Density collapse (Phase 3, #805) — final phase.
- Codeblock leading — `line-height: 1.5` is fine on its own and changing it adds churn without rhythm benefit.
- Headings + `text-box-trim` — body-only scope; headings keep their natural metrics for `text-wrap: balance` compatibility (decided during implementation, noted in the RFC's unresolved questions).
- Fluid type (`clamp()` between breakpoints) — RFC Alternative E; separate experiment.