### PR TITLE
chore(claude): guard codegen pushes behind audit ack

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -39,6 +39,17 @@
           }
         ]
       }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node scripts/hooks/claude-codegen-audit-guard.js"
+          }
+        ]
+      }
     ]
   }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 .claude/plans/
 .claude/scheduled_tasks.lock
 .claude/preflight-review.enabled
+.claude/codegen-audit-ack
 
 # Toolchain
 node_modules/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,11 @@ configs (`biome.json`, `.stylelintrc.cjs`, `tsconfig.json`, `lefthook.yml`,
 - Cross-session state lives in `.claude/handover.md` (`Done` / `In progress` /
   `Settled — do not re-decide` / `Next`). Refresh it after each chunk of work;
   read it before starting one. The file is gitignored — maintainer-only.
+- Before pushing changes that touch the codegen surface (`scripts/codegen/src/generators/**`,
+  `scripts/codegen/src/schema.ts`, `scripts/codegen/src/lib/flatten.ts`), run the
+  four-category audit from memory `project_codegen_surface_audit` and acknowledge
+  it via `audit: codegen-surface` in the latest commit subject. The
+  `claude-codegen-audit-guard` PreToolUse hook refuses the push otherwise.
 
 ## Ask before
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,8 @@ configs (`biome.json`, `.stylelintrc.cjs`, `tsconfig.json`, `lefthook.yml`,
 - Before pushing changes that touch the codegen surface (`scripts/codegen/src/generators/**`,
   `scripts/codegen/src/schema.ts`, `scripts/codegen/src/lib/flatten.ts`), run the
   four-category audit from memory `project_codegen_surface_audit` and acknowledge
-  it via `audit: codegen-surface` in the latest commit subject. The
+  it either via `audit: codegen-surface` in the latest commit subject, or by
+  touching `.claude/codegen-audit-ack` after the last commit. The
   `claude-codegen-audit-guard` PreToolUse hook refuses the push otherwise.
 
 ## Ask before

--- a/scripts/hooks/claude-codegen-audit-guard.js
+++ b/scripts/hooks/claude-codegen-audit-guard.js
@@ -50,10 +50,24 @@ function getCommand(payload) {
   return payload?.tool_input?.command ?? "";
 }
 
+// Git global flags whose value is a separate token (`git --work-tree /x push`).
+// Bundled form (`--work-tree=/x`) is handled by the `=` branch below regardless.
+// Anything not listed here is treated as value-less so `git --no-pager push`,
+// `git --bare push`, `git -p push` etc. parse correctly.
+const GIT_LONG_FLAGS_TAKING_VALUE = new Set([
+  "--exec-path",
+  "--git-dir",
+  "--work-tree",
+  "--namespace",
+  "--super-prefix",
+  "--config-env",
+  "--list-cmds",
+]);
+
 function isGitPush(command) {
   // Tokenize per shell segment and look for `git ... push` where `push` is the
-  // first non-flag token after `git`. Catches `git --no-pager push` and
-  // `git --git-dir=/x push` that a single regex with `-opt <arg>` pairs misses.
+  // first non-flag token after `git`. Handles bundled (`--git-dir=/x`) and
+  // separated (`-c name=value`, `--work-tree /x`) value-taking flags.
   const segments = command.split(/;|&&|\|\|/);
   for (const seg of segments) {
     const tokens = seg.trim().split(/\s+/);
@@ -67,9 +81,11 @@ function isGitPush(command) {
           j += 1;
           continue;
         }
-        // Short flags `-X` conservatively consume the next token; long flags
-        // `--name` do not (matches git's actual global-flag surface).
-        if (t.length === 2) {
+        if (t === "-C" || t === "-c") {
+          j += 2;
+          continue;
+        }
+        if (GIT_LONG_FLAGS_TAKING_VALUE.has(t)) {
           j += 2;
           continue;
         }

--- a/scripts/hooks/claude-codegen-audit-guard.js
+++ b/scripts/hooks/claude-codegen-audit-guard.js
@@ -13,8 +13,8 @@
 // the path filter below handles that — the guard only fires when at least one
 // changed file matches a codegen path.
 
-import { execSync } from "node:child_process";
-import { existsSync, statSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { existsSync, readFileSync, statSync } from "node:fs";
 import { resolve } from "node:path";
 
 const CODEGEN_PATTERNS = [
@@ -30,8 +30,8 @@ const MEMORY_POINTER = "memory: project_codegen_surface_audit (~/.claude/project
 
 function readStdinSync() {
   try {
-    // Claude Code passes the tool call payload as JSON on stdin.
-    return execSync("cat", { stdio: ["inherit", "pipe", "ignore"] }).toString();
+    // Claude Code passes the tool call payload as JSON on stdin (fd 0).
+    return readFileSync(0, "utf8");
   } catch {
     return "";
   }
@@ -57,7 +57,8 @@ function isGitPush(command) {
 }
 
 function gitOut(args) {
-  return execSync(`git ${args}`, { encoding: "utf8" }).trim();
+  // execFileSync avoids any shell interpretation of args (ref names, paths).
+  return execFileSync("git", args, { encoding: "utf8" }).trim();
 }
 
 function getPushRangeFiles() {
@@ -65,17 +66,22 @@ function getPushRangeFiles() {
   // `origin/main` (the project's main branch per CLAUDE.md).
   let base = "";
   try {
-    base = gitOut("rev-parse --abbrev-ref --symbolic-full-name @{u}");
+    base = gitOut(["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"]);
   } catch {
     base = "origin/main";
   }
   let files = "";
   try {
-    files = gitOut(`diff --name-only ${base}...HEAD`);
+    files = gitOut(["diff", "--name-only", `${base}...HEAD`]);
   } catch {
     // No upstream / unreachable base — fall back to last-commit files so we
     // still trip on a fresh branch.
-    files = gitOut("diff --name-only HEAD~1...HEAD");
+    try {
+      files = gitOut(["diff", "--name-only", "HEAD~1...HEAD"]);
+    } catch {
+      // Single-commit branch (no HEAD~1) — list files in the tip commit.
+      files = gitOut(["show", "--name-only", "--pretty=", "HEAD"]);
+    }
   }
   return files ? files.split("\n").filter(Boolean) : [];
 }
@@ -85,11 +91,11 @@ function touchesCodegen(files) {
 }
 
 function lastCommitSubject() {
-  return gitOut("log -1 --pretty=%s");
+  return gitOut(["log", "-1", "--pretty=%s"]);
 }
 
 function lastCommitTimestamp() {
-  return Number(gitOut("log -1 --pretty=%ct")) * 1000;
+  return Number(gitOut(["log", "-1", "--pretty=%ct"])) * 1000;
 }
 
 function ackFileFresh(repoRoot) {
@@ -97,7 +103,9 @@ function ackFileFresh(repoRoot) {
   if (!existsSync(path)) return false;
   try {
     const ackMtime = statSync(path).mtimeMs;
-    return ackMtime > lastCommitTimestamp();
+    // `>=` so coarse-resolution filesystems (FAT32 = 2s) don't reject an ack
+    // touched in the same second as the commit.
+    return ackMtime >= lastCommitTimestamp();
   } catch {
     return false;
   }
@@ -149,7 +157,7 @@ function main() {
 
   let repoRoot = "";
   try {
-    repoRoot = gitOut("rev-parse --show-toplevel");
+    repoRoot = gitOut(["rev-parse", "--show-toplevel"]);
   } catch {
     // Not inside a git repo — nothing to guard.
     return;

--- a/scripts/hooks/claude-codegen-audit-guard.js
+++ b/scripts/hooks/claude-codegen-audit-guard.js
@@ -1,0 +1,174 @@
+#!/usr/bin/env node
+// Claude Code PreToolUse guard fired before `git push`.
+//
+// If the push range touches codegen surface, require the most recent commit
+// subject to contain the literal token `audit: codegen-surface`, OR a fresh
+// `.claude/codegen-audit-ack` file (mtime newer than the most recent commit).
+//
+// Without the acknowledgement, refuse the push by exiting non-zero and writing
+// a structured PreToolUse decision to stdout. The four categories below come
+// from the project memory `project_codegen_surface_audit`.
+//
+// Bypass for one-off commits that genuinely don't touch the codegen surface:
+// the path filter below handles that — the guard only fires when at least one
+// changed file matches a codegen path.
+
+import { execSync } from "node:child_process";
+import { existsSync, statSync } from "node:fs";
+import { resolve } from "node:path";
+
+const CODEGEN_PATTERNS = [
+  /^scripts\/codegen\/src\/generators\//,
+  /^scripts\/codegen\/src\/schema\.ts$/,
+  /^scripts\/codegen\/src\/lib\/flatten\.ts$/,
+];
+
+const AUDIT_TOKEN = "audit: codegen-surface";
+const ACK_FILE = ".claude/codegen-audit-ack";
+
+const MEMORY_POINTER = "memory: project_codegen_surface_audit (~/.claude/projects/.../memory/)";
+
+function readStdinSync() {
+  try {
+    // Claude Code passes the tool call payload as JSON on stdin.
+    return execSync("cat", { stdio: ["inherit", "pipe", "ignore"] }).toString();
+  } catch {
+    return "";
+  }
+}
+
+function parsePayload(raw) {
+  if (!raw) return {};
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return {};
+  }
+}
+
+function getCommand(payload) {
+  return payload?.tool_input?.command ?? "";
+}
+
+function isGitPush(command) {
+  // Match `git push` and `git -C dir push`, but not `git push-something-else`.
+  // Reject leading-aliased forms by requiring `push` as a whole token after `git`.
+  return /(^|\s|;|&&|\|\|)git(\s+-[^\s]+\s+\S+)*\s+push(\s|$|;|&&|\|\|)/.test(command);
+}
+
+function gitOut(args) {
+  return execSync(`git ${args}`, { encoding: "utf8" }).trim();
+}
+
+function getPushRangeFiles() {
+  // Compare HEAD against the upstream tracking branch; fall back to
+  // `origin/main` (the project's main branch per CLAUDE.md).
+  let base = "";
+  try {
+    base = gitOut("rev-parse --abbrev-ref --symbolic-full-name @{u}");
+  } catch {
+    base = "origin/main";
+  }
+  let files = "";
+  try {
+    files = gitOut(`diff --name-only ${base}...HEAD`);
+  } catch {
+    // No upstream / unreachable base — fall back to last-commit files so we
+    // still trip on a fresh branch.
+    files = gitOut("diff --name-only HEAD~1...HEAD");
+  }
+  return files ? files.split("\n").filter(Boolean) : [];
+}
+
+function touchesCodegen(files) {
+  return files.some((f) => CODEGEN_PATTERNS.some((re) => re.test(f)));
+}
+
+function lastCommitSubject() {
+  return gitOut("log -1 --pretty=%s");
+}
+
+function lastCommitTimestamp() {
+  return Number(gitOut("log -1 --pretty=%ct")) * 1000;
+}
+
+function ackFileFresh(repoRoot) {
+  const path = resolve(repoRoot, ACK_FILE);
+  if (!existsSync(path)) return false;
+  try {
+    const ackMtime = statSync(path).mtimeMs;
+    return ackMtime > lastCommitTimestamp();
+  } catch {
+    return false;
+  }
+}
+
+function denyMessage() {
+  return [
+    "",
+    "Codegen-surface audit acknowledgement required.",
+    "",
+    "The push range touches codegen surface (generators / schema / flatten).",
+    "Run the four-category audit before pushing:",
+    "",
+    "  1. Schema-accepts / generator-drops gap",
+    "  2. Raw spec strings used as JS identifiers",
+    "  3. Inherited type / template collisions",
+    "  4. Documentation symmetry (RFC / JSDoc / docs / runtime)",
+    "",
+    `Reference: ${MEMORY_POINTER}`,
+    "",
+    "Acknowledge by either:",
+    `  - including \`${AUDIT_TOKEN}\` in the most recent commit subject, or`,
+    `  - touching \`${ACK_FILE}\` after the last commit.`,
+    "",
+  ].join("\n");
+}
+
+function emitDecision(decision, reason) {
+  // Claude Code reads a JSON object on stdout to decide allow / block.
+  process.stdout.write(
+    `${JSON.stringify({
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        permissionDecision: decision,
+        permissionDecisionReason: reason,
+      },
+    })}\n`,
+  );
+}
+
+function main() {
+  const payload = parsePayload(readStdinSync());
+  const command = getCommand(payload);
+
+  if (!command || !isGitPush(command)) {
+    // Not a git push — allow silently. (Claude Code treats no output as allow.)
+    return;
+  }
+
+  let repoRoot = "";
+  try {
+    repoRoot = gitOut("rev-parse --show-toplevel");
+  } catch {
+    // Not inside a git repo — nothing to guard.
+    return;
+  }
+
+  process.chdir(repoRoot);
+
+  const files = getPushRangeFiles();
+  if (!touchesCodegen(files)) return;
+
+  const subject = lastCommitSubject();
+  if (subject.includes(AUDIT_TOKEN)) return;
+
+  if (ackFileFresh(repoRoot)) return;
+
+  const reason = denyMessage();
+  emitDecision("deny", reason);
+  process.stderr.write(`${reason}\n`);
+  process.exit(2);
+}
+
+main();

--- a/scripts/hooks/claude-codegen-audit-guard.js
+++ b/scripts/hooks/claude-codegen-audit-guard.js
@@ -51,9 +51,34 @@ function getCommand(payload) {
 }
 
 function isGitPush(command) {
-  // Match `git push` and `git -C dir push`, but not `git push-something-else`.
-  // Reject leading-aliased forms by requiring `push` as a whole token after `git`.
-  return /(^|\s|;|&&|\|\|)git(\s+-[^\s]+\s+\S+)*\s+push(\s|$|;|&&|\|\|)/.test(command);
+  // Tokenize per shell segment and look for `git ... push` where `push` is the
+  // first non-flag token after `git`. Catches `git --no-pager push` and
+  // `git --git-dir=/x push` that a single regex with `-opt <arg>` pairs misses.
+  const segments = command.split(/;|&&|\|\|/);
+  for (const seg of segments) {
+    const tokens = seg.trim().split(/\s+/);
+    for (let i = 0; i < tokens.length; i++) {
+      if (tokens[i] !== "git") continue;
+      let j = i + 1;
+      while (j < tokens.length) {
+        const t = tokens[j];
+        if (!t.startsWith("-")) break;
+        if (t.includes("=")) {
+          j += 1;
+          continue;
+        }
+        // Short flags `-X` conservatively consume the next token; long flags
+        // `--name` do not (matches git's actual global-flag surface).
+        if (t.length === 2) {
+          j += 2;
+          continue;
+        }
+        j += 1;
+      }
+      if (tokens[j] === "push") return true;
+    }
+  }
+  return false;
 }
 
 function gitOut(args) {

--- a/scripts/lint/cross-file/.doc-path-allowlist.txt
+++ b/scripts/lint/cross-file/.doc-path-allowlist.txt
@@ -13,6 +13,7 @@ __snapshots__/
 # Local-only state (gitignored maintainer files; absent in CI)
 .claude/handover.md
 .claude/settings.local.json
+.claude/codegen-audit-ack
 
 # Future generated artifacts (created by codegen at later milestones)
 apps/docs/src/components/


### PR DESCRIPTION
## What

Adds a Claude Code `PreToolUse` Bash hook (`scripts/hooks/claude-codegen-audit-guard.js`) that blocks `git push` when the push range touches `scripts/codegen/src/generators/**`, `scripts/codegen/src/schema.ts`, or `scripts/codegen/src/lib/flatten.ts` and the most recent commit subject does not contain `audit: codegen-surface` (or a fresh `.claude/codegen-audit-ack` file).

## Why

Recent codegen PRs cycled through Copilot multiple times on the same four gap categories (schema-accepts/generator-drops, raw-string-as-identifier, inherited-type collisions, doc symmetry). The audit memory `project_codegen_surface_audit` already enumerates them — the gap is that it is not being invoked before push. The hook makes it impossible to forget.

## Test plan

- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test` green
- [x] Smoke: non-push command → exit 0
- [x] Smoke: push with no codegen files → exit 0
- [x] Smoke: push with codegen files, no ack → exit 2 with deny JSON
- [x] Smoke: ack via subject token → exit 0
- [x] Smoke: ack via `.claude/codegen-audit-ack` mtime → exit 0

## Out of scope

- Catching the gaps automatically (audit is still manual).
- CI / lefthook enforcement for direct human pushes — the hook only fires inside Claude Code.

Closes #853