### PR TITLE
docs(spec): record RFC-0007 ADRs

### DIFF
--- a/docs/ADR/0020-states-live-on-parts.md
+++ b/docs/ADR/0020-states-live-on-parts.md
@@ -1,0 +1,80 @@
+# ADR-0020 — States live on parts, not in a root machine block
+
+- **Status:** Accepted (2026-06-20). Implementation shipped in PR #872.
+
+## Decision
+
+A composite spec declares state machines per part. Each part may carry
+a `states:` map; the first declared state is initial; transitions take
+the shape `{ to, after, when, emits }` (string shorthand allowed when
+only `to` is set). No root `interactions:` block, no root `machine:`
+block, no separate state-graph file. The existing descriptive
+`states:` field on `componentNodeFields` (Button's `hover` / `focus` /
+`active` / `loading`) was renamed `visualStates:` to free the name for
+the state-machine block.
+
+Root-level fields removed: `interactions:`, `behavior:`, and the root
+`overlay:` field (overlay now lives on the part that is the floating
+element).
+
+## Why this and not the alternatives
+
+- **Not a separate root `machine:` block (Zag's shape).** Zag declares
+  states next to a `parts:` block joined by string-key matching. That
+  is the same cross-block scatter this ADR is fixing — the spec reader
+  still has to do the name-match in their head to see "the trigger
+  opens the content dialog and the content dismisses via outside /
+  escape / button." Adopting Zag's *concepts* (states, transitions,
+  emissions) is what makes specs readable; adopting its *config shape*
+  is not.
+- **Not lighter "wiring on parts, no state model"
+  (`onClick: toggle`).** Solves `modal.yaml`. Falls apart for
+  `tooltip.yaml` — the open/close delay pair with pointer-and-focus
+  companion events has no structural place, forcing per-component
+  ad-hoc fields. Defers the same conversation to the next stateful
+  component (Combobox, future Popover) instead of resolving it now.
+- **Not "leave the spec alone, fix the validator only."** The
+  spec-format complexity audit (`docs/research/spec-format-complexity-
+  audit.md`) deliberately scoped the validator duplication problem and
+  named the cross-block name-matching as out of scope. The author-side
+  pain — typos, missing companion rules, references at non-existent
+  parts — was what this RFC had to address.
+
+## Consequences
+
+- `componentPart` gains optional `states:` (record of state name →
+  `{ on: Record<source, transition> }`) and optional `overlay:` (the
+  block formerly at root). The root discriminated union loses
+  `interactions:`, `behavior:`, and `overlay:`.
+- The existing descriptive `states:` on `componentNodeFields` is
+  renamed `visualStates:`. Button's spec carries the one-line rename;
+  no other current spec used the field.
+- Every composite spec rewrites once. The four specs in tree at the
+  time (`modal`, `tooltip`, `pagination`, `tablist`) moved together in
+  PR #872; `pagination` and `tablist` carried no states, so the
+  rewrite was just removing the root `behavior:` line.
+- The validator rewrites alongside. Old rules policing the root
+  blocks (`checkInteractionRefs`, `checkOverlayEscapeRules`,
+  `checkInteractionEventVocabulary`) were deleted; the new
+  `checkStateMachines` walks the parts tree and resolves
+  `<part>.<event>` source prefixes, transitions, guards, and
+  `emits:`.
+- ADR-0009's root-only / part-only placement rules for `overlay:` and
+  `interactions:` are partially superseded. The schema-and-validation
+  decision itself stays; only the field-placement specifics flip.
+- A part's state-machine block coexists with its visual-state block.
+  A future composite can declare both — the state machine drives
+  behavior, the visual states drive CSS — without collision.
+
+## References
+
+- [RFC-0007](../RFC/0007-spec-structural-readability.md) — the design
+  pass; this ADR records the load-bearing structural decision.
+- [ADR-0009](0009-spec-schema-and-validation.md) — the existing
+  schema-and-validation ADR; partially superseded by the field
+  placement changes recorded here.
+- [ADR-0018](0018-events-block-surface.md) — the events surface this
+  RFC preserves unchanged; per-transition `emits:` reference the same
+  root `events:` block ADR-0018 introduced.
+- [#867](https://github.com/teseor/teseor/issues/867) — the RFC-0007
+  implementation issue, closed by PR #872.

--- a/docs/ADR/0021-event-source-prefix-syntax.md
+++ b/docs/ADR/0021-event-source-prefix-syntax.md
@@ -1,0 +1,87 @@
+# ADR-0021 — Event source prefix syntax for state transitions
+
+- **Status:** Accepted (2026-06-20). Implementation shipped in PR #872.
+
+## Decision
+
+A transition source key uses one of three prefix forms:
+
+| Form | Example | Resolves to |
+| --- | --- | --- |
+| `<part>.<dom-event>` | `trigger.click` | DOM event on the named part |
+| `key.<name>` | `key.escape` | Global keyboard key |
+| `outside.<dom-event>` | `outside.click` | DOM event outside the part's overlay |
+
+`<part>` is any part declared in the spec's parts tree (ADR-0024
+keeps the name unambiguous). `<dom-event>` and `<name>` resolve
+against closed vocabularies declared in `specs/_vocabulary.yaml`
+under new `dom_events:` and `keys:` blocks. Misspellings are
+rejected with Levenshtein suggestions, the same machinery
+ADR-0019 uses for event-verb names.
+
+Delays do not have a prefix. A timer is set via the transition's
+`after:` field, which names a same-part numeric prop; the
+state-machine runtime owns scheduling and cancellation.
+
+`outside.*` is permitted only when the part declares `overlay:`.
+Any other usage is rejected at validation time.
+
+## Why this and not the alternatives
+
+- **Not a flat list of `{ on, target, do }` rules (today's
+  `interactions:` block).** The flat rule list joins a target part
+  and an event name by independent string fields; misspelling either
+  produced a silently inactive rule. A prefix syntax binds the part
+  reference and the event name into one identifier that the validator
+  resolves as a single unit.
+- **Not unprefixed event names (`click`, `escape`).** Without a
+  prefix the reader cannot tell whether `click` means "click on the
+  part declaring this state," "click on the trigger sibling," or
+  "click anywhere outside the floating element." All three are common
+  in overlay specs; the prefix makes the intent self-describing.
+- **Not free-form event names (no vocabulary).** Open vocabularies
+  reintroduce the `tigger` / `focusIn` / `clik` typos that PR review
+  was catching in the old `interactions:` block. Closed vocabularies
+  with suggestion-on-miss have already proven themselves for event
+  verbs (ADR-0019); extending the pattern to DOM events and key names
+  is the same trade.
+- **Not a separate `timer:` source prefix.** A timer is not an
+  external event; it is a scheduling concern internal to the
+  transition. Putting it on a transition's `after:` field models it
+  as the modifier it is and keeps the source vocabulary tied to
+  things that originate outside the machine.
+
+## Consequences
+
+- `specs/_vocabulary.yaml` gains `dom_events:` and `keys:` blocks.
+  The verb-vocab `arrowLeft` / `arrowRight` collision with the
+  `logical-naming` lint is exempted at the lint-rule level
+  (`arrowLeft` is a hardware key name from `KeyboardEvent.key`,
+  not styling direction).
+- The validator gains rules for source-prefix resolution: part name
+  exists, DOM event in the registered vocabulary, key in the registered
+  vocabulary, `outside.*` only on overlay parts. All landed in
+  `checkStateMachines` (`scripts/codegen/src/semantic-checks.ts`),
+  replacing the deleted `checkInteractionEventVocabulary` rule.
+- Authors get suggestion-on-miss for every source: `clik` →
+  "did you mean click?", `key.scape` → "did you mean key.escape?"
+- The codegen runtime resolves `outside.*` through `useOverlay`'s
+  existing dismissable-layer wiring; `key.*` resolves through a
+  capture-phase document listener; `<part>.<event>` resolves through
+  the wrapper's React/Vue event-prop binding on the named part.
+- Future composite specs (Combobox, Popover, Menu) reuse the same
+  vocabulary without spec-format work. New DOM events or keys land
+  by extending `_vocabulary.yaml`, not by changing the schema.
+
+## References
+
+- [RFC-0007](../RFC/0007-spec-structural-readability.md) — the
+  design pass; section "Event-source prefix syntax" enumerates the
+  three forms.
+- [ADR-0019](0019-closed-vocabularies-for-events.md) — the closed-
+  vocabulary pattern this ADR extends to DOM events and keys.
+- [ADR-0020](0020-states-live-on-parts.md) — the host structure
+  these source prefixes appear inside.
+- [ADR-0024](0024-part-name-uniqueness.md) — the uniqueness
+  guarantee that lets `<part>.<event>` resolve without a fully
+  qualified path.

--- a/docs/ADR/0022-minimal-when-guard-grammar.md
+++ b/docs/ADR/0022-minimal-when-guard-grammar.md
@@ -1,0 +1,85 @@
+# ADR-0022 — Minimal `when:` guard grammar
+
+- **Status:** Accepted (2026-06-20). Implementation shipped in PR #872.
+
+## Decision
+
+A transition's `when:` field accepts one of two expression shapes:
+
+- `<part>.<boolean-prop>` — true when the named part declares the
+  boolean prop and that prop reads true at the active breakpoint.
+- `!<expression>` — negation of any supported expression.
+
+No `&&`, no `||`, no parens, no comparison operators, no arithmetic.
+The expression is parsed at validation time; resolution at runtime
+reads the responsive prop value through the same machinery
+`useOverlay` already uses for the controllable triple.
+
+`<part>` resolves against the parts tree per ADR-0024's uniqueness
+guarantee; `<boolean-prop>` must be declared `type: boolean` on the
+referenced part.
+
+When a real case appears that requires combinators or comparisons,
+a follow-up RFC extends the grammar deliberately. Until then, every
+guard the project has seen — modal and tooltip's `disabled` checks —
+fits inside `[!]<part>.<bool-prop>`.
+
+## Why this and not the alternatives
+
+- **Not a full expression language (Zag-style guards as JS
+  predicates).** Once `&&` and `||` land, parens follow, then
+  comparisons, then arithmetic, then function calls. The spec format
+  drifts from declarative-and-portable into general-purpose code.
+  Every guard in tree today is a single boolean prop check; the
+  minimal grammar covers every current and planned composite (Modal,
+  Tooltip, Popover, Combobox, Menu).
+- **Not hardcoding the `disabled` check (the pre-RFC state).**
+  Composite-overlay codegen carried an `Object.hasOwn(spec.props,
+  "disabled")` special case that read the prop's responsive value and
+  short-circuited transitions. The spec format had no place to declare
+  the guard, so the generator had to assume it. Surfacing the guard
+  as a first-class `when:` field removes the special case and lets
+  other props gate transitions the same way.
+- **Not a CEL-style boolean expression language.** CEL covers every
+  case but pulls in a parser, a typing layer, and a runtime
+  evaluator. Spec files become harder to audit; the validator's
+  resolution layer becomes a small interpreter. Speculative
+  complexity in service of zero current cases.
+- **Not "let authors drop in JS strings"** (`when: '!props.disabled'`
+  evaluated at runtime). Inline JS in YAML is unreviewable, untyped,
+  and silently divergent between framework outputs. Closed grammar
+  with structural resolution is the cost of the readability the rest
+  of the format buys.
+
+## Consequences
+
+- `tooltip.yaml` carries `when: '!trigger.disabled'` on the two
+  pointer/focus open transitions. The hardcoded special case in
+  `scripts/codegen/src/generators/gen-react/kinds/composite-overlay.ts`
+  is gone.
+- The validator gains a guard-expression parser inside
+  `checkStateMachines`. It rejects unknown grammar productions and
+  unresolved part / prop names with the same suggestion-on-miss
+  surface as the source-prefix vocabulary.
+- The codegen runtime reads the guard's referenced prop through the
+  responsive-prop accessor that already exists for the controllable
+  triple. No new runtime concept.
+- The grammar is intentionally small enough that a follow-up RFC can
+  extend it without breaking. Authors who hit a real case file an
+  issue with the spec that needs the operator; the operator lands
+  per documented case.
+- Project memory (`feedback_defensive_guards_specific`) reinforces
+  the same constraint: guards target the exact condition they mean
+  to block, never a broad symptom.
+
+## References
+
+- [RFC-0007](../RFC/0007-spec-structural-readability.md) — sections
+  "Transition shorthand" and "Adoption" enumerate the grammar.
+- [ADR-0020](0020-states-live-on-parts.md) — the host structure for
+  `when:`.
+- [ADR-0024](0024-part-name-uniqueness.md) — the resolution
+  guarantee for the `<part>` reference.
+- [#866](https://github.com/teseor/teseor/issues/866) — visual-state
+  vocabulary RFC; future visual-state guards will share this
+  grammar.

--- a/docs/ADR/0023-state-machine-runtime-in-primitives.md
+++ b/docs/ADR/0023-state-machine-runtime-in-primitives.md
@@ -1,0 +1,98 @@
+# ADR-0023 — State-machine runtime lives in `@teseor/primitives`
+
+- **Status:** Accepted (2026-06-20). Implementation shipped in PR #872.
+
+## Decision
+
+The runtime that drives a composite spec's per-part state machine
+lives in `@teseor/primitives` as `useStateMachine`. The package
+contains a framework-agnostic core
+(`packages/primitives/src/state-machine/index.ts`) plus two thin
+adapters: `packages/primitives/src/state-machine/react.ts` and
+`packages/primitives/src/state-machine/vue.ts`. Both adapters
+re-export from the top-level entry points
+`packages/primitives/src/react.ts` and
+`packages/primitives/src/vue.ts`.
+
+Side effects that are not state — focus trap, scroll lock, portal
+mount, dismissable layer — stay in their own primitives
+(`focus-trap`, `modality`, `portal`, `dismissable-layer`) and are
+wired by the wrapper based on declarative fields (`overlay.modal:
+true`, `a11y.role: dialog`). The state machine does not invoke them.
+
+No external state-machine library (Zag, XState, Robot) is adopted.
+Wrapper code and codegen templates do not import from any
+third-party machine runtime.
+
+## Why this and not the alternatives
+
+- **Not Zag.js.** Spiked against `<Modal>` on a throwaway branch
+  during the RFC-0007 cycle (handover § "Zag spike closed without
+  adopting"). Bundle was acceptable (17 KB gz alone, 30 KB with a
+  second machine, 40 KB with three). The decision is taste and
+  architecture, not size: importing `@zag-js/dialog` into wrapper
+  source conflates Teseor with its upstream library, breaks the YAML
+  spec's portability guarantee (the runtime under the spec must be
+  ours for the spec to mean anything outside this codebase), and
+  forces every future machine to be expressible in Zag's vocabulary.
+- **Not XState.** The full statechart machinery (parallel states,
+  history, invoked services, actions, guards-as-functions) is a
+  superset of every case Teseor specs need. Adopting it imports a
+  modeling surface authors do not use, costs bundle for features
+  unused, and ties the spec format to XState's config shape.
+- **Not in `@teseor/contracts`.** Contracts is the type-only
+  generated package; runtime code there breaks the "contracts is
+  a zero-runtime import" guarantee that the contracts package
+  exists to provide.
+- **Not in each framework wrapper package independently.** Two
+  copies of the same ~150 LOC drift; the validator and the runtime
+  carry the same vocabulary, and the runtime is small enough that
+  a shared core costs less than the drift would.
+- **Not "leave the legacy `useOverlay` interactions runtime in
+  place."** The existing flat-rules runtime — `OverlayInteraction[]`
+  with `{ on, do, delay, when }` — was a two-state shape with the
+  `disabled` guard hardcoded. It worked for Modal and Tooltip and
+  nothing else. The state-machine runtime is the generalization
+  every future stateful composite (Combobox, Menu, Popover, Disclosure
+  variants) needs.
+
+## Consequences
+
+- `packages/primitives/src/state-machine/` ships three TypeScript
+  files (core + React + Vue) plus runtime tests. The core is around
+  150 lines; the adapters are around 50 each. The package exports
+  `useStateMachine` and `UseStateMachineResult` from both
+  framework entry points.
+- The transition shape is `{ to, after, when, emits }` with the
+  spec-level `<part>.<event>` source resolved at codegen time into a
+  `sourceKey` the runtime dispatches against. Authors do not
+  hand-write state-machine config; codegen emits it from the spec's
+  `states:` block.
+- The runtime handles `after:` delays via `setTimeout`; transitions
+  that fire from a competing source key cancel the pending timer.
+  No entry/exit actions, no nested machines, no parallel states.
+- `useOverlay` continues to host focus trap, scroll lock, portal
+  mount, and dismissable layer for parts with `overlay.modal: true`.
+  Its open/close state ownership in the legacy interactions runtime
+  is the open architectural question tracked in handover § "useOverlay
+  vs useStateMachine ownership" — not resolved by this ADR.
+- Consumers cannot swap in a third-party machine. That is the trade
+  for portability: a YAML spec from this project compiles against a
+  known runtime; the runtime travels with the wrapper packages.
+- Project memory (`feedback_no_external_runtime_deps`) is the
+  durable form of this constraint and applies to every future
+  runtime decision in the same family.
+
+## References
+
+- [RFC-0007](../RFC/0007-spec-structural-readability.md) — sections
+  "Generator implications" and "Adoption" describe the runtime.
+- [ADR-0011](0011-css-anchor-positioning-for-overlays.md) — the
+  overlay positioning primitive; the state machine does not own
+  positioning.
+- [ADR-0013](0013-overlay-modality.md) — `overlay.modal: true`
+  drives the focus-trap / scroll-lock cascade outside the state
+  machine.
+- [#871](https://github.com/teseor/teseor/issues/871) — the Zag
+  spike issue; closed without adopting, with bundle measurements
+  archived in `.local/spike-zag-bundle/`.

--- a/docs/ADR/0023-state-machine-runtime-in-primitives.md
+++ b/docs/ADR/0023-state-machine-runtime-in-primitives.md
@@ -94,5 +94,5 @@ third-party machine runtime.
   drives the focus-trap / scroll-lock cascade outside the state
   machine.
 - [#871](https://github.com/teseor/teseor/issues/871) — the Zag
-  spike issue; closed without adopting, with bundle measurements
-  archived in `.local/spike-zag-bundle/`.
+  spike issue; closed without adopting. Bundle measurements
+  recorded in the issue thread.

--- a/docs/ADR/0024-part-name-uniqueness.md
+++ b/docs/ADR/0024-part-name-uniqueness.md
@@ -1,0 +1,73 @@
+# ADR-0024 — Part names are unique across the parts tree
+
+- **Status:** Accepted (2026-06-20). Implementation shipped in PR #872.
+
+## Decision
+
+Within a single spec, every part name in the parts tree must be
+unique. Two parts with the same name — whether siblings, nested
+under different ancestors, or at different depths — are rejected by
+the validator with the full set of declaration paths in the error
+message. The rule applies recursively through any depth of
+`parts.X.parts.Y.parts.Z`.
+
+The uniqueness lets `<part>.<event>` source-prefix references
+(ADR-0021) and `<part>.<bool-prop>` guard references (ADR-0022)
+resolve through a single flat lookup, with no need for
+fully-qualified dotted paths.
+
+## Why this and not the alternatives
+
+- **Not fully-qualified path syntax**
+  (`<ancestor>.<part>.<event>`). Verbose for the common case (every
+  current and planned spec has a flat-enough tree that ambiguity
+  never arises) and brittle on rename (renaming an ancestor breaks
+  every transition source under it). Uniqueness costs the spec
+  author one rename decision per collision; qualified paths cost
+  every source reference everywhere.
+- **Not scoping resolution to the part declaring the transition.**
+  Modal's `content.states.open.on['trigger.click']` already needs to
+  reach the sibling `trigger` part; scoping to "self only" forbids
+  the common case the source-prefix syntax exists to express.
+- **Not "ambiguous names resolve to the closest part."** Subtle
+  scoping rules surprise authors and reviewers; a reader cannot tell
+  which `trigger` a source references without walking the parts
+  tree. Uniqueness is the cheap, mechanical alternative.
+- **Not "warn on duplicates, accept the spec."** Warnings are
+  ignored; the resolution ambiguity then surfaces as a runtime
+  surprise (the wrong part responds to the event). Rejecting at
+  validation time forces the author to pick a name before the
+  ambiguity ships.
+
+## Consequences
+
+- `checkStateMachines` walks the parts tree once at the start of
+  validation, accumulates a `partNameOccurrences` map keyed by name
+  with the full declaration paths as values, and rejects any name
+  that appears more than once. The error message lists every path
+  so the author can see both sites without a second validator run.
+- Authors rename one of the collisions when adding a new nested
+  part. The naming convention `parts.X.parts.Y` is shallow enough
+  in current specs (Modal has two top-level parts, Tooltip two,
+  Pagination one, Tablist one nested layer) that collisions are
+  rare in practice. Future deeper trees (DataTable's
+  `table.body.row.cell` plus `table.header.row.cell`) need
+  distinct names per row depth (`bodyRow` / `headerRow`).
+- The rule is independent of the file format. A future migration to
+  a different config shape (TOML, JSON, generated from TS) preserves
+  the constraint as long as it preserves the parts tree.
+- The rule does not apply across specs. Two specs can both declare a
+  `trigger` part; `<part>.<event>` is resolved per spec, not
+  globally.
+
+## References
+
+- [RFC-0007](../RFC/0007-spec-structural-readability.md) — sections
+  "Event-source prefix syntax" and "Validator additions" cite the
+  uniqueness rule.
+- [ADR-0021](0021-event-source-prefix-syntax.md) — the source-prefix
+  syntax that relies on this guarantee.
+- [ADR-0022](0022-minimal-when-guard-grammar.md) — the guard
+  grammar that relies on the same guarantee.
+- [ADR-0020](0020-states-live-on-parts.md) — the host structure for
+  the parts tree this rule walks.

--- a/docs/ADR/README.md
+++ b/docs/ADR/README.md
@@ -27,6 +27,11 @@ a numbered, durable file.
 | [0017](0017-strict-token-interface-boundary.md) | Strict token-interface boundary | Accepted |
 | [0018](0018-events-block-surface.md) | Events block: scope, consumer surface, docs section split | Proposed |
 | [0019](0019-closed-vocabularies-for-events.md) | Closed vocabularies for event names and payload types | Proposed |
+| [0020](0020-states-live-on-parts.md) | States live on parts, not in a root machine block | Accepted |
+| [0021](0021-event-source-prefix-syntax.md) | Event source prefix syntax for state transitions | Accepted |
+| [0022](0022-minimal-when-guard-grammar.md) | Minimal `when:` guard grammar | Accepted |
+| [0023](0023-state-machine-runtime-in-primitives.md) | State-machine runtime lives in `@teseor/primitives` | Accepted |
+| [0024](0024-part-name-uniqueness.md) | Part names are unique across the parts tree | Accepted |
 
 ## When to write one
 


### PR DESCRIPTION
## What

Five Accepted ADRs covering the load-bearing decisions of RFC-0007.

- ADR-0020 — States live on parts, not in a root machine block.
- ADR-0021 — Event-source prefix syntax (`<part>.<event>`, `key.<name>`, `outside.<event>`) with closed DOM-event / key vocabularies.
- ADR-0022 — Minimal `when:` guard grammar (`[!]<part>.<bool-prop>` only).
- ADR-0023 — `useStateMachine` runtime in `@teseor/primitives` (framework-agnostic core, thin React + Vue adapters; no third-party machine library).
- ADR-0024 — Part names unique across the parts tree.

`docs/ADR/README.md` index updated.

## Why

PR #872 shipped the RFC-0007 implementation. Per ADR-0005 + project memory `project_adr_status_proposed_until_impl`, the load-bearing decisions in the RFC land as Accepted ADRs once the implementation merges.

## Test plan

- [x] `pnpm lint` green (markdown + doc-paths).
- [x] `pnpm typecheck` green.

## Out of scope

- RFC-0006-derived ADRs (per-event consumer surface, docs four-section split, event-name vocabulary, structured payload typing). Tracked separately.
- ADR-0009 supersession sweep — handled when the supersession scope is clear.

Closes #874