### PR TITLE
chore(ci): gate heavy jobs behind path filter for docs-only PRs

### DIFF
--- a/.github/actions/changes/action.yml
+++ b/.github/actions/changes/action.yml
@@ -1,0 +1,33 @@
+name: changes
+description: |
+  Classify what changed in this PR relative to the base ref. Emits
+  `code=true` when any file outside docs/, .changeset/, and *.md changed.
+  Returns `code=true` unconditionally for non-pull_request events so push
+  builds always run the full matrix.
+
+  Requires a checkout with `fetch-depth: 0` in the calling job.
+outputs:
+  code:
+    description: '"true" when code-relevant files changed, "false" for docs-only PRs'
+    value: ${{ steps.detect.outputs.code }}
+runs:
+  using: composite
+  steps:
+    - id: detect
+      shell: bash
+      env:
+        BASE_REF: ${{ github.event.pull_request.base.ref }}
+        EVENT: ${{ github.event_name }}
+      run: |
+        set -e
+        if [ "$EVENT" != "pull_request" ]; then
+          echo "code=true" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+        git fetch --quiet origin "$BASE_REF"
+        changed=$(git diff --name-only "origin/$BASE_REF...HEAD")
+        if echo "$changed" | grep -Ev '^(docs/|\.changeset/|.*\.md$)' | grep -q .; then
+          echo "code=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "code=false" >> "$GITHUB_OUTPUT"
+        fi

--- a/.github/actions/changes/action.yml
+++ b/.github/actions/changes/action.yml
@@ -1,9 +1,13 @@
 name: changes
 description: |
-  Classify what changed in this PR relative to the base ref. Emits
+  Classify what changed in this PR relative to the base SHA. Emits
   `code=true` when any non-markdown file changed. Markdown-only PRs
   (docs, READMEs, changeset bundles) get `code=false`; `.changeset/config.json`
   and other non-markdown files still trigger the full matrix.
+
+  Fail-open: any detection error (missing SHA, broken diff) emits
+  `code=true` so the full matrix runs. Skipping heavy CI must be a
+  positive signal, never the side effect of a transient failure.
 
   Returns `code=true` unconditionally for non-pull_request events so push
   builds always run the full matrix.
@@ -19,16 +23,18 @@ runs:
     - id: detect
       shell: bash
       env:
-        BASE_REF: ${{ github.event.pull_request.base.ref }}
+        BASE_SHA: ${{ github.event.pull_request.base.sha }}
         EVENT: ${{ github.event_name }}
       run: |
-        set -e
         if [ "$EVENT" != "pull_request" ]; then
           echo "code=true" >> "$GITHUB_OUTPUT"
           exit 0
         fi
-        git fetch --quiet origin "$BASE_REF"
-        changed=$(git diff --name-only "origin/$BASE_REF...HEAD")
+        if ! changed=$(git diff --name-only "$BASE_SHA...HEAD" 2>/dev/null); then
+          echo "code=true" >> "$GITHUB_OUTPUT"
+          echo "::warning::changes action could not diff against $BASE_SHA; defaulting code=true"
+          exit 0
+        fi
         if echo "$changed" | grep -Ev '\.md$' | grep -q .; then
           echo "code=true" >> "$GITHUB_OUTPUT"
         else

--- a/.github/actions/changes/action.yml
+++ b/.github/actions/changes/action.yml
@@ -1,7 +1,10 @@
 name: changes
 description: |
   Classify what changed in this PR relative to the base ref. Emits
-  `code=true` when any file outside docs/, .changeset/, and *.md changed.
+  `code=true` when any non-markdown file changed. Markdown-only PRs
+  (docs, READMEs, changeset bundles) get `code=false`; `.changeset/config.json`
+  and other non-markdown files still trigger the full matrix.
+
   Returns `code=true` unconditionally for non-pull_request events so push
   builds always run the full matrix.
 
@@ -26,7 +29,7 @@ runs:
         fi
         git fetch --quiet origin "$BASE_REF"
         changed=$(git diff --name-only "origin/$BASE_REF...HEAD")
-        if echo "$changed" | grep -Ev '^(docs/|\.changeset/|.*\.md$)' | grep -q .; then
+        if echo "$changed" | grep -Ev '\.md$' | grep -q .; then
           echo "code=true" >> "$GITHUB_OUTPUT"
         else
           echo "code=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,17 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.detect.outputs.code }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - id: detect
+        uses: ./.github/actions/changes
+
   lint:
     runs-on: ubuntu-latest
     steps:
@@ -40,6 +51,8 @@ jobs:
           ./actionlint -color
 
   typecheck:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -47,6 +60,8 @@ jobs:
       - run: pnpm typecheck
 
   test-unit:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -58,6 +73,8 @@ jobs:
       - run: pnpm test
 
   test-e2e:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -67,6 +84,8 @@ jobs:
       - run: pnpm test:e2e
 
   gen-drift:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -81,6 +100,8 @@ jobs:
           fi
 
   verify-no-dev-leak:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,12 +16,19 @@ jobs:
   changes:
     runs-on: ubuntu-latest
     outputs:
-      code: ${{ steps.detect.outputs.code }}
+      code: ${{ steps.pr.outputs.code || steps.push.outputs.code }}
     steps:
-      - uses: actions/checkout@v6
+      # Non-PR events (push to main) skip the diff and the checkout entirely.
+      - id: push
+        if: github.event_name != 'pull_request'
+        shell: bash
+        run: echo "code=true" >> "$GITHUB_OUTPUT"
+      - if: github.event_name == 'pull_request'
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - id: detect
+      - id: pr
+        if: github.event_name == 'pull_request'
         uses: ./.github/actions/changes
 
   lint:

--- a/.github/workflows/size-data.yml
+++ b/.github/workflows/size-data.yml
@@ -7,7 +7,20 @@ permissions:
   contents: read
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.detect.outputs.code }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - id: detect
+        uses: ./.github/actions/changes
+
   measure:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/visual-tests.yml
+++ b/.github/workflows/visual-tests.yml
@@ -16,12 +16,19 @@ jobs:
   changes:
     runs-on: ubuntu-latest
     outputs:
-      code: ${{ steps.detect.outputs.code }}
+      code: ${{ steps.pr.outputs.code || steps.push.outputs.code }}
     steps:
-      - uses: actions/checkout@v6
+      # Non-PR events (push to main) skip the diff and the checkout entirely.
+      - id: push
+        if: github.event_name != 'pull_request'
+        shell: bash
+        run: echo "code=true" >> "$GITHUB_OUTPUT"
+      - if: github.event_name == 'pull_request'
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - id: detect
+      - id: pr
+        if: github.event_name == 'pull_request'
         uses: ./.github/actions/changes
 
   visual:

--- a/.github/workflows/visual-tests.yml
+++ b/.github/workflows/visual-tests.yml
@@ -13,7 +13,20 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.detect.outputs.code }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - id: detect
+        uses: ./.github/actions/changes
+
   visual:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## What

Add a shared `./.github/actions/changes` composite action that diffs the PR against its base SHA and emits `code=true|false`. Heavy jobs gate on this output and skip when **every file changed in the PR is markdown** (`**/*.md`). Any non-markdown file in the diff — including `.changeset/config.json`, `docs/diagram.svg`, etc. — triggers `code=true` and the full matrix.

Gated:
- `ci.yml`: `test-e2e`, `test-unit`, `typecheck`, `gen-drift`, `verify-no-dev-leak`
- `visual-tests.yml`: `visual`
- `size-data.yml`: `measure`

Always-on:
- `ci.yml`: `lint` (runs markdownlint + doc-paths), `actionlint`, `changeset`
- `pr-discipline.yml`: `linked-issue`, `title-format`, `body-sections`, `labeler`

The `changes` job is no-op on push events (1-line bash setting `code=true`, no checkout, no composite call). Detection failures fail-open with `code=true` + a workflow warning — skipping heavy CI must always be a positive signal.

Closes #810

## Why

A docs-only PR (#808 was the trigger) currently runs the full matrix including ~90s of test-e2e and the Docker visual job — neither can fail meaningfully on a `.md`-only change. Skipping cuts roughly 2 min of runner time and a Docker pull per docs PR.

## Test plan

- This PR itself exercises the path filter: it modifies workflow files, so `code=true` and all heavy jobs should run + pass.
- Follow-up `.md`-only PR should report `test-e2e` / `visual` / `measure` as skipped.

## Out of scope

- Branch-protection ruleset changes. Skipped jobs report `skipped` not `success`; whether that satisfies required-checks depends on repo settings.
- Consolidating the existing `changeset` job's diff into the new `changes` action.
- Moving `lint` behind the filter (it runs markdownlint + doc-paths, both useful on `.md`-only PRs).