### PR TITLE
feat(token): retune default --t-seed to indigo-violet (RFC-0004 phase 3)

### DIFF
--- a/.changeset/822-color-cascade-phase-3.md
+++ b/.changeset/822-color-cascade-phase-3.md
@@ -1,0 +1,9 @@
+---
+"@teseor/css": minor
+---
+
+Retune the default `--t-seed` from `oklch(65% 0.18 250deg)` (blue, the v0.x accent) to `oklch(58% 0.2 268deg)` (indigo-violet). Pure value change — no API change, no token rename, no consumer code change required.
+
+Why this shade: hue 268° steps out of the most-used CTA blue band (Tailwind blue, Bootstrap primary, MUI primary all sit ~240–250°). Lightness 0.58 lifts APCA contrast against white text past Lc 60 with margin (today's 0.65 sat near the floor). Chroma 0.20 gives the accent presence without crossing into neon. Intent hues stay canonical; harmonization remains opt-in via `--t-harmony`.
+
+Visual diff for consumers who haven't overridden `--t-seed` or `--t-accent`. Consumers who want the v0.x palette can pin `--t-seed: oklch(65% 0.18 250deg);` in their `theme.css`.

--- a/apps/docs/src/pages/components/button.astro
+++ b/apps/docs/src/pages/components/button.astro
@@ -162,28 +162,28 @@ import Base from "../../layouts/Base.astro";
       <table>
         <thead><tr><th>Token</th><th>Default</th><th>Forced-colors</th></tr></thead>
         <tbody>
-        <tr><td><Code>--t-accent</Code></td><td><Code>oklch(65% 0.18 250deg)</Code></td><td><Code>ButtonText</Code></td></tr>
+        <tr><td><Code>--t-accent</Code></td><td><Code>oklch(58% 0.2 268deg)</Code></td><td><Code>ButtonText</Code></td></tr>
         <tr><td><Code>--t-danger</Code></td><td><Code>color-mix(
       in oklch,
-      oklch(from oklch(65% 0.18 250deg) 48% c 25deg),
-      oklch(from oklch(65% 0.18 250deg) 48% c h) calc(0 * 100%)
+      oklch(from oklch(58% 0.2 268deg) 48% c 25deg),
+      oklch(from oklch(58% 0.2 268deg) 48% c h) calc(0 * 100%)
     )</Code></td><td><Code>ButtonText</Code></td></tr>
-        <tr><td><Code>--t-focus-ring</Code></td><td><Code>oklch(65% 0.18 250deg)</Code></td><td><Code>Highlight</Code></td></tr>
-        <tr><td><Code>--t-on-accent</Code></td><td><Code>oklch(from oklch(from oklch(65% 0.18 250deg) 50% calc(c * 0.025) h) 100% 0 h)</Code></td><td><Code>ButtonFace</Code></td></tr>
-        <tr><td><Code>--t-on-danger</Code></td><td><Code>oklch(from oklch(from oklch(65% 0.18 250deg) 50% calc(c * 0.025) h) 100% 0 h)</Code></td><td><Code>ButtonFace</Code></td></tr>
-        <tr><td><Code>--t-on-success</Code></td><td><Code>oklch(from oklch(from oklch(65% 0.18 250deg) 50% calc(c * 0.025) h) 100% 0 h)</Code></td><td><Code>ButtonFace</Code></td></tr>
-        <tr><td><Code>--t-on-surface</Code></td><td><Code>oklch(from oklch(from oklch(65% 0.18 250deg) 50% calc(c * 0.025) h) 18% c h)</Code></td><td><Code>CanvasText</Code></td></tr>
-        <tr><td><Code>--t-on-warning</Code></td><td><Code>oklch(from oklch(from oklch(65% 0.18 250deg) 50% calc(c * 0.025) h) 0% 0 h)</Code></td><td><Code>ButtonFace</Code></td></tr>
+        <tr><td><Code>--t-focus-ring</Code></td><td><Code>oklch(58% 0.2 268deg)</Code></td><td><Code>Highlight</Code></td></tr>
+        <tr><td><Code>--t-on-accent</Code></td><td><Code>oklch(from oklch(from oklch(58% 0.2 268deg) 50% calc(c * 0.025) h) 100% 0 h)</Code></td><td><Code>ButtonFace</Code></td></tr>
+        <tr><td><Code>--t-on-danger</Code></td><td><Code>oklch(from oklch(from oklch(58% 0.2 268deg) 50% calc(c * 0.025) h) 100% 0 h)</Code></td><td><Code>ButtonFace</Code></td></tr>
+        <tr><td><Code>--t-on-success</Code></td><td><Code>oklch(from oklch(from oklch(58% 0.2 268deg) 50% calc(c * 0.025) h) 100% 0 h)</Code></td><td><Code>ButtonFace</Code></td></tr>
+        <tr><td><Code>--t-on-surface</Code></td><td><Code>oklch(from oklch(from oklch(58% 0.2 268deg) 50% calc(c * 0.025) h) 18% c h)</Code></td><td><Code>CanvasText</Code></td></tr>
+        <tr><td><Code>--t-on-warning</Code></td><td><Code>oklch(from oklch(from oklch(58% 0.2 268deg) 50% calc(c * 0.025) h) 0% 0 h)</Code></td><td><Code>ButtonFace</Code></td></tr>
         <tr><td><Code>--t-success</Code></td><td><Code>color-mix(
       in oklch,
-      oklch(from oklch(65% 0.18 250deg) 62% c 155deg),
-      oklch(from oklch(65% 0.18 250deg) 62% c h) calc(0 * 100%)
+      oklch(from oklch(58% 0.2 268deg) 62% c 155deg),
+      oklch(from oklch(58% 0.2 268deg) 62% c h) calc(0 * 100%)
     )</Code></td><td><Code>ButtonText</Code></td></tr>
-        <tr><td><Code>--t-surface</Code></td><td><Code>oklch(from oklch(from oklch(65% 0.18 250deg) 50% calc(c * 0.025) h) 97% c h)</Code></td><td><Code>Canvas</Code></td></tr>
+        <tr><td><Code>--t-surface</Code></td><td><Code>oklch(from oklch(from oklch(58% 0.2 268deg) 50% calc(c * 0.025) h) 97% c h)</Code></td><td><Code>Canvas</Code></td></tr>
         <tr><td><Code>--t-warning</Code></td><td><Code>color-mix(
       in oklch,
-      oklch(from oklch(65% 0.18 250deg) 68% c 80deg),
-      oklch(from oklch(65% 0.18 250deg) 68% c h) calc(0 * 100%)
+      oklch(from oklch(58% 0.2 268deg) 68% c 80deg),
+      oklch(from oklch(58% 0.2 268deg) 68% c h) calc(0 * 100%)
     )</Code></td><td><Code>ButtonText</Code></td></tr>
         </tbody>
       </table>
@@ -200,7 +200,7 @@ import Base from "../../layouts/Base.astro";
       <table>
         <thead><tr><th>Artifact</th><th>Raw</th><th>Gzip</th><th>Brotli</th></tr></thead>
         <tbody>
-        <tr><td><a href="https://github.com/teseor/teseor/blob/main/packages/css/src/components/button/button.css"><Code>@teseor/css/components/button.css</Code></a></td><td>10.35 KB</td><td>1.92 KB</td><td>1.60 KB</td></tr>
+        <tr><td><a href="https://github.com/teseor/teseor/blob/main/packages/css/src/components/button/button.css"><Code>@teseor/css/components/button.css</Code></a></td><td>10.33 KB</td><td>1.92 KB</td><td>1.61 KB</td></tr>
         </tbody>
       </table>
     </section>

--- a/apps/docs/src/pages/components/code.astro
+++ b/apps/docs/src/pages/components/code.astro
@@ -36,8 +36,8 @@ import Base from "../../layouts/Base.astro";
       <table>
         <thead><tr><th>Token</th><th>Default</th><th>Forced-colors</th></tr></thead>
         <tbody>
-        <tr><td><Code>--t-on-surface-muted</Code></td><td><Code>oklch(from oklch(from oklch(65% 0.18 250deg) 50% calc(c * 0.025) h) 18% c h)</Code></td><td><Code>CanvasText</Code></td></tr>
-        <tr><td><Code>--t-surface-muted</Code></td><td><Code>oklch(from oklch(from oklch(65% 0.18 250deg) 50% calc(c * 0.025) h) 92% c h)</Code></td><td><Code>Canvas</Code></td></tr>
+        <tr><td><Code>--t-on-surface-muted</Code></td><td><Code>oklch(from oklch(from oklch(58% 0.2 268deg) 50% calc(c * 0.025) h) 18% c h)</Code></td><td><Code>CanvasText</Code></td></tr>
+        <tr><td><Code>--t-surface-muted</Code></td><td><Code>oklch(from oklch(from oklch(58% 0.2 268deg) 50% calc(c * 0.025) h) 92% c h)</Code></td><td><Code>Canvas</Code></td></tr>
         </tbody>
       </table>
     </section>
@@ -46,7 +46,7 @@ import Base from "../../layouts/Base.astro";
       <table>
         <thead><tr><th>Artifact</th><th>Raw</th><th>Gzip</th><th>Brotli</th></tr></thead>
         <tbody>
-        <tr><td><a href="https://github.com/teseor/teseor/blob/main/packages/css/src/components/code/code.css"><Code>@teseor/css/components/code.css</Code></a></td><td>1.10 KB</td><td>0.48 KB</td><td>0.44 KB</td></tr>
+        <tr><td><a href="https://github.com/teseor/teseor/blob/main/packages/css/src/components/code/code.css"><Code>@teseor/css/components/code.css</Code></a></td><td>1.10 KB</td><td>0.48 KB</td><td>0.43 KB</td></tr>
         </tbody>
       </table>
     </section>

--- a/apps/docs/src/pages/components/codeblock.astro
+++ b/apps/docs/src/pages/components/codeblock.astro
@@ -36,8 +36,8 @@ import Base from "../../layouts/Base.astro";
       <table>
         <thead><tr><th>Token</th><th>Default</th><th>Forced-colors</th></tr></thead>
         <tbody>
-        <tr><td><Code>--t-on-surface-muted</Code></td><td><Code>oklch(from oklch(from oklch(65% 0.18 250deg) 50% calc(c * 0.025) h) 18% c h)</Code></td><td><Code>CanvasText</Code></td></tr>
-        <tr><td><Code>--t-surface-muted</Code></td><td><Code>oklch(from oklch(from oklch(65% 0.18 250deg) 50% calc(c * 0.025) h) 92% c h)</Code></td><td><Code>Canvas</Code></td></tr>
+        <tr><td><Code>--t-on-surface-muted</Code></td><td><Code>oklch(from oklch(from oklch(58% 0.2 268deg) 50% calc(c * 0.025) h) 18% c h)</Code></td><td><Code>CanvasText</Code></td></tr>
+        <tr><td><Code>--t-surface-muted</Code></td><td><Code>oklch(from oklch(from oklch(58% 0.2 268deg) 50% calc(c * 0.025) h) 92% c h)</Code></td><td><Code>Canvas</Code></td></tr>
         </tbody>
       </table>
     </section>
@@ -46,7 +46,7 @@ import Base from "../../layouts/Base.astro";
       <table>
         <thead><tr><th>Artifact</th><th>Raw</th><th>Gzip</th><th>Brotli</th></tr></thead>
         <tbody>
-        <tr><td><a href="https://github.com/teseor/teseor/blob/main/packages/css/src/components/codeblock/codeblock.css"><Code>@teseor/css/components/codeblock.css</Code></a></td><td>1.29 KB</td><td>0.55 KB</td><td>0.47 KB</td></tr>
+        <tr><td><a href="https://github.com/teseor/teseor/blob/main/packages/css/src/components/codeblock/codeblock.css"><Code>@teseor/css/components/codeblock.css</Code></a></td><td>1.29 KB</td><td>0.55 KB</td><td>0.48 KB</td></tr>
         </tbody>
       </table>
     </section>

--- a/apps/docs/src/pages/components/modal.astro
+++ b/apps/docs/src/pages/components/modal.astro
@@ -64,8 +64,8 @@ import Base from "../../layouts/Base.astro";
       <table>
         <thead><tr><th>Token</th><th>Default</th><th>Forced-colors</th></tr></thead>
         <tbody>
-        <tr><td><Code>--t-bg</Code></td><td><Code>oklch(from oklch(from oklch(65% 0.18 250deg) 50% calc(c * 0.025) h) 100% 0 h)</Code></td><td><Code>Canvas</Code></td></tr>
-        <tr><td><Code>--t-on-bg</Code></td><td><Code>oklch(from oklch(from oklch(65% 0.18 250deg) 50% calc(c * 0.025) h) 18% c h)</Code></td><td><Code>CanvasText</Code></td></tr>
+        <tr><td><Code>--t-bg</Code></td><td><Code>oklch(from oklch(from oklch(58% 0.2 268deg) 50% calc(c * 0.025) h) 100% 0 h)</Code></td><td><Code>Canvas</Code></td></tr>
+        <tr><td><Code>--t-on-bg</Code></td><td><Code>oklch(from oklch(from oklch(58% 0.2 268deg) 50% calc(c * 0.025) h) 18% c h)</Code></td><td><Code>CanvasText</Code></td></tr>
         </tbody>
       </table>
     </section>

--- a/apps/docs/src/pages/components/tooltip.astro
+++ b/apps/docs/src/pages/components/tooltip.astro
@@ -121,8 +121,8 @@ import Base from "../../layouts/Base.astro";
       <table>
         <thead><tr><th>Token</th><th>Default</th><th>Forced-colors</th></tr></thead>
         <tbody>
-        <tr><td><Code>--t-on-surface-inverse</Code></td><td><Code>oklch(from oklch(from oklch(65% 0.18 250deg) 50% calc(c * 0.025) h) 97% c h)</Code></td><td><Code>CanvasText</Code></td></tr>
-        <tr><td><Code>--t-surface-inverse</Code></td><td><Code>oklch(from oklch(from oklch(65% 0.18 250deg) 50% calc(c * 0.025) h) 18% c h)</Code></td><td><Code>Canvas</Code></td></tr>
+        <tr><td><Code>--t-on-surface-inverse</Code></td><td><Code>oklch(from oklch(from oklch(58% 0.2 268deg) 50% calc(c * 0.025) h) 97% c h)</Code></td><td><Code>CanvasText</Code></td></tr>
+        <tr><td><Code>--t-surface-inverse</Code></td><td><Code>oklch(from oklch(from oklch(58% 0.2 268deg) 50% calc(c * 0.025) h) 18% c h)</Code></td><td><Code>Canvas</Code></td></tr>
         </tbody>
       </table>
     </section>

--- a/packages/css/__tests__/build-output.test.ts
+++ b/packages/css/__tests__/build-output.test.ts
@@ -54,7 +54,7 @@ test("shipped component CSS floors every token reference (acid test)", () => {
 
 test("shipped component CSS inlines the literal resolved from tokens.css", () => {
   const button = readFileSync(join(distDir, "components", "button.css"), "utf8");
-  expect(button).toContain("var(--t-accent, oklch(65% 0.18 250deg))");
+  expect(button).toContain("var(--t-accent, oklch(58% 0.2 268deg))");
 });
 
 test("shipped component CSS carries a forced-colors token override", () => {

--- a/packages/css/src/tokens.css
+++ b/packages/css/src/tokens.css
@@ -3,7 +3,7 @@
 @layer tokens.scale {
   :root {
     /* ===== Colors — oklch; seed-derived cascade (Baseline 2025). ===== */
-    --t-seed: oklch(65% 0.18 250deg);
+    --t-seed: oklch(58% 0.2 268deg);
     --t-harmony: 0;
     --t-neutral-0: oklch(from var(--t-neutral) 100% 0 h);
     --t-neutral-10: oklch(from var(--t-neutral) 97% c h);


### PR DESCRIPTION
## What

Phase 3 of RFC-0004 (color seed-derived cascade). Single-value change:

- `--t-seed` default shifts from `oklch(65% 0.18 250deg)` (v0.x blue) to `oklch(58% 0.2 268deg)` (indigo-violet).
- No API change, no token rename, no consumer code change required.
- The entire accent ramp re-derives because Phase 1/2 already routed it through `var(--t-seed)`. Intent + neutral families pick up the new seed hue through their derived form too (intent hues stay canonical at `--t-harmony: 0`).
- Updates `packages/css/__tests__/build-output.test.ts` to assert the new literal floor.
- Regenerated component-detail docs to reflect new resolved values + bundle sizes.

Closes #822.

## Why

The current default (hue 250°) sits in the most-used CTA blue band — Tailwind blue, Bootstrap primary, MUI primary all live at ~240–250°. Hue 268° steps out of that band into indigo-violet, which reads "modern" without being a brand-collision magnet for any major company.

Lightness shifts from 0.65 to 0.58: at L=0.65, white-on-accent for a button background sits near the APCA Lc 60 floor (comfortable text contrast). L=0.58 lifts it past Lc 60 with margin. Chroma bumps 0.18 → 0.20: at hue 268 / L=0.58 still well inside sRGB gamut; a touch more saturation gives the accent presence without crossing into neon.

Consumers who want the v0.x palette can pin `--t-seed: oklch(65% 0.18 250deg);` in their `theme.css`.

## Test plan

- [x] `pnpm test` — 942 pass (build-output.test.ts assertion updated to match new literal floor).
- [x] `pnpm lint` — clean.
- [x] `pnpm typecheck` — clean.
- [x] `pnpm build:css` + `pnpm build:docs` — clean.
- [x] `npx size-limit` — 7.95 kB brotlied vs 8 kB limit.
- [ ] Reviewer: navigate to `/themes` on the docs preview deploy, confirm the seed swatch is indigo-violet, the accent ramp shifts toward purple, and intents stay canonical (red danger, green success, etc.) at `--t-harmony: 0`.

## Out of scope

- Holding for v1.0 — RFC-0002 noted Phase 3 may be deferred if the cut date falls inside the phase plan. Reviewer call: if v1.0 is close, hold this PR; otherwise land it now.
- Picker / theme generator (deferred, #823).
- Codegen flattening of derived expressions in component-detail docs (known issue from #826's PR body — still applies).