### PR TITLE
feat(spec): structured events vocabulary

### DIFF
--- a/scripts/codegen/src/lib/vocabulary.test.ts
+++ b/scripts/codegen/src/lib/vocabulary.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import { loadVocabulary } from "./vocabulary.ts";
+
+describe("loadVocabulary", () => {
+  it("exposes the structured events block", async () => {
+    const vocab = await loadVocabulary();
+    expect(vocab.events).toMatchObject({
+      verbs: expect.any(Object),
+      synonyms: expect.any(Object),
+      pattern: expect.any(String),
+      builtins: expect.any(Object),
+    });
+  });
+
+  it("registers the core verbs", async () => {
+    const { events } = await loadVocabulary();
+    for (const verb of ["activate", "select", "submit", "dismiss", "change", "click"]) {
+      expect(events.verbs).toHaveProperty(verb);
+      expect(events.verbs[verb]).toBeTruthy();
+    }
+  });
+
+  it("maps every synonym to either a registered verb or the controllable sentinel", async () => {
+    const { events } = await loadVocabulary();
+    for (const [synonym, canonical] of Object.entries(events.synonyms)) {
+      expect(events.verbs).not.toHaveProperty(synonym);
+      if (canonical !== "—") {
+        expect(events.verbs).toHaveProperty(canonical);
+      }
+    }
+  });
+
+  it("routes the open synonym to the controllable sentinel", async () => {
+    const { events } = await loadVocabulary();
+    expect(events.synonyms.open).toBe("—");
+  });
+
+  it("compiles the event-name pattern as a regex that accepts canonical forms", async () => {
+    const { events } = await loadVocabulary();
+    const re = new RegExp(events.pattern);
+    expect(re.test("dismiss")).toBe(true);
+    expect(re.test("fileAdd")).toBe(true);
+    expect(re.test("endReach")).toBe(true);
+    expect(re.test("rowDoubleClick")).toBe(true);
+    expect(re.test("sort_change")).toBe(false);
+    expect(re.test("Dismiss")).toBe(false);
+    expect(re.test("")).toBe(false);
+  });
+
+  it("registers the documented built-in payload types", async () => {
+    const { events } = await loadVocabulary();
+    for (const builtin of [
+      "Date",
+      "MouseEvent",
+      "KeyboardEvent",
+      "PointerEvent",
+      "FocusEvent",
+      "File",
+      "Error",
+      "HTMLElement",
+    ]) {
+      expect(events.builtins).toHaveProperty(builtin);
+    }
+  });
+});

--- a/scripts/codegen/src/lib/vocabulary.ts
+++ b/scripts/codegen/src/lib/vocabulary.ts
@@ -6,6 +6,13 @@ import { parse as parseYaml } from "yaml";
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..", "..", "..");
 const VOCABULARY_PATH = resolve(REPO_ROOT, "specs", "_vocabulary.yaml");
 
+export type EventVocabulary = {
+  verbs: Record<string, string>;
+  synonyms: Record<string, string>;
+  pattern: string;
+  builtins: Record<string, string>;
+};
+
 export type Vocabulary = {
   components: string[];
   props: string[];
@@ -16,7 +23,7 @@ export type Vocabulary = {
   sizeMap: Record<string, number>;
   states: string[];
   parts: string[];
-  events: string[];
+  events: EventVocabulary;
 };
 
 let cached: Vocabulary | null = null;

--- a/scripts/codegen/src/semantic-checks.test.ts
+++ b/scripts/codegen/src/semantic-checks.test.ts
@@ -48,7 +48,12 @@ const vocabulary: Vocabulary = {
   sizeMap: { sm: 2, md: 4, lg: 6 },
   states: ["disabled", "loading", "error", "success"],
   parts: [],
-  events: [],
+  events: {
+    verbs: {},
+    synonyms: {},
+    pattern: "^([a-z]+|[a-z]+([A-Z][a-zA-Z0-9]+)+)$",
+    builtins: {},
+  },
 };
 
 function makeButton(overrides: Partial<Spec> = {}): Spec {

--- a/specs/_vocabulary.yaml
+++ b/specs/_vocabulary.yaml
@@ -138,14 +138,76 @@ parts:
   - __list
   - __item
 
-# Event verbs (spec form).
+# Event vocabulary (spec form).
+# Consumed by codegen, the validator, and gen-docs via
+# scripts/codegen/src/lib/vocabulary.ts.
 events:
-  - click
-  - submit
-  - dismiss
-  - change
-  - select
-  - open
-  - close
-  - focus
-  - blur
+  # Verb registry — last camelCase token of every event name must
+  # be a key here. Values are the canonical description surfaced in
+  # generated docs.
+  verbs:
+    # User-initiated actions
+    activate:    "Primary action triggered (click + Enter + Space)."
+    select:      "User chose an item from a set."
+    submit:      "User confirmed a value or form."
+    cancel:      "User explicitly cancelled an action."
+    clear:       "User cleared a value back to empty."
+    dismiss:     "Surface closed (outside, escape, button — payload carries reason)."
+    expand:      "Region expanded."
+    collapse:    "Region collapsed."
+    edit:        "Edit lifecycle (start, commit, cancel)."
+    reorder:     "Items reordered by the user."
+    retry:       "User retried a failed operation."
+    abort:       "User aborted an in-progress operation."
+    add:         "Item was added to a collection."
+    remove:      "Item was removed from a collection."
+
+    # Pure state-change verb
+    change:      "A value changed. Bare 'change' or '<noun>Change'."
+
+    # Sub-element gestures
+    click:       "Click on a named sub-element (row, cell, column header)."
+    doubleClick: "Double click on a sub-element."
+    hover:       "Pointer entered a sub-element."
+    focus:       "Focus moved into a sub-element."
+    blur:        "Focus left a sub-element."
+    drag:        "Drag lifecycle (start, over, end)."
+    drop:        "Drop completed."
+    resize:      "Element was resized."
+
+    # Lifecycle / async
+    load:        "Resource load completed successfully."
+    start:       "Operation started."
+    complete:    "Operation completed successfully."
+    progress:    "Long-running operation reported progress."
+    error:       "Operation failed with an error (DOM-convention noun-verb)."
+    reach:       "Sentinel reached (used by 'endReach' for infinite scroll)."
+
+  # Synonyms — author writes the key, validator suggests the value,
+  # hard reject. Value '—' means "use the controllable pair
+  # (open/onOpenChange) instead of declaring an event."
+  synonyms:
+    close:    dismiss
+    hide:     dismiss
+    update:   change
+    modify:   change
+    toggle:   change
+    input:    change
+    press:    activate
+    open:     "—"
+
+  # Event-name pattern — '<verb>' or '<subjectNoun><Verb>'
+  # (camelCase). The LAST camelCase token must be a registered verb.
+  pattern: "^([a-z]+|[a-z]+([A-Z][a-zA-Z0-9]+)+)$"
+
+  # Built-in types the payload vocabulary allows. Extending this
+  # list is the same review gate as adding a verb.
+  builtins:
+    Date:          "ECMAScript Date instance."
+    MouseEvent:    "DOM MouseEvent."
+    KeyboardEvent: "DOM KeyboardEvent."
+    PointerEvent:  "DOM PointerEvent."
+    FocusEvent:    "DOM FocusEvent."
+    File:          "DOM File (uploads, drag-drop)."
+    Error:         "ECMAScript Error subclass."
+    HTMLElement:   "DOM HTMLElement (target references)."


### PR DESCRIPTION
## What

Restructure `specs/_vocabulary.yaml` `events:` from a flat string list into the four-key block (`verbs`, `synonyms`, `pattern`, `builtins`) named in ADR-0019, and extend the typed loader at `scripts/codegen/src/lib/vocabulary.ts` with a matching `EventVocabulary` type.

Closes #846.

## Why

Step 1 of the RFC-0006 phase ladder. Schema + validator work (8 semantic-check rules) and codegen of the per-event surface both import from this loader; nothing else can land until the vocab is in place. The previous flat `events:` list was unreferenced (grep confirms no `vocabulary.events` reads), so this PR is purely additive at runtime — only the type widens.

## Test plan

- `scripts/codegen/src/lib/vocabulary.test.ts` covers the new shape: verbs registered, synonyms mapped to either a registered verb or the `—` controllable sentinel, `open` routed to `—`, name pattern accepts `dismiss` / `fileAdd` / `endReach` / `rowDoubleClick` and rejects `sort_change` / `Dismiss` / empty, builtins include the documented DOM types.
- Existing `scripts/codegen/src/semantic-checks.test.ts` fixture updated to the new `events` shape; full test suite (1048 tests) stays green.
- `pnpm gen` produces no diff — no generator reads `vocabulary.events` yet.

## Out of scope

- Generated TS mirror at `scripts/codegen/src/lib/vocabulary.ts` (the long-term form). The loader stays a runtime YAML loader for now; switching to a `pnpm gen` output is its own follow-up.
- Zod schema for `events:` block on component specs.
- Semantic-check rules (event-name pattern, verb-registered, synonym rejection, etc.).
- Codegen wiring (per-event props, `onEvent` channel, four-section docs split).