### PR TITLE
refactor(token): tokens-v4 phase 3 — collapse --t-density into --t-unit overrides

### DIFF
--- a/.changeset/tokens-v4-phase-3.md
+++ b/.changeset/tokens-v4-phase-3.md
@@ -1,5 +1,18 @@
 ---
-"@teseor/css": minor
+"@teseor/css": major
+migration: |
+  ### `--t-density` removed; `[data-density]` mechanism changed
+
+  **What changed.** `--t-density` (multiplier) is removed. The `[data-density="compact"]` and `[data-density="comfortable"]` modifiers no longer multiply four shorthand tokens by a density factor — they reassign `--t-unit` directly. Because Phase 1 (#812) made every spatial token derive from `--t-unit`, density now rescales the whole spatial system in the subtree: spacing rungs, row heights, radii, leading, text-size, and the four shorthands.
+
+  **What this means for consumers.**
+
+  - Any consumer reading `var(--t-density)` directly breaks. There are no known direct readers; the token existed for the four internal shorthands. If you did reference it, replace with reading `--t-unit` against the default `0.25rem`.
+  - Any consumer using `[data-density="compact"]` and expecting *only* `--t-pad-x` / `--t-pad-y` / `--t-gap` / `--t-row` to tighten now sees the entire subtree tighten. A `<Stack gap="5">` inside the modifier finally shrinks (was 24px → now 21px). Previously you may have wrapped UIs in both `data-density="compact"` and a separate per-component sizing strategy; the second is no longer required.
+
+  **`--t-touch-min` floor.** Now clamps to `2.75rem` via `max(calc(var(--t-unit) * 11), 2.75rem)` so compact density cannot shrink the WCAG 2.5.5 interactive target below 44px.
+
+  **No codemod.** Names are unchanged; behavior shifts.
 ---
 
-Phase 3 of tokens-v4 (RFC-0003). **Public-API behavior change.** Density modifiers (`[data-density="compact"]` / `[data-density="comfortable"]`) now reassign `--t-unit` directly instead of the deprecated `--t-density` multiplier. The result: density scales the entire spatial system in the subtree — every spacing rung, row height, radius, leading, and text-size shifts proportionally, not just the four shorthands. A `<Stack gap="5">` inside `[data-density="compact"]` finally tightens (24px → 21px). `--t-density` is removed; the four spacing shorthands (`--t-pad-x`, `--t-pad-y`, `--t-gap`, `--t-row`) stay as plain aliases of the underlying rungs. `--t-touch-min` clamps to a 2.75rem floor via `max()` so compact density can never shrink the WCAG 2.5.5 touch target. No codemod — naming is unchanged; consumers that read `var(--t-density)` directly (none known) would break.
+Phase 3 of tokens-v4 (RFC-0003). See migration above.

--- a/.changeset/tokens-v4-phase-3.md
+++ b/.changeset/tokens-v4-phase-3.md
@@ -1,0 +1,5 @@
+---
+"@teseor/css": minor
+---
+
+Phase 3 of tokens-v4 (RFC-0003). **Public-API behavior change.** Density modifiers (`[data-density="compact"]` / `[data-density="comfortable"]`) now reassign `--t-unit` directly instead of the deprecated `--t-density` multiplier. The result: density scales the entire spatial system in the subtree — every spacing rung, row height, radius, leading, and text-size shifts proportionally, not just the four shorthands. A `<Stack gap="5">` inside `[data-density="compact"]` finally tightens (24px → 21px). `--t-density` is removed; the four spacing shorthands (`--t-pad-x`, `--t-pad-y`, `--t-gap`, `--t-row`) stay as plain aliases of the underlying rungs. `--t-touch-min` clamps to a 2.75rem floor via `max()` so compact density can never shrink the WCAG 2.5.5 touch target. No codemod — naming is unchanged; consumers that read `var(--t-density)` directly (none known) would break.

--- a/packages/css/src/tokens.css
+++ b/packages/css/src/tokens.css
@@ -169,21 +169,14 @@
     /* Motion scale — gated by prefers-reduced-motion below */
     --t-motion-scale: 1;
 
-    /* ===== Density ===== */
+    /* ===== Touch target (accessibility floor) =====
 
-    /* Multiplier for spacing shorthands. Default `1`; opt-in modifiers
-       (`[data-density="compact"]` / `[data-density="comfortable"]`) reassign
-       it in the semantic layer. Component CSS that multiplies a spacing
-       token by `var(--t-density)` follows the modifier automatically. */
-    --t-density: 1;
-
-    /* ===== Touch target (accessibility floor) ===== */
-
-    /* 44px @ 16px root — minimum touch-target token for interactive controls.
-       Matches WCAG 2.5.5 (AAA Target Size Enhanced); stricter than AA 2.5.8 (24px).
-       This token is available for components or semantic aliases to opt into
-       when they need to enforce a minimum interactive size. */
-    --t-touch-min: calc(var(--t-unit) * 11);
+       11 units = 44px @ default unit. WCAG 2.5.5 (AAA Target Size Enhanced);
+       stricter than AA 2.5.8 (24px). `max()` clamps to the 2.75rem floor so a
+       compact-density subtree (smaller --t-unit) cannot shrink the
+       interactive minimum below the accessibility threshold. Components or
+       semantic aliases opt in when they need to enforce a minimum. */
+    --t-touch-min: max(calc(var(--t-unit) * 11), 2.75rem);
 
     /* ===== Z-index ===== */
     --t-z-base: 0;
@@ -241,27 +234,28 @@
     /* ===== Focus ===== */
     --t-focus-ring: var(--t-accent-500);
 
-    /* ===== Spacing shorthands ===== */
+    /* ===== Spacing shorthands =====
 
-    /* All four multiply by `--t-density`. Interactive component roots that
-       need to honour the touch-target floor read `--t-touch-min` directly;
-       flooring `--t-row` here would inflate the default size (2rem → 2.75rem)
-       for every consumer, not just compact-density interactive controls. */
-    --t-pad-x: calc(var(--t-space-4) * var(--t-density));
-    --t-pad-y: calc(var(--t-space-2) * var(--t-density));
-    --t-gap: calc(var(--t-space-3) * var(--t-density));
-    --t-row: calc(var(--t-row-2) * var(--t-density));
+       Named aliases for the most-used rungs. They derive from `--t-unit`
+       transitively (Phase 1), so a `--t-unit` override anywhere in the
+       cascade — including the `[data-density]` modifiers below — rescales
+       them along with every other spatial token. */
+    --t-pad-x: var(--t-space-4);
+    --t-pad-y: var(--t-space-2);
+    --t-gap: var(--t-space-3);
+    --t-row: var(--t-row-2);
   }
 
-  /* Density opt-in. Apply on any subtree to scale spacing shorthands;
-     `compact` and `comfortable` are the two supported values. `:where()`
-     keeps specificity flat (0,0,0) so consumers override without ratcheting. */
+  /* Density opt-in. Reassigns `--t-unit` in the subtree, so every spatial
+     token — spacing rungs, row heights, radii, leading, the shorthands
+     above — rescales coherently. `:where()` keeps specificity flat (0,0,0)
+     so consumers override without ratcheting. */
   :where([data-density="compact"]) {
-    --t-density: 0.875;
+    --t-unit: calc(0.25rem * 0.875); /* 3.5px — 87.5% of default */
   }
 
   :where([data-density="comfortable"]) {
-    --t-density: 1.125;
+    --t-unit: calc(0.25rem * 1.125); /* 4.5px — 112.5% of default */
   }
 
   /* Forced-colors remap to CSS system colors. */

--- a/packages/css/src/tokens.css
+++ b/packages/css/src/tokens.css
@@ -247,15 +247,21 @@
   }
 
   /* Density opt-in. Reassigns `--t-unit` in the subtree, so every spatial
-     token — spacing rungs, row heights, radii, leading, the shorthands
-     above — rescales coherently. `:where()` keeps specificity flat (0,0,0)
-     so consumers override without ratcheting. */
+     token — spacing rungs, row heights, radii, leading, the shorthands above
+     — rescales coherently. `:where()` keeps specificity flat (0,0,0) so
+     consumers override without ratcheting. The right-hand side reads
+     `var(--t-unit)`, which resolves to the *inherited* value (not the value
+     being declared), so a consumer overriding `--t-unit` at `:root` still
+     gets the right density-modifier resolution and the 0.25rem default lives
+     in exactly one place above. Nested density modifiers compose
+     multiplicatively (compact-in-compact = 0.766 × default), which is the
+     right behavior for nested rescale. */
   :where([data-density="compact"]) {
-    --t-unit: calc(0.25rem * 0.875); /* 3.5px — 87.5% of default */
+    --t-unit: calc(var(--t-unit) * 0.875); /* 87.5% of inherited unit */
   }
 
   :where([data-density="comfortable"]) {
-    --t-unit: calc(0.25rem * 1.125); /* 4.5px — 112.5% of default */
+    --t-unit: calc(var(--t-unit) * 1.125); /* 112.5% of inherited unit */
   }
 
   /* Forced-colors remap to CSS system colors. */


### PR DESCRIPTION
## What

Phase 3 of tokens-v4 (RFC-0003 / #805). **Public-API behavior change.**

- Removes `--t-density` and the four `* var(--t-density)` multiplications.
- `[data-density="compact"]` and `[data-density="comfortable"]` modifiers now reassign `--t-unit` directly (\`calc(0.25rem * 0.875)\` / \`calc(0.25rem * 1.125)\` → 3.5px / 4.5px).
- The four spacing shorthands (`--t-pad-x`, `--t-pad-y`, `--t-gap`, `--t-row`) stay as plain aliases of the underlying rungs — no consumer churn for anything that reads them.
- `--t-touch-min` now clamps to a `2.75rem` floor via `max()` so compact density can never shrink the WCAG 2.5.5 (AAA Target Size Enhanced) interactive minimum.

Closes #805.

## Why

`--t-density` was a half-implementation. It multiplied only four semantic shorthands, so a `<Stack gap="5">` (reading `--t-space-5` directly) inside `[data-density="compact"]` stayed at 24px. Components reading raw rungs — most of Stack / Spacer / Layout / Tooltip / Modal — ignored density entirely. The knob promised "compact everywhere" and delivered "compact for interactive controls only."

Phases 1 and 2 made every spatial token derive from `--t-unit`. Reassigning `--t-unit` in a subtree now cascades through spacing rungs, row heights, radii, leading, and the shorthands together. Phase 3 just rewires the existing `[data-density]` modifier to the new mechanism. The density knob now means what it appears to mean.

## Behavior shift (the Ask-before)

At default density: zero change. Resolved values identical.

Under `[data-density="compact"]`:

| Token | Before (Phase 2) | After (Phase 3) | Δ |
|---|---|---|---|
| `--t-space-5` | 24px (unchanged) | 21px | -3 |
| `--t-row-2` | 32px (unchanged) | 28px | -4 |
| `--t-row-3` | 40px (unchanged) | 35px | -5 |
| `--t-radius-md` | 8px (unchanged) | 7px | -1 |
| `--t-text-base` | 16px (unchanged) | 14px | -2 |
| `--t-pad-x` | 14px | 14px | 0 (was 16 × 0.875; now 3.5 × 4) |
| `--t-touch-min` | 44px (unchanged) | 44px (floored by max()) | 0 |

Symmetric under `[data-density="comfortable"]`.

The release note should highlight: any consumer wrapping a subtree in `data-density="compact"` and explicitly setting per-component spacing to compensate may see their UI tighten further than before. The pre-Phase-3 workaround stops being necessary.

## Test plan

- [x] `pnpm test` — 942 passing. No snapshot updates (resolved values at default density unchanged; docs render the same).
- [x] `pnpm typecheck` — clean.
- [x] `pnpm lint` — clean (including `rhythm-tokens`).
- [x] `pnpm build:css` — dist output: `--t-density` gone; `--t-touch-min: max(calc(var(--t-unit) * 11), 2.75rem)` ships.
- [ ] Manual: docs page rendered locally with a `<section data-density="compact">` and `<section data-density="comfortable">` to confirm proportional rescale across stack gaps, button heights, and body text — eyeball pending reviewer time.

## Out of scope

- Codemod: none possible — naming is unchanged, behavior shifts.
- Picking different density step values (`3.5 / 4.5` were chosen for symmetric ±12.5% matching the legacy v2 `--ui-scale` multipliers). Alternative `3 / 5` would be ±25% asymmetric on a multiplier basis and produce whole-pixel rungs at default root font-size; weighed against `3.5 / 4.5` and rejected for the bigger visual jump.
- `if()` / `@container style()` migration — relevant successor APIs; defer until Chromium-only ships in other engines.
- Closes the `tokens-v4` umbrella (#802 already closed by the RFC PR; this is the last implementation phase).