### PR TITLE
docs(spec): record ADRs for events block

### DIFF
--- a/docs/ADR/0018-events-block-surface.md
+++ b/docs/ADR/0018-events-block-surface.md
@@ -1,0 +1,175 @@
+# ADR-0018 — Events block: scope, consumer surface, docs section split
+
+- **Status:** Accepted.
+- **Deciders:** repo owner (letanure).
+
+## Decision
+
+A new optional `events:` field lands on the spec root, separate from
+the existing `interactions:` block. The two evolve on their own
+timelines; specs may declare either, both, or neither. When a spec
+carries both, codegen glues the link at the wrapper layer (an
+interaction transition that closes an overlay fires the declared
+`dismiss` event from the same handler) — there is no spec-level field
+tying an event to a transition.
+
+Every spec with a non-empty `events:` block exposes **two callable
+surfaces** generated from the same entries:
+
+1. **Per-event props.** One typed prop per declared event
+   (`onSelect`, `onDismiss`, `onInputChange`). Each carries a typed
+   payload object — never positional arguments.
+2. **Discriminated `onEvent` channel.** One prop per component,
+   payload is a discriminated union over `type`. The channel fires
+   for **both declared events and controllable callbacks** —
+   `pattern: "controllable"` mirrors remain as their own per-event
+   props but are also visible to the channel.
+
+When a single user gesture emits more than one thing, the wrapper
+fires in a fixed sequence: declared event prop → channel for that
+event → controllable callback → channel for the state mirror. Each
+emission is its own channel call; declared events always fire before
+their corresponding state mirror so consumer code can read the
+semantic reason without racing the state update. Vue ships the same
+shape: per-event emits (`@dismiss`, `@select`) plus a literal
+`@event` channel.
+
+The generated docs page splits the single `## Props` table into four
+role-keyed sections — `## Configuration`, `## Content`, `## State`,
+`## Events` — in that fixed order. The renderer infers each prop's
+section from existing markers (`slot: true` → Content;
+`pattern: "controllable"` → State; an entry in `events:` → Events;
+everything else → Configuration). No new spec field is introduced.
+
+## Why this and not the alternatives
+
+- **Not "derive events from a generalized statechart."** Today only
+  Modal and Tooltip carry `interactions:`, both with the narrow
+  overlay vocabulary (`open | close | toggle`). Promoting it to a
+  full statechart vocabulary requires anticipating 8+ unbuilt
+  components — the upfront over-design ADR-0001 warned against. The
+  industry split confirms it: Radix, React Aria, Spectrum, Mantine,
+  and Chakra itself all hand-roll without statecharts; Zag.js is the
+  single outlier. Two data points is not enough to commit. The events
+  shape leaves an optional `emittedBy:` field reachable later without
+  breaking specs.
+- **Not "block events on the statechart question."** The events
+  surface is needed today by every wrapped Modal / Combobox /
+  DataTable consumer (RFC-0006 § Motivation). Waiting for an
+  unwritten state-machine RFC would leave the surface broken for an
+  indefinite window.
+- **Not channel-only (Spectrum's `onAction` taken to its
+  conclusion).** Per-event ergonomics are the dominant call-site
+  pattern across every major React DS (Radix, Spectrum, Zag,
+  Mantine, MUI). Forcing every consumer to `switch` on a
+  discriminator just to handle one event hurts the common case and
+  gives up TypeScript's per-prop narrowing.
+- **Not per-event-only (Radix / Zag / Mantine default).** PostHog /
+  Datadog / Segment integration is a recurring real consumer need
+  (#669). Without a channel, every consumer writes N-per-component
+  bridging code. The channel costs ~10 lines of generated wiring per
+  spec and removes that boilerplate entirely.
+- **Not "channel only for controllable, declared events only for
+  declared events."** Splitting the channel by source would leak the
+  spec's internal classification into the consumer's analytics
+  layer. A consumer's "what just happened on this component" lens
+  should not need to know that `valueChange` is a controllable
+  mirror and `dismiss` is a declared event.
+- **Not free-order emission.** Without a documented ordering, a
+  consumer reading both `onDismiss` and `onOpenChange` would see them
+  in whichever order the wrapper happened to fire. Pinning the order
+  — declared event before state mirror, per-event handler before
+  channel — means consumer code can rely on reading the semantic
+  reason from a closure variable in `onOpenChange` if it wants to.
+- **Not positional payload arguments.** `(reason, target) => …`
+  couples the call site to the declared order; payload objects let
+  new fields be added without breaking existing handlers. Matches
+  React Aria's `(e: { … })` shape and Vue's payload-object
+  convention.
+- **Not a schema-level `section:` field per prop for docs.** A
+  `section:` override would let spec authors place a prop in any
+  section regardless of its actual role. That breaks the audit story
+  — reviewers could no longer trust that everything under `## State`
+  came from a controllable pair. Inferring from the existing markers
+  keeps the section assignment derivable from the spec's structural
+  truth.
+- **Not "render Events only when the spec has events."** Empty
+  sections still render (with a one-line "no declared events" note)
+  so the page shape is consistent. A reader landing on Button's page
+  learns "no declared events; use native `onClick`" from the same
+  section that, on Combobox, lists five.
+
+## Consequences
+
+- The Zod schema gains one optional field (`events:`) on the spec
+  root. Specs that don't declare it are byte-identical under
+  codegen.
+- `gen-contract` emits one TypeScript prop per declared event plus
+  the `<Spec>Event` discriminated union plus an `onEvent?: (e:
+  <Spec>Event<...>) => void` prop. The union includes both declared
+  events and controllable callbacks.
+- `gen-react` and `gen-vue` emit the per-emission ordering in
+  wrapper code: each handler calls the per-event prop, fires the
+  channel with the same payload (`{ type, ...payload }`), then
+  proceeds to the controllable callback (which also fires the
+  channel after the state-mirror prop).
+- The discriminated union grows linearly with declared events plus
+  controllable pairs. A 12-event DataTable becomes a ~15-arm type;
+  TypeScript handles it but the hover symbol is large.
+- Vue's literal `@event` emit is slightly foreign vs the per-event
+  `@dismiss` idiom Vue developers expect. Documented in the
+  generated docs; not deep cost.
+- `onEvent` is always present on the props interface (not gated
+  behind a separate import path). The tree-shake cost of an
+  undefined-default handler is essentially zero, and a single attach
+  point matters more than a marginal bundle saving.
+- The ordering rule is a runtime contract, not just a docs note.
+  Cross-framework DOM-parity testing (#841) will eventually assert
+  the order on both React and Vue outputs.
+- `scripts/codegen/src/generators/gen-docs/_shared/sections.ts`
+  splits `renderProps` into `renderConfiguration` / `renderContent`
+  / `renderState` / `renderEvents`. The shared row-rendering helper
+  stays one function; only the partitioning is new. Every existing
+  component docs page re-renders into the new layout the first time
+  `pnpm gen` runs after the split lands.
+- Docs anchors change: `#props` → `#configuration` / `#content` /
+  `#state` / `#events`. Acceptable because there are no published
+  consumers of the docs site yet; if that changes, a redirect rule
+  lands at the Astro level.
+- Hardcoded composite-emitted props (`asChild`, `ref`) are routed to
+  whichever section helper matches their role. The pre-existing
+  requirement to mirror those props in `sections.ts` (project memory
+  `composite_generator_props_need_docs_mirror`) generalizes to one
+  helper per section.
+- Native DOM events (`onClick` on Button) keep flowing through the
+  existing `Omit<…>`-based spread. The events surface is additive:
+  it doesn't replace DOM events for atoms that don't need a semantic
+  layer.
+- The state-machine question stays open. Behavior tests derived from
+  `interactions:` (#582) stay blocked on the same generalization. If
+  a future RFC promotes `interactions:` to a real machine, declared
+  events may move into "transition effects" form; the migration cost
+  is bounded by an optional `emittedBy:` field on existing keys.
+
+## References
+
+- [RFC-0006](../RFC/0006-events.md) — consumer event surface. This
+  ADR records the scope-and-surface settlements (events vs
+  interactions independence, per-event + channel layered surface,
+  per-emission ordering, four-section docs split).
+- [ADR-0001](0001-rewrite-not-migrate.md) — "don't design for unbuilt
+  components." Applied here to the statechart question.
+- [ADR-0015](0015-codegen-layout.md) — target-first generators; this
+  ADR touches `gen-contract`, `gen-react`, `gen-vue`, and `gen-docs`.
+- [ADR-0019](0019-closed-vocabularies-for-events.md) — the closed
+  vocabularies this surface relies on.
+- [#582](https://github.com/teseor/teseor/issues/582) — behavior
+  tests from interactions; blocked on the state-model generalization
+  this ADR defers.
+- [#669](https://github.com/teseor/teseor/issues/669) — analytics /
+  tracking; the `onEvent` channel is its foundation.
+- [#690](https://github.com/teseor/teseor/issues/690) — events block
+  umbrella.
+- [#841](https://github.com/teseor/teseor/issues/841) —
+  cross-framework DOM-parity contract test that will pin the
+  ordering rule.

--- a/docs/ADR/0018-events-block-surface.md
+++ b/docs/ADR/0018-events-block-surface.md
@@ -1,7 +1,11 @@
 # ADR-0018 — Events block: scope, consumer surface, docs section split
 
-- **Status:** Accepted.
+- **Status:** Proposed.
 - **Deciders:** repo owner (letanure).
+
+Flips to Accepted when the tracer-bullet spec (Modal with
+`events: dismiss`) has merged end-to-end across schema, validator,
+and the React + Vue generators.
 
 ## Decision
 
@@ -136,11 +140,12 @@ everything else → Configuration). No new spec field is introduced.
   `#state` / `#events`. Acceptable because there are no published
   consumers of the docs site yet; if that changes, a redirect rule
   lands at the Astro level.
-- Hardcoded composite-emitted props (`asChild`, `ref`) are routed to
-  whichever section helper matches their role. The pre-existing
-  requirement to mirror those props in `sections.ts` (project memory
-  `composite_generator_props_need_docs_mirror`) generalizes to one
-  helper per section.
+- Hardcoded composite-emitted props (`asChild`, `ref`) keep needing
+  explicit rows in
+  `scripts/codegen/src/generators/gen-docs/_shared/sections.ts` — the
+  generator does not infer them from a spec field because no field
+  declares them. After the split, those explicit rows live under
+  whichever per-section helper matches their role.
 - Native DOM events (`onClick` on Button) keep flowing through the
   existing `Omit<…>`-based spread. The events surface is additive:
   it doesn't replace DOM events for atoms that don't need a semantic

--- a/docs/ADR/0019-closed-vocabularies-for-events.md
+++ b/docs/ADR/0019-closed-vocabularies-for-events.md
@@ -1,23 +1,33 @@
 # ADR-0019 — Closed vocabularies for event names and payload types
 
-- **Status:** Accepted.
+- **Status:** Proposed.
 - **Deciders:** repo owner (letanure).
+
+Flips to Accepted when the vocabulary infrastructure PR has merged
+(`specs/_vocabulary.yaml` carrying the structured `events:` block
+and `scripts/codegen/src/lib/vocabulary.ts` rebuilt as the generated
+TS mirror).
 
 ## Decision
 
 Both halves of the events block — the event *name* and its *payload
-type* — are constrained by closed vocabularies stored in
-`specs/_vocabulary.yaml`. A generated TypeScript mirror at
-`scripts/codegen/src/lib/vocabulary.ts` is the single source every
-consumer of the vocab (validator, codegen, gen-docs) imports.
+type* — will be constrained by closed vocabularies stored in
+`specs/_vocabulary.yaml`. Today that file carries a flat `events:`
+string list; the implementation PR extends it into the structured
+form below. A generated TypeScript mirror at
+`scripts/codegen/src/lib/vocabulary.ts` (today a runtime YAML
+loader, rebuilt as a generated artifact in the same PR) is the
+single source every consumer of the vocab (validator, codegen,
+gen-docs) imports.
 
 **Event names.** The last camelCase token of every event name must be
 a registered verb. Synonyms (`close` → `dismiss`, `hide` → `dismiss`,
-`update` → `change`, `press` → `activate`, `open` → "use
-`pattern: controllable`") are rejected with a suggestion. Verbs are
-the base form, not past tense: `fileAdd`, not `fileAdded`;
-`endReach`, not `endReached`. The pattern is
-`^([a-z]+|[a-z]+([A-Z][a-zA-Z0-9]+)+)$` — bare verb or
+`update` → `change`, `press` → `activate`) are rejected with a
+suggestion. The `open` synonym is special-cased: it routes the
+author to `pattern: "controllable"` on the `open` prop instead of an
+event declaration. Verbs are the base form, not past tense:
+`fileAdd`, not `fileAdded`; `endReach`, not `endReached`. The
+pattern is `^([a-z]+|[a-z]+([A-Z][a-zA-Z0-9]+)+)$` — bare verb or
 `<subjectNoun><Verb>`.
 
 **Payload types.** Every payload field is declared structurally as a
@@ -84,14 +94,17 @@ the vocab, extend the schema) — they don't open bypasses.
 
 ## Consequences
 
-- **Single source.** `specs/_vocabulary.yaml` carries
-  `events.verbs`, `events.synonyms`, `events.builtins`, and the
-  name pattern. Every consumer (validate-spec, gen-contract,
-  gen-react, gen-vue, gen-docs) reads from the generated TS mirror.
-  No string lives in two places.
-- **Eight new semantic-check rules** in `validate-spec.ts` (RFC-0006
-  § Validator rules): event-name pattern, verb-registered, synonym
-  rejection (with "—" for controllable-mirror synonyms like `open`),
+- **Single source.** After the implementation PR,
+  `specs/_vocabulary.yaml` carries `events.verbs`, `events.synonyms`,
+  `events.builtins`, and the name pattern — extending today's flat
+  `events:` list. Every consumer (validate-spec runner,
+  gen-contract, gen-react, gen-vue, gen-docs) reads from the
+  generated TS mirror. No string lives in two places.
+- **Eight new semantic-check rules** in
+  `scripts/codegen/src/semantic-checks.ts` (the rules file invoked
+  by `validate-spec.ts` via `runSemanticChecks`, per RFC-0006 §
+  Validator rules): event-name pattern, verb-registered, synonym
+  rejection (with `open` routed to `pattern: "controllable"`),
   generic-ref existence, builtin-name existence, root-only
   declaration, no collision with controllable callback names. The
   `semantic-checks.ts` file is already ~1700 LOC (#838 audit); this
@@ -107,12 +120,12 @@ the vocab, extend the schema) — they don't open bypasses.
   they want at the call site. If a real case demands a bound, the
   constraint vocabulary lands as a follow-up — not as a raw-string
   escape hatch.
-- **No state mirror via events.** `open` and `value` are synonyms
-  with a `—` canonical: the validator instructs the author to use
-  `pattern: "controllable"` on the open / value prop instead. This
-  keeps controllable mirrors and declared events as distinct
-  authoring concerns even though they share the `onEvent` channel
-  (ADR-0018).
+- **No state mirror via events.** The `open` synonym carries no
+  canonical verb; the validator instructs the author to use
+  `pattern: "controllable"` on the `open` prop instead of declaring
+  an event. This keeps controllable mirrors and declared events as
+  distinct authoring concerns even though they share the `onEvent`
+  channel (ADR-0018).
 - **The generated TS mirror is the typed API surface.** Adding a
   verb in YAML is one line; the mirror keeps the `EventVerb` /
   `BuiltinType` union types honest with zero hand-editing.

--- a/docs/ADR/0019-closed-vocabularies-for-events.md
+++ b/docs/ADR/0019-closed-vocabularies-for-events.md
@@ -1,0 +1,142 @@
+# ADR-0019 — Closed vocabularies for event names and payload types
+
+- **Status:** Accepted.
+- **Deciders:** repo owner (letanure).
+
+## Decision
+
+Both halves of the events block — the event *name* and its *payload
+type* — are constrained by closed vocabularies stored in
+`specs/_vocabulary.yaml`. A generated TypeScript mirror at
+`scripts/codegen/src/lib/vocabulary.ts` is the single source every
+consumer of the vocab (validator, codegen, gen-docs) imports.
+
+**Event names.** The last camelCase token of every event name must be
+a registered verb. Synonyms (`close` → `dismiss`, `hide` → `dismiss`,
+`update` → `change`, `press` → `activate`, `open` → "use
+`pattern: controllable`") are rejected with a suggestion. Verbs are
+the base form, not past tense: `fileAdd`, not `fileAdded`;
+`endReach`, not `endReached`. The pattern is
+`^([a-z]+|[a-z]+([A-Z][a-zA-Z0-9]+)+)$` — bare verb or
+`<subjectNoun><Verb>`.
+
+**Payload types.** Every payload field is declared structurally as a
+discriminated `PayloadEntry`: `string`, `number`, `boolean`, `enum`
+(with `values: string[]`), `generic` (with `ref:` into the spec's
+`generics:` block), `builtin` (with `name:` from a closed `builtins:`
+list — `Date`, `MouseEvent`, `File`, `Error`, etc.), or `array`
+(with `of:` recursing). Every variant accepts `nullable: true` to
+promote it to a nullable union. A new top-level `generics:` block on
+the spec root lets a single component declare reusable type
+parameters (`Item`, `Row`) referenced by `type: generic, ref: <Name>`
+in payload fields.
+
+There are no escape hatches: no raw TypeScript strings in `payload:`,
+no `unknown` / `any` / `never`, no unregistered builtin names. When
+the existing rules don't fit a new case, the rules expand (extend
+the vocab, extend the schema) — they don't open bypasses.
+
+## Why this and not the alternatives
+
+- **Not an open verb vocabulary.** Free-form verbs let two
+  components ship `close` and `dismiss` for the same action, or
+  `cancel` / `abort` / `stop` / `quit` for nominally the same
+  gesture. A reader scanning analytics across components would see
+  synonyms and not know whether they meant different things. The
+  verb registry is what makes the cross-component telemetry layer
+  (#669) tractable.
+- **Not "synonyms warn, not reject."** A warn-level lint quietly
+  accumulates the synonym in CI logs and leaves the spec with the
+  wrong name. Hard rejection at validate-time forces the choice to
+  the author. The suggestion message tells them which verb to pick.
+- **Not past-tense allowed alongside base form.** Two valid names
+  per event (`fileAdd` *and* `fileAdded`) would double the registry
+  and require an irregular-verb stemmer at validate-time. The minor
+  English-awkwardness of `onEndReach` vs `onEndReached` is the trade
+  for a single canonical name.
+- **Not raw TypeScript strings for payloads
+  (`payload: "{ row: T; index: number }"`).** Terse, but a
+  TS-fragment parser would have to live in the validator, payload
+  field names could not be checked against any registry, and the
+  structural shape of the spec would collapse into opaque strings.
+  Once strings are accepted, arbitrary types flow through —
+  including `unknown` and third-party imports — and the vocab story
+  breaks.
+- **Not `unknown` / `any` as a fallback variant.** If a payload
+  value can't be typed at spec time, the fix is one of: (a) declare
+  a generic in the spec's `generics:` block and pass it through;
+  (b) redesign the payload to carry identifiers the consumer uses
+  to look up the value in data they already own (e.g., `cellEdit`
+  carries `{ row, columnId }`, not `{ oldValue, newValue }`). Both
+  paths are documented; neither is a bypass.
+- **Not "add new built-in types ad-hoc in code."** A new builtin
+  (`ResizeObserverEntry`, `URL`) lands as one line in
+  `_vocabulary.yaml` plus a description, reviewed under the same
+  gate as a new verb. The validator rejects unregistered names
+  until the vocab PR lands.
+- **Not "constrained generics" in v1.** A spec can declare
+  `generics: [{ name: Item, description: … }]` but cannot declare
+  `Item extends Record<string, unknown>`. Constraint vocabulary is
+  a follow-up — adding raw TypeScript constraint strings would be
+  an escape hatch by construction. When a real case demands it, the
+  constraint vocab expands to a closed set the same way `builtins:`
+  did.
+
+## Consequences
+
+- **Single source.** `specs/_vocabulary.yaml` carries
+  `events.verbs`, `events.synonyms`, `events.builtins`, and the
+  name pattern. Every consumer (validate-spec, gen-contract,
+  gen-react, gen-vue, gen-docs) reads from the generated TS mirror.
+  No string lives in two places.
+- **Eight new semantic-check rules** in `validate-spec.ts` (RFC-0006
+  § Validator rules): event-name pattern, verb-registered, synonym
+  rejection (with "—" for controllable-mirror synonyms like `open`),
+  generic-ref existence, builtin-name existence, root-only
+  declaration, no collision with controllable callback names. The
+  `semantic-checks.ts` file is already ~1700 LOC (#838 audit); this
+  pushes it further. Audit task remains open.
+- **Vocab maintenance becomes a bottleneck.** Every new verb or
+  builtin is a one-line vocab PR + description. Cost matches token
+  additions; payoff is cross-component consistency.
+- **Schema growth.** Zod schema gains `events:`, `generics:`, and
+  the recursive `PayloadEntry` discriminated union. Atomic specs
+  without events are byte-identical under codegen.
+- **`generics:` block is unconstrained in v1.** A spec author
+  declares names and descriptions; consumers pass whatever type
+  they want at the call site. If a real case demands a bound, the
+  constraint vocabulary lands as a follow-up — not as a raw-string
+  escape hatch.
+- **No state mirror via events.** `open` and `value` are synonyms
+  with a `—` canonical: the validator instructs the author to use
+  `pattern: "controllable"` on the open / value prop instead. This
+  keeps controllable mirrors and declared events as distinct
+  authoring concerns even though they share the `onEvent` channel
+  (ADR-0018).
+- **The generated TS mirror is the typed API surface.** Adding a
+  verb in YAML is one line; the mirror keeps the `EventVerb` /
+  `BuiltinType` union types honest with zero hand-editing.
+  Validator and generators both fail-fast on typos in the YAML
+  file.
+- **Payload field-name vocabulary** (always-call-it `reason`,
+  always-call-it `value`) is deferred to a follow-up vocab PR. The
+  failure mode is mild — field names are read at the call site,
+  not on every analytics line — and the verb registry is the
+  larger consistency lever.
+
+## References
+
+- [RFC-0006](../RFC/0006-events.md) — § "Vocabulary" and § "No
+  escape hatches".
+- [ADR-0018](0018-events-block-surface.md) — the surface this
+  vocabulary types.
+- [ADR-0006](0006-enum-typed-string-props.md) — closed-set string
+  props; payload `enum` variant builds on the same pattern.
+- [ADR-0009](0009-spec-schema-and-validation.md) — Zod schema +
+  semantic-check pass; this ADR adds eight rules to that pass.
+- [#669](https://github.com/teseor/teseor/issues/669) — analytics /
+  tracking layer; the verb registry is what makes its
+  cross-component reporting tractable.
+- [#838](https://github.com/teseor/teseor/issues/838) — 300-LOC
+  file audit covering `semantic-checks.ts`; this ADR adds load to
+  it.

--- a/docs/ADR/0019-closed-vocabularies-for-events.md
+++ b/docs/ADR/0019-closed-vocabularies-for-events.md
@@ -13,12 +13,14 @@ TS mirror).
 Both halves of the events block — the event *name* and its *payload
 type* — will be constrained by closed vocabularies stored in
 `specs/_vocabulary.yaml`. Today that file carries a flat `events:`
-string list; the implementation PR extends it into the structured
-form below. A generated TypeScript mirror at
-`scripts/codegen/src/lib/vocabulary.ts` (today a runtime YAML
-loader, rebuilt as a generated artifact in the same PR) is the
-single source every consumer of the vocab (validator, codegen,
-gen-docs) imports.
+string list; the implementation PR extends it into four keys —
+`events.verbs`, `events.synonyms`, `events.builtins`, and the
+name `pattern` — whose roles are described in the two sub-headings
+("Event names" and "Payload types") that follow. A generated
+TypeScript mirror at `scripts/codegen/src/lib/vocabulary.ts` (today
+a runtime YAML loader, rebuilt as a generated artifact in the same
+PR) is the single source every consumer of the vocab (validator,
+codegen, gen-docs) imports.
 
 **Event names.** The last camelCase token of every event name must be
 a registered verb. Synonyms (`close` → `dismiss`, `hide` → `dismiss`,

--- a/docs/ADR/README.md
+++ b/docs/ADR/README.md
@@ -25,8 +25,8 @@ a numbered, durable file.
 | [0015](0015-codegen-layout.md) | Codegen layout: target-first generators | Accepted |
 | [0016](0016-per-breakpoint-css-cost.md) | Per-breakpoint CSS cost: status quo with budget | Accepted |
 | [0017](0017-strict-token-interface-boundary.md) | Strict token-interface boundary | Accepted |
-| [0018](0018-events-block-surface.md) | Events block: scope, consumer surface, docs section split | Accepted |
-| [0019](0019-closed-vocabularies-for-events.md) | Closed vocabularies for event names and payload types | Accepted |
+| [0018](0018-events-block-surface.md) | Events block: scope, consumer surface, docs section split | Proposed |
+| [0019](0019-closed-vocabularies-for-events.md) | Closed vocabularies for event names and payload types | Proposed |
 
 ## When to write one
 

--- a/docs/ADR/README.md
+++ b/docs/ADR/README.md
@@ -25,6 +25,8 @@ a numbered, durable file.
 | [0015](0015-codegen-layout.md) | Codegen layout: target-first generators | Accepted |
 | [0016](0016-per-breakpoint-css-cost.md) | Per-breakpoint CSS cost: status quo with budget | Accepted |
 | [0017](0017-strict-token-interface-boundary.md) | Strict token-interface boundary | Accepted |
+| [0018](0018-events-block-surface.md) | Events block: scope, consumer surface, docs section split | Accepted |
+| [0019](0019-closed-vocabularies-for-events.md) | Closed vocabularies for event names and payload types | Accepted |
 
 ## When to write one
 


### PR DESCRIPTION
## What

Two ADRs derived from RFC-0006, recording the load-bearing decisions for the consumer event surface.

- ADR-0018 — events block: scope, consumer surface, docs section split.
- ADR-0019 — closed vocabularies for event names and payload types.

Closes #844.

## Why

ADR-0005 makes ADRs the durable decision log; RFC-0006 is exploration. The events block is about to be implemented across the vocabulary, schema, validator, and four code generators. The ADRs need to land before the implementation PRs so future contributors hit a "Why this and not the alternatives" record on the surface they're touching, not a 900-line RFC.

## Test plan

- [ ] `docs/ADR/README.md` index lists 0018 + 0019.
- [ ] Each ADR follows the README shape (status, deciders, decision, why-this-and-not, consequences, references).
- [ ] No spec / schema / codegen / test changes; this PR is docs-only.

## Out of scope

- Vocabulary infrastructure (`_vocabulary.yaml` extension + generated TS mirror).
- Schema + validator (Zod fields + semantic-check rules).
- Codegen tracer-bullet (Modal `events: dismiss`).
- Docs four-section rewrite of `gen-docs/_shared/sections.ts`.
- Per-spec rollout.