### PR TITLE
feat(token): derive --t-accent from --t-seed (RFC-0004 phase 1)

### DIFF
--- a/.changeset/820-color-cascade-phase-1.md
+++ b/.changeset/820-color-cascade-phase-1.md
@@ -1,0 +1,12 @@
+---
+"@teseor/css": minor
+"@teseor/docs": patch
+---
+
+Add `--t-seed` (the color cascade's sole knob, default `oklch(65% 0.18 250deg)`) and `--t-harmony` (intent-drift slot, default `0`, reserved for the next phase) at `:root`. Refactor `--t-accent-{50..900}` to derive from the seed via `oklch(from var(--t-accent) <L> calc(c * <multiplier>) h)`. The `--t-accent` Tier-2 semantic alias now reads `var(--t-seed)` directly; the ramp steps read `--t-accent`. Resolved values are identical to the previous hand-tabulated palette at the default seed.
+
+Override `--t-seed` at `:root` or any subtree to re-skin the accent family — the 50–900 ramp re-derives via CSS relative-color syntax (Baseline 2025). Existing per-step overrides (`--t-accent-500: oklch(...)`) keep working through the cascade. Neutral and intent ramps remain hand-authored; they migrate in the next phase.
+
+Behavior change: overriding `--t-accent` now cascades into the accent ramp (and through it, `--t-focus-ring`). Previously the ramp was hand-tabulated and isolated from the semantic alias.
+
+Adds `/themes` to the docs site — accent ramp + intent/neutral ramps for context + button examples + inline color pickers so reviewers can eyeball seed/intent overrides without devtools.

--- a/apps/docs/src/layouts/Base.astro
+++ b/apps/docs/src/layouts/Base.astro
@@ -12,6 +12,7 @@ const { title } = Astro.props;
 
 const navItems = [
   { href: "/", label: "Home" },
+  { href: "/themes/", label: "Themes" },
   ...components.map((c) => ({ href: c.href, label: c.label })),
 ];
 

--- a/apps/docs/src/pages/themes.astro
+++ b/apps/docs/src/pages/themes.astro
@@ -1,0 +1,238 @@
+---
+// dogfood-allow: preview-only layout for the color cascade — swatch grid + inline
+// pickers aren't a reusable DS pattern; they exist to let reviewers eyeball
+// --t-seed / intent overrides without devtools.
+import { Button } from "@teseor/react";
+import Base from "../layouts/Base.astro";
+
+const accentSteps = [50, 100, 200, 300, 400, 500, 600, 700, 800, 900] as const;
+const intentSteps = [50, 100, 200, 300, 400, 500, 600, 700, 800, 900] as const;
+const neutralSteps = [0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100] as const;
+const intents = ["accent", "success", "warning", "danger", "info"] as const;
+---
+
+<Base title="Themes — Teseor">
+  <main class="t-stack" data-gap="6">
+    <h1>Themes</h1>
+    <p>
+      Color cascade preview. Phase 1: <code>--t-seed</code> drives the accent
+      ramp via <code>oklch(from …)</code>. Intent + neutral ramps are still
+      hand-authored — they migrate in phase 2.
+    </p>
+
+    <section class="t-stack" data-gap="3">
+      <h2>Edit</h2>
+      <p class="hint">
+        Color inputs emit hex; CSS relative-color syntax converts to OKLCH
+        internally. Reset clears the overrides.
+      </p>
+      <div class="picker-grid">
+        <label>
+          <span>seed</span>
+          <input type="color" data-token="--t-seed" value="#5471b5" />
+        </label>
+        {intents.map((intent) => (
+          <label>
+            <span>{intent}</span>
+            <input
+              type="color"
+              data-token={`--t-${intent === "accent" ? "accent" : intent}`}
+              value="#5471b5"
+            />
+          </label>
+        ))}
+        <button type="button" id="reset-tokens">Reset</button>
+      </div>
+    </section>
+
+    <section class="t-stack" data-gap="3">
+      <h2>Seed</h2>
+      <div class="ramp">
+        <div class="swatch seed" />
+      </div>
+    </section>
+
+    <section class="t-stack" data-gap="3">
+      <h2>Accent ramp (seed-derived)</h2>
+      <div class="ramp" data-family="accent">
+        {accentSteps.map((step) => (
+          <div class="swatch" data-step={step} style={`background: var(--t-accent-${step})`}>
+            <span class="label">accent-{step}</span>
+          </div>
+        ))}
+      </div>
+    </section>
+
+    <section class="t-stack" data-gap="3">
+      <h2>Intent ramps (hand-authored, derived in phase 2)</h2>
+      {(["success", "warning", "danger", "info"] as const).map((family) => (
+        <div>
+          <h3>{family}</h3>
+          <div class="ramp" data-family={family}>
+            {intentSteps.map((step) => (
+              <div class="swatch" data-step={step} style={`background: var(--t-${family}-${step})`}>
+                <span class="label">{family}-{step}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      ))}
+    </section>
+
+    <section class="t-stack" data-gap="3">
+      <h2>Neutral ramp (hand-authored, derived in phase 2)</h2>
+      <div class="ramp" data-family="neutral">
+        {neutralSteps.map((step) => (
+          <div class="swatch" data-step={step} style={`background: var(--t-neutral-${step})`}>
+            <span class="label">neutral-{step}</span>
+          </div>
+        ))}
+      </div>
+    </section>
+
+    <section class="t-stack" data-gap="3">
+      <h2>Button examples</h2>
+      <p class="hint">Solid.</p>
+      <div class="t-cluster" data-gap="3">
+        {intents.map((intent) => (
+          <Button variant="solid" intent={intent === "accent" ? "primary" : intent}>
+            {intent}
+          </Button>
+        ))}
+      </div>
+      <p class="hint">Outline.</p>
+      <div class="t-cluster" data-gap="3">
+        {intents.map((intent) => (
+          <Button variant="outline" intent={intent === "accent" ? "primary" : intent}>
+            {intent}
+          </Button>
+        ))}
+      </div>
+      <p class="hint">Ghost.</p>
+      <div class="t-cluster" data-gap="3">
+        {intents.map((intent) => (
+          <Button variant="ghost" intent={intent === "accent" ? "primary" : intent}>
+            {intent}
+          </Button>
+        ))}
+      </div>
+    </section>
+  </main>
+</Base>
+
+<script>
+  const root = document.documentElement;
+  const inputs = document.querySelectorAll<HTMLInputElement>("input[data-token]");
+  inputs.forEach((input) => {
+    input.addEventListener("input", (event) => {
+      const target = event.currentTarget as HTMLInputElement;
+      const token = target.dataset.token;
+      if (token) root.style.setProperty(token, target.value);
+    });
+  });
+  document.getElementById("reset-tokens")?.addEventListener("click", () => {
+    inputs.forEach((input) => {
+      const token = input.dataset.token;
+      if (token) root.style.removeProperty(token);
+      input.value = "#5471b5";
+    });
+  });
+</script>
+
+<style>
+  .ramp {
+    display: grid;
+    grid-auto-flow: column;
+    grid-auto-columns: 1fr;
+    gap: var(--t-space-1);
+  }
+
+  .swatch {
+    block-size: 4rem;
+    border-radius: var(--t-radius-sm);
+    border: 1px solid var(--t-neutral-30);
+    display: flex;
+    align-items: end;
+    padding: var(--t-space-1);
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 0.625rem;
+    color: var(--t-neutral-90);
+  }
+
+  .swatch[data-step="500"],
+  .swatch[data-step="600"],
+  .swatch[data-step="700"],
+  .swatch[data-step="800"],
+  .swatch[data-step="900"],
+  .swatch[data-step="100"] {
+    color: var(--t-neutral-10);
+  }
+
+  .swatch[data-step="0"],
+  .swatch[data-step="10"],
+  .swatch[data-step="20"],
+  .swatch[data-step="50"] {
+    color: var(--t-neutral-90);
+  }
+
+  .swatch.seed {
+    background: var(--t-seed);
+    block-size: 6rem;
+    color: var(--t-neutral-10);
+  }
+
+  .label {
+    background: rgb(255 255 255 / 0.6);
+    color: black;
+    padding: 0 0.25rem;
+    border-radius: 2px;
+  }
+
+  .hint {
+    color: var(--t-neutral-70);
+    font-size: 0.875rem;
+  }
+
+  h3 {
+    margin: 0 0 var(--t-space-2);
+    font-size: 1rem;
+    text-transform: capitalize;
+  }
+
+  .picker-grid {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--t-space-3);
+    align-items: end;
+  }
+
+  .picker-grid label {
+    display: flex;
+    flex-direction: column;
+    gap: var(--t-space-1);
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--t-neutral-70);
+  }
+
+  .picker-grid input[type="color"] {
+    inline-size: 3rem;
+    block-size: 2rem;
+    border: 1px solid var(--t-neutral-30);
+    border-radius: var(--t-radius-sm);
+    padding: 0;
+    background: transparent;
+  }
+
+  .picker-grid button {
+    block-size: 2rem;
+    padding: 0 var(--t-space-3);
+    border: 1px solid var(--t-neutral-30);
+    border-radius: var(--t-radius-sm);
+    background: var(--t-neutral-10);
+    color: inherit;
+    font: inherit;
+    cursor: pointer;
+  }
+</style>

--- a/packages/css/src/tokens.css
+++ b/packages/css/src/tokens.css
@@ -17,17 +17,21 @@
     --t-neutral-90: oklch(18% 0 0deg);
     --t-neutral-100: oklch(0% 0 0deg);
 
-    /* Accent — blue, hue 250 */
-    --t-accent-50: oklch(97% 0.02 250deg);
-    --t-accent-100: oklch(93% 0.05 250deg);
-    --t-accent-200: oklch(86% 0.09 250deg);
-    --t-accent-300: oklch(78% 0.13 250deg);
-    --t-accent-400: oklch(71% 0.16 250deg);
-    --t-accent-500: oklch(65% 0.18 250deg);
-    --t-accent-600: oklch(55% 0.18 250deg);
-    --t-accent-700: oklch(45% 0.16 250deg);
-    --t-accent-800: oklch(35% 0.13 250deg);
-    --t-accent-900: oklch(25% 0.1 250deg);
+    /* ===== Color seed — sole knob for the color cascade. ===== */
+    --t-seed: oklch(65% 0.18 250deg);
+    --t-harmony: 0;
+
+    /* Accent — derived from --t-accent (default = seed). */
+    --t-accent-50: oklch(from var(--t-accent) 97% calc(c * 0.111) h);
+    --t-accent-100: oklch(from var(--t-accent) 93% calc(c * 0.278) h);
+    --t-accent-200: oklch(from var(--t-accent) 86% calc(c * 0.5) h);
+    --t-accent-300: oklch(from var(--t-accent) 78% calc(c * 0.722) h);
+    --t-accent-400: oklch(from var(--t-accent) 71% calc(c * 0.889) h);
+    --t-accent-500: var(--t-accent);
+    --t-accent-600: oklch(from var(--t-accent) 55% c h);
+    --t-accent-700: oklch(from var(--t-accent) 45% calc(c * 0.889) h);
+    --t-accent-800: oklch(from var(--t-accent) 35% calc(c * 0.722) h);
+    --t-accent-900: oklch(from var(--t-accent) 25% calc(c * 0.556) h);
 
     /* Success — green, hue 155 */
     --t-success-50: oklch(97% 0.02 155deg);
@@ -220,7 +224,7 @@
     --t-border-strong: var(--t-neutral-40);
 
     /* ===== Intents — pairs every fill with --t-on-<role> ===== */
-    --t-accent: var(--t-accent-500);
+    --t-accent: var(--t-seed);
     --t-on-accent: var(--t-neutral-0);
     --t-success: var(--t-success-500);
     --t-on-success: var(--t-neutral-0);


### PR DESCRIPTION
## What

Phase 1 of RFC-0004 (color seed-derived cascade).

- Add `--t-seed` (default `oklch(65% 0.18 250deg)`) and `--t-harmony` (default `0`, reserved for phase 2) at `:root` in `packages/css/src/tokens.css`.
- Refactor `--t-accent-{50..900}` to derive from `--t-seed` via `oklch(from var(--t-accent) <L> calc(c * <multiplier>) h)`. Lightness ladder unchanged; chroma multipliers chosen so resolved values match today's hand-tabulated palette at the default seed.
- Refactor the `--t-accent` Tier-2 semantic alias from `var(--t-accent-500)` to `var(--t-seed)`. Same resolved value at the default seed.
- Neutral, intent, and shadow tokens are unchanged — they migrate in phase 2 (#821).
- Add `/themes` preview page on the docs site with the accent ramp, intent + neutral ramps for context, button examples, and inline color pickers so reviewers can eyeball seed / intent overrides without devtools.

Closes #820.

## Why

RFC-0004 is the color cascade ([docs/RFC/0004-color-seed-derived.md](https://github.com/teseor/teseor/blob/main/docs/RFC/0004-color-seed-derived.md)). Phase 1 is the seed surface + accent derivation, scoped so resolved values stay identical at default — no visual diff, internal refactor. Subsequent phases migrate intent + neutral (#821) and retune the default seed (#822).

The plugin (`postcss-teseor-floor`) already handles relative-color expressions correctly through its existing `var()` chain resolution; no extension needed.

## Test plan

- [x] `pnpm test` — 942 tests pass.
- [x] `pnpm lint` — clean (themes page carries a `dogfood-allow:` sentinel for the preview-only swatch grid).
- [x] `pnpm typecheck` — clean.
- [x] `pnpm build:css` + `pnpm build:docs` — clean; `/themes/index.html` builds; `dist/tokens.css` contains the derived expressions; component CSS (`dist/components/button.css`) inlines the correct literal floor for `var(--t-accent)`.
- [x] Spot-check resolved values: `--t-accent-50` = `oklch(97% 0.01998 250)` (today: `oklch(97% 0.02 250)`); `--t-accent-400` = `oklch(71% 0.16002 250)` (today: `oklch(71% 0.16 250)`). Identical at three-decimal precision.
- [ ] Reviewer: navigate to `/themes/` on the docs preview deploy, override the seed picker, verify the accent ramp re-derives.

## Out of scope

- Intent + neutral ramp derivation (phase 2, #821).
- Staggered per-family anchor L for cb-safety (phase 2, #821).
- Default seed retune (phase 3, #822).
- Picker / theme generator (deferred, #823) — the `/themes` page is a preview, not the picker.
- Codemod — none required (resolved values identical at default seed).