### PR TITLE
feat(spec): events/generics blocks + semantic checks

### DIFF
--- a/scripts/codegen/src/schema.test.ts
+++ b/scripts/codegen/src/schema.test.ts
@@ -316,7 +316,7 @@ describe("Spec schema — shape layer", () => {
     });
     expect(result.success).toBe(true);
     if (result.success && result.data.kind === "atomic") {
-      expect(result.data.events?.dismiss.payload).toEqual({});
+      expect(result.data.events?.dismiss?.payload).toEqual({});
     }
   });
 

--- a/scripts/codegen/src/schema.test.ts
+++ b/scripts/codegen/src/schema.test.ts
@@ -283,4 +283,88 @@ describe("Spec schema — shape layer", () => {
     });
     expect(result.success).toBe(false);
   });
+
+  test("accepts an empty events: block", () => {
+    const result = Spec.safeParse({ ...minimalAtomic(), events: {} });
+    expect(result.success).toBe(true);
+  });
+
+  test("accepts a declared event with structured payload variants", () => {
+    const result = Spec.safeParse({
+      ...minimalAtomic(),
+      generics: [{ name: "Item", description: "Item shape." }],
+      events: {
+        dismiss: {
+          description: "Closed.",
+          payload: {
+            reason: { type: "enum", values: ["outside", "escape", "button"] },
+            depth: { type: "number", nullable: true },
+            origin: { type: "generic", ref: "Item" },
+            file: { type: "builtin", name: "File" },
+            tags: { type: "array", of: { type: "string" } },
+          },
+        },
+      },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  test("defaults a missing payload to an empty object", () => {
+    const result = Spec.safeParse({
+      ...minimalAtomic(),
+      events: { dismiss: { description: "Closed." } },
+    });
+    expect(result.success).toBe(true);
+    if (result.success && result.data.kind === "atomic") {
+      expect(result.data.events?.dismiss.payload).toEqual({});
+    }
+  });
+
+  test("rejects an enum payload with no values", () => {
+    const result = Spec.safeParse({
+      ...minimalAtomic(),
+      events: {
+        dismiss: {
+          description: "Closed.",
+          payload: { reason: { type: "enum", values: [] } },
+        },
+      },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects an events: block declared on a sub-part (root-only)", () => {
+    const result = Spec.safeParse({
+      name: "popover",
+      kind: "composite",
+      parts: {
+        root: {
+          element: "div",
+          events: { dismiss: { description: "x" } },
+        },
+      },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects a generic with a lowercase name", () => {
+    const result = Spec.safeParse({
+      ...minimalAtomic(),
+      generics: [{ name: "item", description: "Item shape." }],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects a payload entry with an unknown type discriminator", () => {
+    const result = Spec.safeParse({
+      ...minimalAtomic(),
+      events: {
+        dismiss: {
+          description: "Closed.",
+          payload: { reason: { type: "regex", source: "x" } },
+        },
+      },
+    });
+    expect(result.success).toBe(false);
+  });
 });

--- a/scripts/codegen/src/schema.ts
+++ b/scripts/codegen/src/schema.ts
@@ -184,6 +184,63 @@ const interactionRule = z.strictObject({
   when: z.string().optional(),
 });
 
+// Consumer-facing event surface. Each declared event names a semantic action
+// (verb registry lives in `specs/_vocabulary.yaml`) and carries a typed
+// payload. Payload fields use a closed vocabulary — no raw TypeScript
+// fragments, no `unknown`/`any`. `generic` payloads reference names declared
+// in the spec's `generics:` block; `builtin` payloads reference names from
+// the vocab's `events.builtins` list. Validator enforces both.
+export type PayloadEntry =
+  | { type: "string"; nullable?: boolean }
+  | { type: "number"; nullable?: boolean }
+  | { type: "boolean"; nullable?: boolean }
+  | { type: "enum"; values: string[]; nullable?: boolean }
+  | { type: "generic"; ref: string; nullable?: boolean }
+  | { type: "builtin"; name: string; nullable?: boolean }
+  | { type: "array"; of: PayloadEntry; nullable?: boolean };
+
+const payloadEntry: z.ZodType<PayloadEntry> = z.lazy(() =>
+  z.discriminatedUnion("type", [
+    z.strictObject({ type: z.literal("string"), nullable: z.boolean().optional() }),
+    z.strictObject({ type: z.literal("number"), nullable: z.boolean().optional() }),
+    z.strictObject({ type: z.literal("boolean"), nullable: z.boolean().optional() }),
+    z.strictObject({
+      type: z.literal("enum"),
+      values: z.array(z.string()).min(1),
+      nullable: z.boolean().optional(),
+    }),
+    z.strictObject({
+      type: z.literal("generic"),
+      ref: z.string().min(1),
+      nullable: z.boolean().optional(),
+    }),
+    z.strictObject({
+      type: z.literal("builtin"),
+      name: z.string().min(1),
+      nullable: z.boolean().optional(),
+    }),
+    z.strictObject({
+      type: z.literal("array"),
+      of: payloadEntry,
+      nullable: z.boolean().optional(),
+    }),
+  ]),
+);
+
+const eventEntry = z.strictObject({
+  description: z.string().min(1),
+  payload: z.record(z.string(), payloadEntry).default({}),
+});
+
+// Unconstrained generics: spec author declares a name + description;
+// consumers pass whatever type they want at the call site. Constraint
+// vocabulary (`Item extends ...`) is a closed-set follow-up — raw TypeScript
+// constraint strings would be an escape hatch.
+const genericEntry = z.strictObject({
+  name: z.string().regex(/^[A-Z][A-Za-z0-9]*$/),
+  description: z.string().min(1),
+});
+
 // Identity-layer fields — only at the root, never on a sub-part.
 const guidanceBlock = z.strictObject({
   when: z.array(z.string()).optional(),
@@ -216,6 +273,8 @@ const identityFields = {
   coverage: coverageBlock.optional(),
   overlay: overlayBlock.optional(),
   interactions: z.array(interactionRule).optional(),
+  generics: z.array(genericEntry).optional(),
+  events: z.record(z.string(), eventEntry).optional(),
 } as const;
 
 const atomicSpec = z.strictObject({

--- a/scripts/codegen/src/semantic-checks.test.ts
+++ b/scripts/codegen/src/semantic-checks.test.ts
@@ -2080,4 +2080,30 @@ describe("checkEvents (RFC-0006)", () => {
     expect(issues.length).toBe(1);
     expect(issues[0]?.message).not.toMatch(/not registered/);
   });
+
+  test("rejects verbs that collide with Object.prototype method names", () => {
+    // `in` operator would treat `toString` / `valueOf` / `hasOwnProperty`
+    // as registered via inheritance — Object.hasOwn keeps the vocab closed.
+    const spec = makeEvents({
+      toString: { description: "x", payload: {} },
+      valueOf: { description: "x", payload: {} },
+      hasOwnProperty: { description: "x", payload: {} },
+    });
+    const issues = checkEvents(spec, vocabulary);
+    expect(issues.length).toBe(3);
+    for (const verb of ["toString", "valueOf", "hasOwnProperty"]) {
+      expect(issues.some((i) => i.message.includes(`'${verb}'`))).toBe(true);
+    }
+  });
+
+  test("rejects payload builtin names that collide with Object.prototype", () => {
+    const spec = makeEvents({
+      add: {
+        description: "x",
+        payload: { thing: { type: "builtin", name: "toString" } },
+      },
+    });
+    const issues = checkEvents(spec, vocabulary);
+    expect(issues.some((i) => /built-in type 'toString'/.test(i.message))).toBe(true);
+  });
 });

--- a/scripts/codegen/src/semantic-checks.test.ts
+++ b/scripts/codegen/src/semantic-checks.test.ts
@@ -9,6 +9,7 @@ import {
   checkCoverageShape,
   checkCssImportAllowlist,
   checkDependencyCycles,
+  checkEvents,
   checkExamplesPresent,
   checkExamplesReferences,
   checkInteractionEventVocabulary,
@@ -49,10 +50,25 @@ const vocabulary: Vocabulary = {
   states: ["disabled", "loading", "error", "success"],
   parts: [],
   events: {
-    verbs: {},
-    synonyms: {},
+    verbs: {
+      dismiss: "Surface closed.",
+      change: "Value changed.",
+      select: "User chose an item.",
+      add: "Item added.",
+      reach: "Sentinel reached.",
+      activate: "Primary action.",
+    },
+    synonyms: {
+      close: "dismiss",
+      update: "change",
+      press: "activate",
+      open: "—",
+    },
     pattern: "^([a-z]+|[a-z]+([A-Z][a-zA-Z0-9]+)+)$",
-    builtins: {},
+    builtins: {
+      File: "DOM File.",
+      Date: "ECMAScript Date.",
+    },
   },
 };
 
@@ -1873,5 +1889,195 @@ describe("checkRepeatingParts (RFC-0005)", () => {
     const issues = checkRepeatingParts(spec);
     expect(issues.map((i) => i.path)).toEqual(["parts.page.props.id"]);
     expect(issues[0]?.message).toMatch(/reserved/i);
+  });
+});
+
+describe("checkEvents (RFC-0006)", () => {
+  function makeEvents(events: Record<string, unknown>, extra: Partial<Spec> = {}): Spec {
+    return makeButton({
+      events: events as Spec["events"],
+      ...extra,
+    });
+  }
+
+  test("returns no issues when events: is absent", () => {
+    expect(checkEvents(makeButton(), vocabulary)).toEqual([]);
+  });
+
+  test("returns no issues for a declared event with a registered verb", () => {
+    const spec = makeEvents({
+      dismiss: { description: "Closed.", payload: {} },
+    });
+    expect(checkEvents(spec, vocabulary)).toEqual([]);
+  });
+
+  test("E1: rejects an event name that doesn't match the vocab pattern", () => {
+    const spec = makeEvents({
+      sort_change: { description: "x", payload: {} },
+    });
+    const issues = checkEvents(spec, vocabulary);
+    expect(issues.map((i) => i.path)).toEqual(["events.sort_change"]);
+    expect(issues[0]?.message).toMatch(/valid event name/);
+  });
+
+  test("E1: rejects PascalCase event names", () => {
+    const spec = makeEvents({
+      Dismiss: { description: "x", payload: {} },
+    });
+    const issues = checkEvents(spec, vocabulary);
+    expect(issues.map((i) => i.path)).toEqual(["events.Dismiss"]);
+  });
+
+  test("E2: rejects an unregistered verb with a Levenshtein suggestion", () => {
+    const spec = makeEvents({
+      activatee: { description: "x", payload: {} },
+    });
+    const issues = checkEvents(spec, vocabulary);
+    expect(issues.map((i) => i.path)).toEqual(["events.activatee"]);
+    expect(issues[0]?.message).toMatch(/not registered/);
+    expect(issues[0]?.message).toMatch(/'activate'/);
+  });
+
+  test("E2: extracts the last camelCase token as the verb", () => {
+    const spec = makeEvents({
+      rowMutate: { description: "x", payload: {} },
+    });
+    const issues = checkEvents(spec, vocabulary);
+    expect(issues[0]?.message).toMatch(/'mutate' is not registered/);
+  });
+
+  test("E3: rejects a synonym with the canonical suggestion", () => {
+    const spec = makeEvents({
+      close: { description: "x", payload: {} },
+    });
+    const issues = checkEvents(spec, vocabulary);
+    expect(issues.map((i) => i.path)).toEqual(["events.close"]);
+    expect(issues[0]?.message).toMatch(/synonym for 'dismiss'/);
+  });
+
+  test("E3: synonym in subject+verb form is detected by the last token", () => {
+    const spec = makeEvents({
+      modalClose: { description: "x", payload: {} },
+    });
+    const issues = checkEvents(spec, vocabulary);
+    expect(issues[0]?.message).toMatch(/'close' is registered as a synonym/);
+  });
+
+  test("E4: routes the open synonym to pattern: controllable", () => {
+    const spec = makeEvents({
+      open: { description: "x", payload: {} },
+    });
+    const issues = checkEvents(spec, vocabulary);
+    expect(issues.map((i) => i.path)).toEqual(["events.open"]);
+    expect(issues[0]?.message).toMatch(/pattern: "controllable"/);
+  });
+
+  test("E5: rejects a generic ref not declared on the spec", () => {
+    const spec = makeEvents({
+      select: {
+        description: "x",
+        payload: { item: { type: "generic", ref: "Item" } },
+      },
+    });
+    const issues = checkEvents(spec, vocabulary);
+    expect(issues.map((i) => i.path)).toEqual(["events.select.payload.item"]);
+    expect(issues[0]?.message).toMatch(/generic 'Item'/);
+  });
+
+  test("E5: accepts a generic ref that is declared", () => {
+    const spec = makeEvents(
+      {
+        select: {
+          description: "x",
+          payload: { item: { type: "generic", ref: "Item" } },
+        },
+      },
+      { generics: [{ name: "Item", description: "Item shape." }] },
+    );
+    expect(checkEvents(spec, vocabulary)).toEqual([]);
+  });
+
+  test("E5: walks generic refs inside array.of", () => {
+    const spec = makeEvents({
+      select: {
+        description: "x",
+        payload: {
+          items: { type: "array", of: { type: "generic", ref: "Row" } },
+        },
+      },
+    });
+    const issues = checkEvents(spec, vocabulary);
+    expect(issues.map((i) => i.path)).toEqual(["events.select.payload.items.of"]);
+  });
+
+  test("E6: rejects an unregistered builtin name", () => {
+    const spec = makeEvents({
+      add: {
+        description: "x",
+        payload: { entry: { type: "builtin", name: "Blob" } },
+      },
+    });
+    const issues = checkEvents(spec, vocabulary);
+    expect(issues.map((i) => i.path)).toEqual(["events.add.payload.entry"]);
+    expect(issues[0]?.message).toMatch(/built-in type 'Blob'/);
+  });
+
+  test("E6: accepts a registered builtin name", () => {
+    const spec = makeEvents({
+      add: {
+        description: "x",
+        payload: { file: { type: "builtin", name: "File" } },
+      },
+    });
+    expect(checkEvents(spec, vocabulary)).toEqual([]);
+  });
+
+  test("E8: rejects an event name that collides with a controllable callback", () => {
+    const spec = makeEvents(
+      { valueChange: { description: "x", payload: {} } },
+      {
+        props: {
+          value: {
+            type: "string",
+            description: "Value.",
+            pattern: "controllable",
+          },
+        },
+      },
+    );
+    const issues = checkEvents(spec, vocabulary);
+    expect(issues.some((i) => /onValueChange/.test(i.message))).toBe(true);
+  });
+
+  test("E8: composite spec checks controllable props across all parts", () => {
+    const spec: Spec = {
+      name: "combobox",
+      kind: "composite",
+      events: { openChange: { description: "x", payload: {} } },
+      parts: {
+        root: {
+          element: "div",
+          props: {
+            open: {
+              type: "boolean",
+              description: "Open state.",
+              pattern: "controllable",
+            },
+          },
+        },
+      },
+    } as Spec;
+    const issues = checkEvents(spec, vocabulary);
+    expect(issues.some((i) => /onOpenChange/.test(i.message))).toBe(true);
+  });
+
+  test("verb-registered check is mutually exclusive with synonym check", () => {
+    // 'close' is a synonym; the verb-not-registered message should NOT also fire.
+    const spec = makeEvents({
+      close: { description: "x", payload: {} },
+    });
+    const issues = checkEvents(spec, vocabulary);
+    expect(issues.length).toBe(1);
+    expect(issues[0]?.message).not.toMatch(/not registered/);
   });
 });

--- a/scripts/codegen/src/semantic-checks.ts
+++ b/scripts/codegen/src/semantic-checks.ts
@@ -1236,7 +1236,7 @@ export function checkEvents(spec: Spec, vocabulary: Vocabulary): Issue[] {
 
     const verb = eventVerb(name);
 
-    if (verb in synonyms) {
+    if (Object.hasOwn(synonyms, verb)) {
       const canonical = synonyms[verb];
       if (canonical === "—") {
         issues.push(
@@ -1255,7 +1255,7 @@ export function checkEvents(spec: Spec, vocabulary: Vocabulary): Issue[] {
           ),
         );
       }
-    } else if (!(verb in verbs)) {
+    } else if (!Object.hasOwn(verbs, verb)) {
       issues.push(
         issue(
           spec.name,
@@ -1287,7 +1287,7 @@ export function checkEvents(spec: Spec, vocabulary: Vocabulary): Issue[] {
             ),
           );
         }
-        if (p.type === "builtin" && !(p.name in builtins)) {
+        if (p.type === "builtin" && !Object.hasOwn(builtins, p.name)) {
           issues.push(
             issue(
               spec.name,

--- a/scripts/codegen/src/semantic-checks.ts
+++ b/scripts/codegen/src/semantic-checks.ts
@@ -10,7 +10,7 @@ import { isVoidElement } from "./lib/html-void-elements.ts";
 import { REACT_EVENT_VOCABULARY } from "./lib/react-events.ts";
 import type { TokenDictionary } from "./lib/token-dictionary.ts";
 import type { Vocabulary } from "./lib/vocabulary.ts";
-import type { Spec, SpecPart } from "./schema.ts";
+import type { PayloadEntry, Spec, SpecPart } from "./schema.ts";
 
 type TokensCss = ReadonlySet<string>;
 
@@ -1164,6 +1164,144 @@ export function checkInteractionEventVocabulary(spec: Spec): Issue[] {
   return issues;
 }
 
+// ── Events block ────────────────────────────────────────────────────────────
+
+const CAMEL_TAIL_RE = /[A-Z][a-zA-Z0-9]*$/;
+
+function eventVerb(name: string): string {
+  const match = name.match(CAMEL_TAIL_RE);
+  return match ? match[0].toLowerCase() : name.toLowerCase();
+}
+
+function visitPayload(
+  entry: PayloadEntry,
+  path: string,
+  visit: (p: PayloadEntry, path: string) => void,
+): void {
+  visit(entry, path);
+  if (entry.type === "array") visitPayload(entry.of, `${path}.of`, visit);
+}
+
+function collectControllableProps(spec: Spec): string[] {
+  const names: string[] = [];
+  visitNodes(spec, (node) => {
+    for (const [propName, def] of Object.entries(node.props ?? {})) {
+      if (def.pattern === "controllable") names.push(propName);
+    }
+  });
+  return names;
+}
+
+/**
+ * Validates `events:` declarations against the vocab + the spec's own
+ * `generics:` and controllable props. Per RFC-0006 § Validator rules:
+ *
+ *  - E1 — event name doesn't match the vocab pattern.
+ *  - E2 — last camelCase token isn't a registered verb (Levenshtein suggest).
+ *  - E3 — name's verb is a synonym for a canonical verb.
+ *  - E4 — name's verb is a synonym whose canonical is '—' (controllable).
+ *  - E5 — payload `generic.ref` not in this spec's `generics:` block.
+ *  - E6 — payload `builtin.name` not in vocab `events.builtins`.
+ *  - E8 — event name collides with a `<prop>Change` callback emitted by a
+ *    controllable prop on this spec.
+ *
+ * E7 ("events declared on a sub-part") falls out of the schema: `events:`
+ * lives on `identityFields`, so a part-level declaration fails strictObject
+ * with an "Unrecognized key" before semantic checks run.
+ */
+export function checkEvents(spec: Spec, vocabulary: Vocabulary): Issue[] {
+  const events = spec.events;
+  if (!events || Object.keys(events).length === 0) return [];
+
+  const issues: Issue[] = [];
+  const { verbs, synonyms, pattern, builtins } = vocabulary.events;
+  const nameRe = new RegExp(pattern);
+  const verbList = Object.keys(verbs);
+  const declaredGenerics = new Set((spec.generics ?? []).map((g) => g.name));
+  const controllableCallbacks = new Set(collectControllableProps(spec).map((p) => `${p}Change`));
+
+  for (const [name, entry] of Object.entries(events)) {
+    const path = `events.${name}`;
+
+    if (!nameRe.test(name)) {
+      issues.push(
+        issue(
+          spec.name,
+          path,
+          `'${name}' is not a valid event name. Use camelCase: '<verb>' or '<subjectNoun><Verb>'.`,
+        ),
+      );
+      continue;
+    }
+
+    const verb = eventVerb(name);
+
+    if (verb in synonyms) {
+      const canonical = synonyms[verb];
+      if (canonical === "—") {
+        issues.push(
+          issue(
+            spec.name,
+            path,
+            `'${name}' uses the state-mirror verb '${verb}'. Declare \`pattern: "controllable"\` on the '${verb}' prop instead of declaring an event.`,
+          ),
+        );
+      } else {
+        issues.push(
+          issue(
+            spec.name,
+            path,
+            `'${verb}' is registered as a synonym for '${canonical}'. Use '${canonical}' to keep event names consistent across components.`,
+          ),
+        );
+      }
+    } else if (!(verb in verbs)) {
+      issues.push(
+        issue(
+          spec.name,
+          path,
+          `'${name}' verb '${verb}' is not registered.${suggestionFragment(verb, verbList)}`,
+        ),
+      );
+    }
+
+    if (controllableCallbacks.has(name)) {
+      const propName = name.slice(0, -"Change".length);
+      issues.push(
+        issue(
+          spec.name,
+          path,
+          `'${name}' collides with the on${propName[0]?.toUpperCase()}${propName.slice(1)}Change callback emitted by \`pattern: "controllable"\` on prop '${propName}'. Pick a distinct event name or remove the controllable pattern.`,
+        ),
+      );
+    }
+
+    for (const [field, payload] of Object.entries(entry.payload)) {
+      visitPayload(payload, `${path}.payload.${field}`, (p, payloadPath) => {
+        if (p.type === "generic" && !declaredGenerics.has(p.ref)) {
+          issues.push(
+            issue(
+              spec.name,
+              payloadPath,
+              `'${name}' payload references generic '${p.ref}' which is not declared in this spec's generics: block.`,
+            ),
+          );
+        }
+        if (p.type === "builtin" && !(p.name in builtins)) {
+          issues.push(
+            issue(
+              spec.name,
+              payloadPath,
+              `'${name}' payload references built-in type '${p.name}' which is not registered. Add it to specs/_vocabulary.yaml events.builtins.`,
+            ),
+          );
+        }
+      });
+    }
+  }
+  return issues;
+}
+
 // ── Repeating parts (RFC-0005, phase 1) ─────────────────────────────────────
 
 /**
@@ -1683,6 +1821,7 @@ export function runSemanticChecks(
     ...checkOverlayEscapeRules(spec),
     ...checkRepeatingParts(spec),
     ...checkExamplesPresent(spec),
+    ...checkEvents(spec, ctx.vocabulary),
   ];
 }
 


### PR DESCRIPTION
## What

Add the spec-side `events:` and `generics:` blocks to the Zod schema in `scripts/codegen/src/schema.ts`, with a recursive discriminated `PayloadEntry` union (`string` / `number` / `boolean` / `enum` / `generic` / `builtin` / `array`, each with optional `nullable`). Add `checkEvents` in `scripts/codegen/src/semantic-checks.ts` with seven rules that enforce the closed vocabularies and cross-block constraints.

Closes #848.

## Why

Step 2 of the RFC-0006 phase ladder. The vocab registry landed in PR #847; this PR makes the spec layer accept and validate `events:` declarations against that vocab. Codegen wiring (per-event props, `onEvent` channel) follows in step 3 and consumes the same Zod-typed shape and the validator's rejection of invalid declarations.

## Test plan

- `scripts/codegen/src/schema.test.ts` — eight new cases covering the new fields (empty events, full payload variants, default payload to `{}`, enum-with-no-values rejected, events on a sub-part rejected, lowercase generic name rejected, unknown payload type discriminator rejected).
- `scripts/codegen/src/semantic-checks.test.ts` — seventeen cases for `checkEvents` covering each rule (E1-E6, E8) on happy + unhappy paths, including: generic-ref existence inside `array.of`, composite spec walking parts for E8 controllable collision, mutual exclusion of E2/E3 (synonym fires alone).
- Full suite: 101 files, 1072 tests, all green.

## Scope note

RFC-0006 § Validator rules lists eight checks (E1-E8). E7 ("events declared on a sub-part") is enforced by Zod's strictObject placement of `events:` on the root-only `identityFields` block — a `events:` key on any part fails the schema with an "Unrecognized key" error before semantic checks run. Same UX as every other root-only field (`dependencies:`, `guidance:`, `examples:`); no custom message added for this case. Net: seven semantic rules, one schema-level rejection. The new schema test `rejects an events: block declared on a sub-part (root-only)` covers the Zod path.

## Out of scope

- Codegen wiring (per-event props, `onEvent` channel, four-section docs split).
- Generated TS mirror at `scripts/codegen/src/lib/vocabulary.ts`.
- Per-spec rollout (Modal tracer-bullet, Tooltip, list components).
- Constraint vocabulary for generics (`Item extends …`).