### PR TITLE
chore(ci): align lefthook commit-msg scopes with CI title-format

### DIFF
--- a/.github/commit-scopes.txt
+++ b/.github/commit-scopes.txt
@@ -1,0 +1,14 @@
+token
+theme
+codegen
+showcase
+css
+wrapper
+i18n
+ci
+repo
+claude
+scripts
+docs
+spec
+primitives

--- a/.github/workflows/pr-discipline.yml
+++ b/.github/workflows/pr-discipline.yml
@@ -40,7 +40,7 @@ jobs:
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
           set -e
-          fixed='token theme codegen showcase css wrapper i18n ci repo claude scripts docs spec primitives'
+          fixed="$(cat .github/commit-scopes.txt)"
           components=''
           shopt -s nullglob
           for spec in specs/*.yaml; do

--- a/scripts/hooks/commit-msg.js
+++ b/scripts/hooks/commit-msg.js
@@ -1,12 +1,20 @@
 #!/usr/bin/env node
 // Conventional-commit verifier called from lefthook commit-msg.
-// Port of Vue's scripts/verify-commit.js — kept intentionally small.
+// Reads the same scope vocabulary the CI `title-format` gate uses, so a
+// commit that passes locally also passes on the PR title check.
 
-import { readFileSync } from "node:fs";
+import { readdirSync, readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(here, "..", "..");
+const scopesFile = resolve(repoRoot, ".github/commit-scopes.txt");
+const specsDir = resolve(repoRoot, "specs");
 
 const msgPath = process.argv[2];
 if (!msgPath) {
-  console.error("Usage: verify-commit.js <path-to-commit-msg-file>");
+  console.error("Usage: commit-msg.js <path-to-commit-msg-file>");
   process.exit(1);
 }
 
@@ -14,7 +22,19 @@ const firstLine = readFileSync(msgPath, "utf8").split("\n")[0].trim();
 
 if (/^(Merge|Revert)\s/.test(firstLine)) process.exit(0);
 
-const pattern = /^(feat|fix|perf|refactor|docs|chore|test)\([a-z0-9-]+\): .+/;
+const fixedScopes = readFileSync(scopesFile, "utf8")
+  .split("\n")
+  .map((line) => line.trim())
+  .filter(Boolean);
+
+const componentScopes = readdirSync(specsDir)
+  .filter((name) => name.endsWith(".yaml") && name !== "_vocabulary.yaml")
+  .map((name) => name.replace(/\.yaml$/, ""));
+
+const scopes = [...new Set([...fixedScopes, ...componentScopes])].sort();
+const pattern = new RegExp(
+  `^(feat|fix|perf|refactor|docs|chore|test)\\((${scopes.join("|")})\\): .+`,
+);
 
 if (!pattern.test(firstLine)) {
   console.error("");
@@ -27,7 +47,7 @@ if (!pattern.test(firstLine)) {
   console.error("  fix(css): resolve focus-visible regression");
   console.error("");
   console.error("Allowed types: feat, fix, perf, refactor, docs, chore, test");
-  console.error("Allowed scopes: lowercase alphanumeric + dashes");
+  console.error(`Allowed scopes: ${scopes.join(", ")}`);
   console.error("");
   console.error(`Got: "${firstLine}"`);
   console.error("");


### PR DESCRIPTION
## What

Extract the fixed scope vocabulary into `.github/commit-scopes.txt`. Both the lefthook `commit-msg` hook (`scripts/hooks/commit-msg.js`) and the CI `title-format` job read from the same file, then layer the dynamic `specs/*.yaml` basenames on top. The hook now rejects scopes the CI gate would reject.

Closes #811

## Why

The previous lefthook regex (`[a-z0-9-]+`) accepted any lowercase scope. CI's `title-format` job enforces a fixed list plus `specs/*.yaml` basenames. So `chore(rfc): …` committed cleanly locally and failed on the PR title check — one fix-push-recheck round-trip per bad commit. Hit again earlier in this session.

## Test plan

- Manually exercised `commit-msg.js` against bad cases (`chore(rfc): …`, `style(css): …`) and good cases (`chore(ci): …`, `feat(button): …`, `Merge branch …`).
- Both commits on this branch (and #832 before it) go through the new hook.
- CI title-format reads the same file, so a mismatch between the two is now impossible without editing the same line.

## Out of scope

- Changing the allowed scope vocabulary itself.
- Squash-merge title validation (already covered by `title-format` on the PR title).
- Adding a unit test for `commit-msg.js` (no test infra under `scripts/hooks/` today).