### PR TITLE
feat(token): derive intent + neutral ramps from --t-seed (RFC-0004 phase 2)

### DIFF
--- a/.changeset/821-color-cascade-phase-2.md
+++ b/.changeset/821-color-cascade-phase-2.md
@@ -1,0 +1,22 @@
+---
+"@teseor/css": minor
+"@teseor/docs": patch
+---
+
+Refactor `--t-neutral-{0..100}` and `--t-{success,warning,danger,info}-{50..900}` to derive from family anchors via `oklch(from var(--t-<family>) <L> calc(c * <multiplier>) h)`. New Tier-2 anchors at `:root`:
+
+- `--t-neutral`: `oklch(from var(--t-seed) 50% calc(c * 0.025) h)` — seed-tinted gray.
+- `--t-success`, `--t-warning`, `--t-danger`, `--t-info`: `color-mix(in oklch, oklch(from var(--t-seed) <L> c <canonical-hue>), oklch(from var(--t-seed) <L> c h) calc(var(--t-harmony) * 100%))` — canonical hue at `--t-harmony: 0`; drifts toward seed hue as `--t-harmony` rises toward `1`.
+
+Adopt staggered per-family anchor lightness for color-blind separation under deuteranopia:
+
+- `--t-success`: 62%
+- `--t-warning`: 68%
+- `--t-danger`: 48% (darker; separates from success luminance-wise)
+- `--t-info`: 55%
+
+Resolved values shift across the intent ramps — most notably danger gets darker (anchor 0.48 vs today's 0.62) and warning settles slightly under amber (anchor 0.68 vs 0.75). Neutral picks up a faint seed tint (chroma `0.18 × 0.025 ≈ 0.0045` at default seed). Consumers who pinned individual `--t-<family>-<step>` values keep their overrides via cascade.
+
+The `--t-on-<intent>` semantic foregrounds keep their existing mappings. Override `--t-seed` to re-skin everything; override `--t-<family>` (e.g. `--t-danger: oklch(0.55 0.25 12)`) to pin a specific intent and let only its ramp re-derive.
+
+Themes page (`/themes`) updates: harmony slider added; section headers describe the new derivation path.

--- a/apps/docs/src/pages/components/button.astro
+++ b/apps/docs/src/pages/components/button.astro
@@ -163,16 +163,28 @@ import Base from "../../layouts/Base.astro";
         <thead><tr><th>Token</th><th>Default</th><th>Forced-colors</th></tr></thead>
         <tbody>
         <tr><td><Code>--t-accent</Code></td><td><Code>oklch(65% 0.18 250deg)</Code></td><td><Code>ButtonText</Code></td></tr>
-        <tr><td><Code>--t-danger</Code></td><td><Code>oklch(62% 0.2 25deg)</Code></td><td><Code>ButtonText</Code></td></tr>
+        <tr><td><Code>--t-danger</Code></td><td><Code>color-mix(
+      in oklch,
+      oklch(from oklch(65% 0.18 250deg) 48% c 25deg),
+      oklch(from oklch(65% 0.18 250deg) 48% c h) calc(0 * 100%)
+    )</Code></td><td><Code>ButtonText</Code></td></tr>
         <tr><td><Code>--t-focus-ring</Code></td><td><Code>oklch(65% 0.18 250deg)</Code></td><td><Code>Highlight</Code></td></tr>
-        <tr><td><Code>--t-on-accent</Code></td><td><Code>oklch(100% 0 0deg)</Code></td><td><Code>ButtonFace</Code></td></tr>
-        <tr><td><Code>--t-on-danger</Code></td><td><Code>oklch(100% 0 0deg)</Code></td><td><Code>ButtonFace</Code></td></tr>
-        <tr><td><Code>--t-on-success</Code></td><td><Code>oklch(100% 0 0deg)</Code></td><td><Code>ButtonFace</Code></td></tr>
-        <tr><td><Code>--t-on-surface</Code></td><td><Code>oklch(18% 0 0deg)</Code></td><td><Code>CanvasText</Code></td></tr>
-        <tr><td><Code>--t-on-warning</Code></td><td><Code>oklch(0% 0 0deg)</Code></td><td><Code>ButtonFace</Code></td></tr>
-        <tr><td><Code>--t-success</Code></td><td><Code>oklch(65% 0.18 155deg)</Code></td><td><Code>ButtonText</Code></td></tr>
-        <tr><td><Code>--t-surface</Code></td><td><Code>oklch(97% 0 0deg)</Code></td><td><Code>Canvas</Code></td></tr>
-        <tr><td><Code>--t-warning</Code></td><td><Code>oklch(75% 0.18 80deg)</Code></td><td><Code>ButtonText</Code></td></tr>
+        <tr><td><Code>--t-on-accent</Code></td><td><Code>oklch(from oklch(from oklch(65% 0.18 250deg) 50% calc(c * 0.025) h) 100% 0 h)</Code></td><td><Code>ButtonFace</Code></td></tr>
+        <tr><td><Code>--t-on-danger</Code></td><td><Code>oklch(from oklch(from oklch(65% 0.18 250deg) 50% calc(c * 0.025) h) 100% 0 h)</Code></td><td><Code>ButtonFace</Code></td></tr>
+        <tr><td><Code>--t-on-success</Code></td><td><Code>oklch(from oklch(from oklch(65% 0.18 250deg) 50% calc(c * 0.025) h) 100% 0 h)</Code></td><td><Code>ButtonFace</Code></td></tr>
+        <tr><td><Code>--t-on-surface</Code></td><td><Code>oklch(from oklch(from oklch(65% 0.18 250deg) 50% calc(c * 0.025) h) 18% c h)</Code></td><td><Code>CanvasText</Code></td></tr>
+        <tr><td><Code>--t-on-warning</Code></td><td><Code>oklch(from oklch(from oklch(65% 0.18 250deg) 50% calc(c * 0.025) h) 0% 0 h)</Code></td><td><Code>ButtonFace</Code></td></tr>
+        <tr><td><Code>--t-success</Code></td><td><Code>color-mix(
+      in oklch,
+      oklch(from oklch(65% 0.18 250deg) 62% c 155deg),
+      oklch(from oklch(65% 0.18 250deg) 62% c h) calc(0 * 100%)
+    )</Code></td><td><Code>ButtonText</Code></td></tr>
+        <tr><td><Code>--t-surface</Code></td><td><Code>oklch(from oklch(from oklch(65% 0.18 250deg) 50% calc(c * 0.025) h) 97% c h)</Code></td><td><Code>Canvas</Code></td></tr>
+        <tr><td><Code>--t-warning</Code></td><td><Code>color-mix(
+      in oklch,
+      oklch(from oklch(65% 0.18 250deg) 68% c 80deg),
+      oklch(from oklch(65% 0.18 250deg) 68% c h) calc(0 * 100%)
+    )</Code></td><td><Code>ButtonText</Code></td></tr>
         </tbody>
       </table>
     </section>
@@ -188,7 +200,7 @@ import Base from "../../layouts/Base.astro";
       <table>
         <thead><tr><th>Artifact</th><th>Raw</th><th>Gzip</th><th>Brotli</th></tr></thead>
         <tbody>
-        <tr><td><a href="https://github.com/teseor/teseor/blob/main/packages/css/src/components/button/button.css"><Code>@teseor/css/components/button.css</Code></a></td><td>9.56 KB</td><td>1.84 KB</td><td>1.53 KB</td></tr>
+        <tr><td><a href="https://github.com/teseor/teseor/blob/main/packages/css/src/components/button/button.css"><Code>@teseor/css/components/button.css</Code></a></td><td>10.35 KB</td><td>1.92 KB</td><td>1.60 KB</td></tr>
         </tbody>
       </table>
     </section>

--- a/apps/docs/src/pages/components/code.astro
+++ b/apps/docs/src/pages/components/code.astro
@@ -36,8 +36,8 @@ import Base from "../../layouts/Base.astro";
       <table>
         <thead><tr><th>Token</th><th>Default</th><th>Forced-colors</th></tr></thead>
         <tbody>
-        <tr><td><Code>--t-on-surface-muted</Code></td><td><Code>oklch(18% 0 0deg)</Code></td><td><Code>CanvasText</Code></td></tr>
-        <tr><td><Code>--t-surface-muted</Code></td><td><Code>oklch(92% 0 0deg)</Code></td><td><Code>Canvas</Code></td></tr>
+        <tr><td><Code>--t-on-surface-muted</Code></td><td><Code>oklch(from oklch(from oklch(65% 0.18 250deg) 50% calc(c * 0.025) h) 18% c h)</Code></td><td><Code>CanvasText</Code></td></tr>
+        <tr><td><Code>--t-surface-muted</Code></td><td><Code>oklch(from oklch(from oklch(65% 0.18 250deg) 50% calc(c * 0.025) h) 92% c h)</Code></td><td><Code>Canvas</Code></td></tr>
         </tbody>
       </table>
     </section>
@@ -46,7 +46,7 @@ import Base from "../../layouts/Base.astro";
       <table>
         <thead><tr><th>Artifact</th><th>Raw</th><th>Gzip</th><th>Brotli</th></tr></thead>
         <tbody>
-        <tr><td><a href="https://github.com/teseor/teseor/blob/main/packages/css/src/components/code/code.css"><Code>@teseor/css/components/code.css</Code></a></td><td>0.98 KB</td><td>0.45 KB</td><td>0.40 KB</td></tr>
+        <tr><td><a href="https://github.com/teseor/teseor/blob/main/packages/css/src/components/code/code.css"><Code>@teseor/css/components/code.css</Code></a></td><td>1.10 KB</td><td>0.48 KB</td><td>0.44 KB</td></tr>
         </tbody>
       </table>
     </section>

--- a/apps/docs/src/pages/components/codeblock.astro
+++ b/apps/docs/src/pages/components/codeblock.astro
@@ -36,8 +36,8 @@ import Base from "../../layouts/Base.astro";
       <table>
         <thead><tr><th>Token</th><th>Default</th><th>Forced-colors</th></tr></thead>
         <tbody>
-        <tr><td><Code>--t-on-surface-muted</Code></td><td><Code>oklch(18% 0 0deg)</Code></td><td><Code>CanvasText</Code></td></tr>
-        <tr><td><Code>--t-surface-muted</Code></td><td><Code>oklch(92% 0 0deg)</Code></td><td><Code>Canvas</Code></td></tr>
+        <tr><td><Code>--t-on-surface-muted</Code></td><td><Code>oklch(from oklch(from oklch(65% 0.18 250deg) 50% calc(c * 0.025) h) 18% c h)</Code></td><td><Code>CanvasText</Code></td></tr>
+        <tr><td><Code>--t-surface-muted</Code></td><td><Code>oklch(from oklch(from oklch(65% 0.18 250deg) 50% calc(c * 0.025) h) 92% c h)</Code></td><td><Code>Canvas</Code></td></tr>
         </tbody>
       </table>
     </section>
@@ -46,7 +46,7 @@ import Base from "../../layouts/Base.astro";
       <table>
         <thead><tr><th>Artifact</th><th>Raw</th><th>Gzip</th><th>Brotli</th></tr></thead>
         <tbody>
-        <tr><td><a href="https://github.com/teseor/teseor/blob/main/packages/css/src/components/codeblock/codeblock.css"><Code>@teseor/css/components/codeblock.css</Code></a></td><td>1.18 KB</td><td>0.52 KB</td><td>0.45 KB</td></tr>
+        <tr><td><a href="https://github.com/teseor/teseor/blob/main/packages/css/src/components/codeblock/codeblock.css"><Code>@teseor/css/components/codeblock.css</Code></a></td><td>1.29 KB</td><td>0.55 KB</td><td>0.47 KB</td></tr>
         </tbody>
       </table>
     </section>

--- a/apps/docs/src/pages/components/modal.astro
+++ b/apps/docs/src/pages/components/modal.astro
@@ -64,8 +64,8 @@ import Base from "../../layouts/Base.astro";
       <table>
         <thead><tr><th>Token</th><th>Default</th><th>Forced-colors</th></tr></thead>
         <tbody>
-        <tr><td><Code>--t-bg</Code></td><td><Code>oklch(100% 0 0deg)</Code></td><td><Code>Canvas</Code></td></tr>
-        <tr><td><Code>--t-on-bg</Code></td><td><Code>oklch(18% 0 0deg)</Code></td><td><Code>CanvasText</Code></td></tr>
+        <tr><td><Code>--t-bg</Code></td><td><Code>oklch(from oklch(from oklch(65% 0.18 250deg) 50% calc(c * 0.025) h) 100% 0 h)</Code></td><td><Code>Canvas</Code></td></tr>
+        <tr><td><Code>--t-on-bg</Code></td><td><Code>oklch(from oklch(from oklch(65% 0.18 250deg) 50% calc(c * 0.025) h) 18% c h)</Code></td><td><Code>CanvasText</Code></td></tr>
         </tbody>
       </table>
     </section>
@@ -74,7 +74,7 @@ import Base from "../../layouts/Base.astro";
       <table>
         <thead><tr><th>Artifact</th><th>Raw</th><th>Gzip</th><th>Brotli</th></tr></thead>
         <tbody>
-        <tr><td><a href="https://github.com/teseor/teseor/blob/main/packages/css/src/components/modal/modal.css"><Code>@teseor/css/components/modal.css</Code></a></td><td>1.36 KB</td><td>0.58 KB</td><td>0.51 KB</td></tr>
+        <tr><td><a href="https://github.com/teseor/teseor/blob/main/packages/css/src/components/modal/modal.css"><Code>@teseor/css/components/modal.css</Code></a></td><td>1.47 KB</td><td>0.61 KB</td><td>0.53 KB</td></tr>
         </tbody>
       </table>
     </section>

--- a/apps/docs/src/pages/components/tooltip.astro
+++ b/apps/docs/src/pages/components/tooltip.astro
@@ -121,8 +121,8 @@ import Base from "../../layouts/Base.astro";
       <table>
         <thead><tr><th>Token</th><th>Default</th><th>Forced-colors</th></tr></thead>
         <tbody>
-        <tr><td><Code>--t-on-surface-inverse</Code></td><td><Code>oklch(97% 0 0deg)</Code></td><td><Code>CanvasText</Code></td></tr>
-        <tr><td><Code>--t-surface-inverse</Code></td><td><Code>oklch(18% 0 0deg)</Code></td><td><Code>Canvas</Code></td></tr>
+        <tr><td><Code>--t-on-surface-inverse</Code></td><td><Code>oklch(from oklch(from oklch(65% 0.18 250deg) 50% calc(c * 0.025) h) 97% c h)</Code></td><td><Code>CanvasText</Code></td></tr>
+        <tr><td><Code>--t-surface-inverse</Code></td><td><Code>oklch(from oklch(from oklch(65% 0.18 250deg) 50% calc(c * 0.025) h) 18% c h)</Code></td><td><Code>Canvas</Code></td></tr>
         </tbody>
       </table>
     </section>
@@ -131,7 +131,7 @@ import Base from "../../layouts/Base.astro";
       <table>
         <thead><tr><th>Artifact</th><th>Raw</th><th>Gzip</th><th>Brotli</th></tr></thead>
         <tbody>
-        <tr><td><a href="https://github.com/teseor/teseor/blob/main/packages/css/src/components/tooltip/tooltip.css"><Code>@teseor/css/components/tooltip.css</Code></a></td><td>12.06 KB</td><td>2.09 KB</td><td>1.72 KB</td></tr>
+        <tr><td><a href="https://github.com/teseor/teseor/blob/main/packages/css/src/components/tooltip/tooltip.css"><Code>@teseor/css/components/tooltip.css</Code></a></td><td>12.23 KB</td><td>2.12 KB</td><td>1.75 KB</td></tr>
         </tbody>
       </table>
     </section>

--- a/apps/docs/src/pages/themes.astro
+++ b/apps/docs/src/pages/themes.astro
@@ -138,6 +138,47 @@ const intents = ["accent", "success", "warning", "danger", "info"] as const;
   const root = document.documentElement;
   const inputs = document.querySelectorAll<HTMLInputElement>("input[data-token]");
   const harmonyOut = document.getElementById("harmony-out");
+
+  /**
+   * Resolves any CSS color (oklch, color-mix, var-chain) to a six-digit hex by
+   * letting the browser paint into a probe element and reading the computed rgb.
+   * `<input type="color">` only accepts hex, so we go through the computed-style
+   * rgb form and convert.
+   */
+  function tokenToHex(token: string): string | null {
+    const probe = document.createElement("div");
+    probe.style.color = `var(${token})`;
+    document.body.appendChild(probe);
+    const computed = getComputedStyle(probe).color;
+    document.body.removeChild(probe);
+    const match = computed.match(/rgba?\(\s*([\d.]+)[,\s]+([\d.]+)[,\s]+([\d.]+)/);
+    if (!match) return null;
+    const [, r, g, b] = match;
+    return (
+      "#" +
+      [r, g, b]
+        .map((n) => Math.round(Number.parseFloat(n)).toString(16).padStart(2, "0"))
+        .join("")
+    );
+  }
+
+  function syncInputs(): void {
+    inputs.forEach((input) => {
+      const token = input.dataset.token;
+      if (!token) return;
+      if (input.type === "color") {
+        const hex = tokenToHex(token);
+        if (hex) input.value = hex;
+      } else if (input.type === "range") {
+        const value = getComputedStyle(root).getPropertyValue(token).trim();
+        input.value = value || "0";
+        if (token === "--t-harmony" && harmonyOut) harmonyOut.textContent = input.value;
+      }
+    });
+  }
+
+  syncInputs();
+
   inputs.forEach((input) => {
     input.addEventListener("input", (event) => {
       const target = event.currentTarget as HTMLInputElement;
@@ -147,14 +188,13 @@ const intents = ["accent", "success", "warning", "danger", "info"] as const;
       if (token === "--t-harmony" && harmonyOut) harmonyOut.textContent = target.value;
     });
   });
+
   document.getElementById("reset-tokens")?.addEventListener("click", () => {
     inputs.forEach((input) => {
       const token = input.dataset.token;
       if (token) root.style.removeProperty(token);
-      if (input.type === "range") input.value = "0";
-      else input.value = "#5471b5";
     });
-    if (harmonyOut) harmonyOut.textContent = "0";
+    syncInputs();
   });
 </script>
 

--- a/apps/docs/src/pages/themes.astro
+++ b/apps/docs/src/pages/themes.astro
@@ -15,9 +15,11 @@ const intents = ["accent", "success", "warning", "danger", "info"] as const;
   <main class="t-stack" data-gap="6">
     <h1>Themes</h1>
     <p>
-      Color cascade preview. Phase 1: <code>--t-seed</code> drives the accent
-      ramp via <code>oklch(from …)</code>. Intent + neutral ramps are still
-      hand-authored — they migrate in phase 2.
+      Color cascade preview. <code>--t-seed</code> drives every ramp:
+      accent + neutral inherit the seed hue directly; intents canonical-hue
+      by default and drift toward seed as <code>--t-harmony</code> rises.
+      Override any family anchor below to pin a specific color; the ramp
+      re-derives in place.
     </p>
 
     <section class="t-stack" data-gap="3">
@@ -30,6 +32,18 @@ const intents = ["accent", "success", "warning", "danger", "info"] as const;
         <label>
           <span>seed</span>
           <input type="color" data-token="--t-seed" value="#5471b5" />
+        </label>
+        <label class="slider">
+          <span>harmony</span>
+          <input
+            type="range"
+            data-token="--t-harmony"
+            min="0"
+            max="1"
+            step="0.05"
+            value="0"
+          />
+          <output id="harmony-out">0</output>
         </label>
         {intents.map((intent) => (
           <label>
@@ -64,7 +78,7 @@ const intents = ["accent", "success", "warning", "danger", "info"] as const;
     </section>
 
     <section class="t-stack" data-gap="3">
-      <h2>Intent ramps (hand-authored, derived in phase 2)</h2>
+      <h2>Intent ramps (seed-derived; canonical-hue at <code>--t-harmony: 0</code>)</h2>
       {(["success", "warning", "danger", "info"] as const).map((family) => (
         <div>
           <h3>{family}</h3>
@@ -80,7 +94,7 @@ const intents = ["accent", "success", "warning", "danger", "info"] as const;
     </section>
 
     <section class="t-stack" data-gap="3">
-      <h2>Neutral ramp (hand-authored, derived in phase 2)</h2>
+      <h2>Neutral ramp (seed-tinted gray; chroma 0.025× seed)</h2>
       <div class="ramp" data-family="neutral">
         {neutralSteps.map((step) => (
           <div class="swatch" data-step={step} style={`background: var(--t-neutral-${step})`}>
@@ -123,19 +137,24 @@ const intents = ["accent", "success", "warning", "danger", "info"] as const;
 <script>
   const root = document.documentElement;
   const inputs = document.querySelectorAll<HTMLInputElement>("input[data-token]");
+  const harmonyOut = document.getElementById("harmony-out");
   inputs.forEach((input) => {
     input.addEventListener("input", (event) => {
       const target = event.currentTarget as HTMLInputElement;
       const token = target.dataset.token;
-      if (token) root.style.setProperty(token, target.value);
+      if (!token) return;
+      root.style.setProperty(token, target.value);
+      if (token === "--t-harmony" && harmonyOut) harmonyOut.textContent = target.value;
     });
   });
   document.getElementById("reset-tokens")?.addEventListener("click", () => {
     inputs.forEach((input) => {
       const token = input.dataset.token;
       if (token) root.style.removeProperty(token);
-      input.value = "#5471b5";
+      if (input.type === "range") input.value = "0";
+      else input.value = "#5471b5";
     });
+    if (harmonyOut) harmonyOut.textContent = "0";
   });
 </script>
 
@@ -223,6 +242,21 @@ const intents = ["accent", "success", "warning", "danger", "info"] as const;
     border-radius: var(--t-radius-sm);
     padding: 0;
     background: transparent;
+  }
+
+  .picker-grid .slider {
+    flex-direction: column;
+    gap: var(--t-space-1);
+  }
+
+  .picker-grid .slider input[type="range"] {
+    inline-size: 8rem;
+  }
+
+  .picker-grid output {
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 0.75rem;
+    color: var(--t-neutral-90);
   }
 
   .picker-grid button {

--- a/packages/css/src/tokens.css
+++ b/packages/css/src/tokens.css
@@ -2,13 +2,9 @@
 
 @layer tokens.scale {
   :root {
-    /* ===== Colors — oklch throughout (Baseline 2024) ===== */
-
-    /* ===== Color seed — sole knob for the color cascade. ===== */
+    /* ===== Colors — oklch; seed-derived cascade (Baseline 2025). ===== */
     --t-seed: oklch(65% 0.18 250deg);
     --t-harmony: 0;
-
-    /* Neutral — derived from --t-neutral (seed-tinted gray). Steps 0/100 forced pure. */
     --t-neutral-0: oklch(from var(--t-neutral) 100% 0 h);
     --t-neutral-10: oklch(from var(--t-neutral) 97% c h);
     --t-neutral-20: oklch(from var(--t-neutral) 92% c h);
@@ -20,8 +16,6 @@
     --t-neutral-80: oklch(from var(--t-neutral) 30% c h);
     --t-neutral-90: oklch(from var(--t-neutral) 18% c h);
     --t-neutral-100: oklch(from var(--t-neutral) 0% 0 h);
-
-    /* Accent — derived from --t-accent (default = seed). */
     --t-accent-50: oklch(from var(--t-accent) 97% calc(c * 0.111) h);
     --t-accent-100: oklch(from var(--t-accent) 93% calc(c * 0.278) h);
     --t-accent-200: oklch(from var(--t-accent) 86% calc(c * 0.5) h);
@@ -32,8 +26,6 @@
     --t-accent-700: oklch(from var(--t-accent) 45% calc(c * 0.889) h);
     --t-accent-800: oklch(from var(--t-accent) 35% calc(c * 0.722) h);
     --t-accent-900: oklch(from var(--t-accent) 25% calc(c * 0.556) h);
-
-    /* Success — derived from --t-success (anchor L=62%; canonical hue 155 ↔ seed at --t-harmony). */
     --t-success-50: oklch(from var(--t-success) 97% calc(c * 0.111) h);
     --t-success-100: oklch(from var(--t-success) 93% calc(c * 0.278) h);
     --t-success-200: oklch(from var(--t-success) 86% calc(c * 0.5) h);
@@ -44,8 +36,6 @@
     --t-success-700: oklch(from var(--t-success) 42% calc(c * 0.889) h);
     --t-success-800: oklch(from var(--t-success) 32% calc(c * 0.722) h);
     --t-success-900: oklch(from var(--t-success) 22% calc(c * 0.556) h);
-
-    /* Warning — derived from --t-warning (anchor L=68%; "alert, not stop"). */
     --t-warning-50: oklch(from var(--t-warning) 97% calc(c * 0.111) h);
     --t-warning-100: oklch(from var(--t-warning) 93% calc(c * 0.278) h);
     --t-warning-200: oklch(from var(--t-warning) 86% calc(c * 0.5) h);
@@ -56,8 +46,6 @@
     --t-warning-700: oklch(from var(--t-warning) 48% calc(c * 0.889) h);
     --t-warning-800: oklch(from var(--t-warning) 38% calc(c * 0.722) h);
     --t-warning-900: oklch(from var(--t-warning) 28% calc(c * 0.556) h);
-
-    /* Danger — derived from --t-danger (anchor L=48%; darker, cb-safety from success). */
     --t-danger-50: oklch(from var(--t-danger) 97% calc(c * 0.111) h);
     --t-danger-100: oklch(from var(--t-danger) 93% calc(c * 0.278) h);
     --t-danger-200: oklch(from var(--t-danger) 86% calc(c * 0.5) h);
@@ -68,8 +56,6 @@
     --t-danger-700: oklch(from var(--t-danger) 32% calc(c * 0.889) h);
     --t-danger-800: oklch(from var(--t-danger) 24% calc(c * 0.722) h);
     --t-danger-900: oklch(from var(--t-danger) 16% calc(c * 0.556) h);
-
-    /* Info — derived from --t-info (anchor L=55%). */
     --t-info-50: oklch(from var(--t-info) 97% calc(c * 0.111) h);
     --t-info-100: oklch(from var(--t-info) 93% calc(c * 0.278) h);
     --t-info-200: oklch(from var(--t-info) 86% calc(c * 0.5) h);
@@ -223,7 +209,7 @@
     --t-border: var(--t-neutral-20);
     --t-border-strong: var(--t-neutral-40);
 
-    /* ===== Family anchors — derive from --t-seed; ramps read these. ===== */
+    /* ===== Family anchors — ramps read these. ===== */
     --t-accent: var(--t-seed);
     --t-neutral: oklch(from var(--t-seed) 50% calc(c * 0.025) h);
     --t-success: color-mix(
@@ -247,7 +233,7 @@
       oklch(from var(--t-seed) 55% c h) calc(var(--t-harmony) * 100%)
     );
 
-    /* ===== Intent foregrounds — paired text/icon color for each fill. ===== */
+    /* ===== Intent foregrounds. ===== */
     --t-on-accent: var(--t-neutral-0);
     --t-on-success: var(--t-neutral-0);
     --t-on-warning: var(--t-neutral-100);

--- a/packages/css/src/tokens.css
+++ b/packages/css/src/tokens.css
@@ -4,22 +4,22 @@
   :root {
     /* ===== Colors — oklch throughout (Baseline 2024) ===== */
 
-    /* Neutral — 0 lightest, 100 darkest */
-    --t-neutral-0: oklch(100% 0 0deg);
-    --t-neutral-10: oklch(97% 0 0deg);
-    --t-neutral-20: oklch(92% 0 0deg);
-    --t-neutral-30: oklch(85% 0 0deg);
-    --t-neutral-40: oklch(75% 0 0deg);
-    --t-neutral-50: oklch(65% 0 0deg);
-    --t-neutral-60: oklch(55% 0 0deg);
-    --t-neutral-70: oklch(42% 0 0deg);
-    --t-neutral-80: oklch(30% 0 0deg);
-    --t-neutral-90: oklch(18% 0 0deg);
-    --t-neutral-100: oklch(0% 0 0deg);
-
     /* ===== Color seed — sole knob for the color cascade. ===== */
     --t-seed: oklch(65% 0.18 250deg);
     --t-harmony: 0;
+
+    /* Neutral — derived from --t-neutral (seed-tinted gray). Steps 0/100 forced pure. */
+    --t-neutral-0: oklch(from var(--t-neutral) 100% 0 h);
+    --t-neutral-10: oklch(from var(--t-neutral) 97% c h);
+    --t-neutral-20: oklch(from var(--t-neutral) 92% c h);
+    --t-neutral-30: oklch(from var(--t-neutral) 85% c h);
+    --t-neutral-40: oklch(from var(--t-neutral) 75% c h);
+    --t-neutral-50: oklch(from var(--t-neutral) 65% c h);
+    --t-neutral-60: oklch(from var(--t-neutral) 55% c h);
+    --t-neutral-70: oklch(from var(--t-neutral) 42% c h);
+    --t-neutral-80: oklch(from var(--t-neutral) 30% c h);
+    --t-neutral-90: oklch(from var(--t-neutral) 18% c h);
+    --t-neutral-100: oklch(from var(--t-neutral) 0% 0 h);
 
     /* Accent — derived from --t-accent (default = seed). */
     --t-accent-50: oklch(from var(--t-accent) 97% calc(c * 0.111) h);
@@ -33,53 +33,53 @@
     --t-accent-800: oklch(from var(--t-accent) 35% calc(c * 0.722) h);
     --t-accent-900: oklch(from var(--t-accent) 25% calc(c * 0.556) h);
 
-    /* Success — green, hue 155 */
-    --t-success-50: oklch(97% 0.02 155deg);
-    --t-success-100: oklch(93% 0.05 155deg);
-    --t-success-200: oklch(86% 0.09 155deg);
-    --t-success-300: oklch(78% 0.13 155deg);
-    --t-success-400: oklch(71% 0.16 155deg);
-    --t-success-500: oklch(65% 0.18 155deg);
-    --t-success-600: oklch(55% 0.18 155deg);
-    --t-success-700: oklch(45% 0.16 155deg);
-    --t-success-800: oklch(35% 0.13 155deg);
-    --t-success-900: oklch(25% 0.1 155deg);
+    /* Success — derived from --t-success (anchor L=62%; canonical hue 155 ↔ seed at --t-harmony). */
+    --t-success-50: oklch(from var(--t-success) 97% calc(c * 0.111) h);
+    --t-success-100: oklch(from var(--t-success) 93% calc(c * 0.278) h);
+    --t-success-200: oklch(from var(--t-success) 86% calc(c * 0.5) h);
+    --t-success-300: oklch(from var(--t-success) 78% calc(c * 0.722) h);
+    --t-success-400: oklch(from var(--t-success) 71% calc(c * 0.889) h);
+    --t-success-500: var(--t-success);
+    --t-success-600: oklch(from var(--t-success) 52% c h);
+    --t-success-700: oklch(from var(--t-success) 42% calc(c * 0.889) h);
+    --t-success-800: oklch(from var(--t-success) 32% calc(c * 0.722) h);
+    --t-success-900: oklch(from var(--t-success) 22% calc(c * 0.556) h);
 
-    /* Warning — amber, hue 80 */
-    --t-warning-50: oklch(97% 0.02 80deg);
-    --t-warning-100: oklch(93% 0.05 80deg);
-    --t-warning-200: oklch(86% 0.09 80deg);
-    --t-warning-300: oklch(82% 0.13 80deg);
-    --t-warning-400: oklch(78% 0.16 80deg);
-    --t-warning-500: oklch(75% 0.18 80deg);
-    --t-warning-600: oklch(65% 0.18 80deg);
-    --t-warning-700: oklch(55% 0.16 80deg);
-    --t-warning-800: oklch(40% 0.13 80deg);
-    --t-warning-900: oklch(30% 0.1 80deg);
+    /* Warning — derived from --t-warning (anchor L=68%; "alert, not stop"). */
+    --t-warning-50: oklch(from var(--t-warning) 97% calc(c * 0.111) h);
+    --t-warning-100: oklch(from var(--t-warning) 93% calc(c * 0.278) h);
+    --t-warning-200: oklch(from var(--t-warning) 86% calc(c * 0.5) h);
+    --t-warning-300: oklch(from var(--t-warning) 80% calc(c * 0.722) h);
+    --t-warning-400: oklch(from var(--t-warning) 75% calc(c * 0.889) h);
+    --t-warning-500: var(--t-warning);
+    --t-warning-600: oklch(from var(--t-warning) 58% c h);
+    --t-warning-700: oklch(from var(--t-warning) 48% calc(c * 0.889) h);
+    --t-warning-800: oklch(from var(--t-warning) 38% calc(c * 0.722) h);
+    --t-warning-900: oklch(from var(--t-warning) 28% calc(c * 0.556) h);
 
-    /* Danger — red, hue 25 */
-    --t-danger-50: oklch(97% 0.02 25deg);
-    --t-danger-100: oklch(93% 0.05 25deg);
-    --t-danger-200: oklch(86% 0.09 25deg);
-    --t-danger-300: oklch(78% 0.13 25deg);
-    --t-danger-400: oklch(70% 0.16 25deg);
-    --t-danger-500: oklch(62% 0.2 25deg);
-    --t-danger-600: oklch(52% 0.2 25deg);
-    --t-danger-700: oklch(42% 0.18 25deg);
-    --t-danger-800: oklch(33% 0.14 25deg);
-    --t-danger-900: oklch(24% 0.1 25deg);
+    /* Danger — derived from --t-danger (anchor L=48%; darker, cb-safety from success). */
+    --t-danger-50: oklch(from var(--t-danger) 97% calc(c * 0.111) h);
+    --t-danger-100: oklch(from var(--t-danger) 93% calc(c * 0.278) h);
+    --t-danger-200: oklch(from var(--t-danger) 86% calc(c * 0.5) h);
+    --t-danger-300: oklch(from var(--t-danger) 78% calc(c * 0.722) h);
+    --t-danger-400: oklch(from var(--t-danger) 70% calc(c * 0.889) h);
+    --t-danger-500: var(--t-danger);
+    --t-danger-600: oklch(from var(--t-danger) 40% c h);
+    --t-danger-700: oklch(from var(--t-danger) 32% calc(c * 0.889) h);
+    --t-danger-800: oklch(from var(--t-danger) 24% calc(c * 0.722) h);
+    --t-danger-900: oklch(from var(--t-danger) 16% calc(c * 0.556) h);
 
-    /* Info — cyan, hue 210 */
-    --t-info-50: oklch(97% 0.02 210deg);
-    --t-info-100: oklch(93% 0.05 210deg);
-    --t-info-200: oklch(86% 0.09 210deg);
-    --t-info-300: oklch(78% 0.13 210deg);
-    --t-info-400: oklch(71% 0.15 210deg);
-    --t-info-500: oklch(65% 0.17 210deg);
-    --t-info-600: oklch(55% 0.17 210deg);
-    --t-info-700: oklch(45% 0.15 210deg);
-    --t-info-800: oklch(35% 0.12 210deg);
-    --t-info-900: oklch(25% 0.09 210deg);
+    /* Info — derived from --t-info (anchor L=55%). */
+    --t-info-50: oklch(from var(--t-info) 97% calc(c * 0.111) h);
+    --t-info-100: oklch(from var(--t-info) 93% calc(c * 0.278) h);
+    --t-info-200: oklch(from var(--t-info) 86% calc(c * 0.5) h);
+    --t-info-300: oklch(from var(--t-info) 78% calc(c * 0.722) h);
+    --t-info-400: oklch(from var(--t-info) 66% calc(c * 0.889) h);
+    --t-info-500: var(--t-info);
+    --t-info-600: oklch(from var(--t-info) 45% c h);
+    --t-info-700: oklch(from var(--t-info) 37% calc(c * 0.889) h);
+    --t-info-800: oklch(from var(--t-info) 28% calc(c * 0.722) h);
+    --t-info-900: oklch(from var(--t-info) 20% calc(c * 0.556) h);
 
     /* ===== Grid unit — sole knob for the spatial system =====
 
@@ -223,16 +223,35 @@
     --t-border: var(--t-neutral-20);
     --t-border-strong: var(--t-neutral-40);
 
-    /* ===== Intents — pairs every fill with --t-on-<role> ===== */
+    /* ===== Family anchors — derive from --t-seed; ramps read these. ===== */
     --t-accent: var(--t-seed);
+    --t-neutral: oklch(from var(--t-seed) 50% calc(c * 0.025) h);
+    --t-success: color-mix(
+      in oklch,
+      oklch(from var(--t-seed) 62% c 155deg),
+      oklch(from var(--t-seed) 62% c h) calc(var(--t-harmony) * 100%)
+    );
+    --t-warning: color-mix(
+      in oklch,
+      oklch(from var(--t-seed) 68% c 80deg),
+      oklch(from var(--t-seed) 68% c h) calc(var(--t-harmony) * 100%)
+    );
+    --t-danger: color-mix(
+      in oklch,
+      oklch(from var(--t-seed) 48% c 25deg),
+      oklch(from var(--t-seed) 48% c h) calc(var(--t-harmony) * 100%)
+    );
+    --t-info: color-mix(
+      in oklch,
+      oklch(from var(--t-seed) 55% c 210deg),
+      oklch(from var(--t-seed) 55% c h) calc(var(--t-harmony) * 100%)
+    );
+
+    /* ===== Intent foregrounds — paired text/icon color for each fill. ===== */
     --t-on-accent: var(--t-neutral-0);
-    --t-success: var(--t-success-500);
     --t-on-success: var(--t-neutral-0);
-    --t-warning: var(--t-warning-500);
     --t-on-warning: var(--t-neutral-100);
-    --t-danger: var(--t-danger-500);
     --t-on-danger: var(--t-neutral-0);
-    --t-info: var(--t-info-500);
     --t-on-info: var(--t-neutral-0);
 
     /* ===== Focus ===== */


### PR DESCRIPTION
## What

Phase 2 of RFC-0004 (color seed-derived cascade).

- Refactor `--t-{success,warning,danger,info}-{50..900}` and `--t-neutral-{0..100}` to derive from family anchors via `oklch(from var(--t-<family>) <L> calc(c * <multiplier>) h)`. Shared chroma multiplier table; family-specific L per step below 500.
- New Tier-2 family anchors at `:root`:
  - `--t-neutral`: `oklch(from var(--t-seed) 50% calc(c * 0.025) h)` — seed-tinted gray (chroma ~0.0045 at default seed).
  - `--t-success`, `--t-warning`, `--t-danger`, `--t-info`: `color-mix(in oklch, oklch(from var(--t-seed) <anchorL> c <canonicalH>), oklch(from var(--t-seed) <anchorL> c h) calc(var(--t-harmony) * 100%))`. Canonical hues (155 / 80 / 25 / 210) at `--t-harmony: 0`; drift toward seed as `--t-harmony` rises.
- Staggered per-family anchor lightness for color-blind separation under deuteranopia: success 62%, warning 68%, danger 48%, info 55%. Today's clustered intent-500 lightness (danger 0.62 / success 0.65 / info 0.65) collapse under deuteranopia — danger and success were within 0.03 L of each other.
- `--t-on-<intent>` semantic foregrounds keep their existing neutral mapping.
- Plugin (`postcss-teseor-floor`) handles `color-mix(in oklch, …)` cleanly through its existing var-chain recursion — no plugin changes needed.
- Themes page (`/themes`) update: harmony slider added; section copy reflects the new derivation path.

Closes #821.

## Why

RFC-0004 ([docs/RFC/0004-color-seed-derived.md](https://github.com/teseor/teseor/blob/main/docs/RFC/0004-color-seed-derived.md)). Phase 1 landed the seed surface + accent derivation; Phase 2 brings the intent + neutral families under the same cascade. The staggered anchor lightness is the color-blind-safety win the RFC promised — defaults that don't collapse under deuteranopia, with the picker handling cb-safety warnings for Level-2 overrides.

Resolved values shift across the intent ramps (most notably danger gets darker — anchor 0.48 vs today's 0.62). Consumers who pinned per-step values keep their overrides via cascade.

## Test plan

- [x] `pnpm test` — 942 tests pass.
- [x] `pnpm lint` — clean.
- [x] `pnpm typecheck` — clean.
- [x] `pnpm build:css` + `pnpm build:docs` — clean.
- [x] `npx size-limit` — 7.94 kB brotlied vs 8 kB limit.
- [x] Spot-check: `--t-danger-500` resolves at default seed (`oklch(0.65 0.18 250deg)`, `--t-harmony: 0`) to `oklch(48% 0.18 25deg)` — anchor L=0.48, canonical hue 25 (harmony=0 → pure canonical branch).
- [ ] Reviewer: navigate to `/themes`, observe the intent ramps now respond to seed picker changes; move the harmony slider to see canonical→seed-hue drift; verify the danger button stays distinct from success under simulated color-blindness.

## Known issue (deferred)

Component "Tokens" tables in `apps/docs/src/pages/components/*.astro` now show nested `oklch(from oklch(from … ) … )` expressions instead of flat literal values, because the codegen pulls from `buildTokenMap` which resolves `var()` chains but doesn't evaluate relative-color expressions. Accurate but unreadable for end users. Filing a follow-up to flatten derived expressions in the docs codegen.

## Out of scope

- Default seed retune (phase 3, #822) — `--t-seed` stays at `oklch(65% 0.18 250deg)` for this PR.
- Picker / theme generator (deferred, #823).
- Loop-based ramp generation via `postcss-each` — surfaced during the review; tabled for a follow-up since family L values are staggered per anchor and don't share a clean iteration shape. The bundle stays under the 8 kB budget without the optimization.
- Codegen flattening of derived expressions in component-detail docs (known issue above).