### PR TITLE
refactor(css): collapse Button intent slots to --_accent

### DIFF
--- a/.changeset/806-button-accent.md
+++ b/.changeset/806-button-accent.md
@@ -1,0 +1,5 @@
+---
+"@teseor/css": patch
+---
+
+Collapse Button per-intent slot pairs to a single `--_accent` per intent with foreground derived inline via the RFC-0004 phase-4 OKLCH threshold formula. Output colors are identical; intent slot count drops from 12 to 6; adding a new intent now costs one slot declaration and one selector line. Bundle drops 8.92→7.36 KB raw (1.83→1.69 KB gz).

--- a/apps/docs/src/pages/components/button.astro
+++ b/apps/docs/src/pages/components/button.astro
@@ -175,28 +175,6 @@ import Base from "../../layouts/Base.astro";
       oklch(from oklch(58% 0.2 268deg) 50% c 210deg),
       oklch(from oklch(58% 0.2 268deg) 50% c h) calc(0 * 100%)
     )</Code></td><td><Code>ButtonText</Code></td></tr>
-        <tr><td><Code>--t-on-accent</Code></td><td><Code>oklch(from oklch(from oklch(58% 0.2 268deg) 55% c h) max(0, sign(0.62 - l)) 0 h)</Code></td><td><Code>ButtonFace</Code></td></tr>
-        <tr><td><Code>--t-on-danger</Code></td><td><Code>oklch(from color-mix(
-      in oklch,
-      oklch(from oklch(58% 0.2 268deg) 48% c 25deg),
-      oklch(from oklch(58% 0.2 268deg) 48% c h) calc(0 * 100%)
-    ) max(0, sign(0.62 - l)) 0 h)</Code></td><td><Code>ButtonFace</Code></td></tr>
-        <tr><td><Code>--t-on-info</Code></td><td><Code>oklch(from color-mix(
-      in oklch,
-      oklch(from oklch(58% 0.2 268deg) 50% c 210deg),
-      oklch(from oklch(58% 0.2 268deg) 50% c h) calc(0 * 100%)
-    ) max(0, sign(0.62 - l)) 0 h)</Code></td><td><Code>ButtonFace</Code></td></tr>
-        <tr><td><Code>--t-on-success</Code></td><td><Code>oklch(from color-mix(
-      in oklch,
-      oklch(from oklch(58% 0.2 268deg) 52% c 155deg),
-      oklch(from oklch(58% 0.2 268deg) 52% c h) calc(0 * 100%)
-    ) max(0, sign(0.62 - l)) 0 h)</Code></td><td><Code>ButtonFace</Code></td></tr>
-        <tr><td><Code>--t-on-surface</Code></td><td><Code>oklch(from oklch(from oklch(58% 0.2 268deg) 50% calc(c * 0.025) h) 18% c h)</Code></td><td><Code>CanvasText</Code></td></tr>
-        <tr><td><Code>--t-on-warning</Code></td><td><Code>oklch(from color-mix(
-      in oklch,
-      oklch(from oklch(58% 0.2 268deg) 80% c 85deg),
-      oklch(from oklch(58% 0.2 268deg) 80% c h) calc(0 * 100%)
-    ) max(0, sign(0.62 - l)) 0 h)</Code></td><td><Code>ButtonFace</Code></td></tr>
         <tr><td><Code>--t-success</Code></td><td><Code>color-mix(
       in oklch,
       oklch(from oklch(58% 0.2 268deg) 52% c 155deg),
@@ -223,7 +201,7 @@ import Base from "../../layouts/Base.astro";
       <table>
         <thead><tr><th>Artifact</th><th>Raw</th><th>Gzip</th><th>Brotli</th></tr></thead>
         <tbody>
-        <tr><td><a href="https://github.com/teseor/teseor/blob/main/packages/css/src/components/button/button.css"><Code>@teseor/css/components/button.css</Code></a></td><td>8.92 KB</td><td>1.83 KB</td><td>1.54 KB</td></tr>
+        <tr><td><a href="https://github.com/teseor/teseor/blob/main/packages/css/src/components/button/button.css"><Code>@teseor/css/components/button.css</Code></a></td><td>7.36 KB</td><td>1.69 KB</td><td>1.43 KB</td></tr>
         </tbody>
       </table>
     </section>

--- a/packages/css/postcss-teseor-floor.test.ts
+++ b/packages/css/postcss-teseor-floor.test.ts
@@ -140,8 +140,8 @@ describe("teseorFloor — forced-colors synthesis", () => {
   test("emits one nested forced-colors block at the component root", () => {
     const out = floorWithFC(`
       .t-button {
-        --_fill: var(--t-accent);
-        &:where([data-intent="primary"]) { --_fill: var(--t-accent); }
+        --_accent: var(--t-accent);
+        &:where([data-intent="primary"]) { --_accent: var(--t-accent); }
         &:focus-visible { outline: 2px solid var(--t-focus-ring); }
       }
     `);
@@ -150,14 +150,14 @@ describe("teseorFloor — forced-colors synthesis", () => {
   });
 
   test("pairs the synthesised block with forced-color-adjust: none", () => {
-    const out = floorWithFC(".t-x { --_fill: var(--t-accent); }");
+    const out = floorWithFC(".t-x { --_accent: var(--t-accent); }");
     expect(out).toMatch(/@media \(forced-colors: active\)\s*{\s*forced-color-adjust:\s*none/);
   });
 
   test("re-declares the upstream semantic token, not the component-private", () => {
-    const out = floorWithFC(".t-x { --_fill: var(--t-accent); }");
+    const out = floorWithFC(".t-x { --_accent: var(--t-accent); }");
     expect(out).toContain("--t-accent: ButtonText");
-    expect(out).not.toContain("--_fill: var(--t-accent, ButtonText)");
+    expect(out).not.toContain("--_accent: var(--t-accent, ButtonText)");
   });
 
   test("includes every differing token the file references", () => {
@@ -202,10 +202,10 @@ describe("teseorFloor — forced-colors synthesis", () => {
   test("targets the first rule in the file, even when wrapped in @layer", () => {
     const out = floorWithFC(`
       @layer components.tokens {
-        .t-button { --_fill: var(--t-accent); }
+        .t-button { --_accent: var(--t-accent); }
       }
       @layer components.styles {
-        .t-button { color: var(--_fill); }
+        .t-button { color: var(--_accent); }
       }
     `);
     const tokensLayer = out.split("@layer components.styles")[0];

--- a/packages/css/src/components/button/button.css
+++ b/packages/css/src/components/button/button.css
@@ -6,10 +6,9 @@
     --_radius: var(--t-button-radius, var(--t-radius-md));
     --_dur: var(--t-button-dur, var(--t-dur-fast));
     --_ease: var(--t-button-ease, var(--t-ease-out));
-    --_fill: var(--t-button-bg, var(--t-accent));
-    --_on-fill: var(--t-button-fg, var(--t-on-accent));
-    --_bg: var(--_fill);
-    --_fg: var(--_on-fill);
+    --_accent: var(--t-button-bg, var(--t-accent));
+    --_bg: var(--_accent);
+    --_fg: var(--t-button-fg, oklch(from var(--_accent) max(0, sign(0.62 - l)) 0 h));
     --_shadow: none;
     --_font-size: inherit;
     --_text-decoration: none;
@@ -29,18 +28,12 @@
     --_h-lg: var(--t-row-4);
     --_pad-x-lg: var(--t-space-5);
     --_font-size-lg: var(--t-text-lg);
-    --_intent-primary-fill: var(--t-accent);
-    --_intent-primary-on-fill: var(--t-on-accent);
-    --_intent-neutral-fill: var(--t-surface);
-    --_intent-neutral-on-fill: var(--t-on-surface);
-    --_intent-success-fill: var(--t-success);
-    --_intent-success-on-fill: var(--t-on-success);
-    --_intent-warning-fill: var(--t-warning);
-    --_intent-warning-on-fill: var(--t-on-warning);
-    --_intent-danger-fill: var(--t-danger);
-    --_intent-danger-on-fill: var(--t-on-danger);
-    --_intent-info-fill: var(--t-info);
-    --_intent-info-on-fill: var(--t-on-info);
+    --_intent-primary-accent: var(--t-accent);
+    --_intent-neutral-accent: var(--t-surface);
+    --_intent-success-accent: var(--t-success);
+    --_intent-warning-accent: var(--t-warning);
+    --_intent-danger-accent: var(--t-danger);
+    --_intent-info-accent: var(--t-info);
   }
 }
 
@@ -110,51 +103,45 @@
     }
 
     &:where([data-intent="primary"]) {
-      --_fill: var(--_intent-primary-fill);
-      --_on-fill: var(--_intent-primary-on-fill);
+      --_accent: var(--_intent-primary-accent);
     }
 
     &:where([data-intent="neutral"]) {
-      --_fill: var(--_intent-neutral-fill);
-      --_on-fill: var(--_intent-neutral-on-fill);
+      --_accent: var(--_intent-neutral-accent);
     }
 
     &:where([data-intent="success"]) {
-      --_fill: var(--_intent-success-fill);
-      --_on-fill: var(--_intent-success-on-fill);
+      --_accent: var(--_intent-success-accent);
     }
 
     &:where([data-intent="warning"]) {
-      --_fill: var(--_intent-warning-fill);
-      --_on-fill: var(--_intent-warning-on-fill);
+      --_accent: var(--_intent-warning-accent);
     }
 
     &:where([data-intent="danger"]) {
-      --_fill: var(--_intent-danger-fill);
-      --_on-fill: var(--_intent-danger-on-fill);
+      --_accent: var(--_intent-danger-accent);
     }
 
     &:where([data-intent="info"]) {
-      --_fill: var(--_intent-info-fill);
-      --_on-fill: var(--_intent-info-on-fill);
+      --_accent: var(--_intent-info-accent);
     }
 
     &:where([data-variant="outline"]) {
       --_bg: transparent;
-      --_fg: var(--_fill);
+      --_fg: var(--_accent);
       --_shadow: inset 0 0 0 1px currentcolor;
     }
 
     &:where([data-variant="ghost"]) {
       --_bg: transparent;
-      --_fg: var(--_fill);
+      --_fg: var(--_accent);
     }
 
     &:where([data-variant="link"]) {
       --_h: auto;
       --_pad-x: 0;
       --_bg: transparent;
-      --_fg: var(--_fill);
+      --_fg: var(--_accent);
       --_text-decoration: underline;
       --_text-underline-offset: 0.2em;
     }
@@ -182,11 +169,11 @@
     }
 
     &:where(:hover):not([disabled], [aria-disabled="true"]) {
-      --_bg: color-mix(in oklch, var(--_fill) 92%, black);
+      --_bg: color-mix(in oklch, var(--_accent) 92%, black);
     }
 
     &:where(:active):not([disabled], [aria-disabled="true"]) {
-      --_bg: color-mix(in oklch, var(--_fill) 84%, black);
+      --_bg: color-mix(in oklch, var(--_accent) 84%, black);
       --_transform: translateY(1px);
     }
 
@@ -204,7 +191,7 @@
       [data-variant="outline"],
       [data-variant="ghost"]
     ):hover:not([disabled], [aria-disabled="true"]) {
-      --_bg: color-mix(in oklch, var(--_fill) 12%, transparent);
+      --_bg: color-mix(in oklch, var(--_accent) 12%, transparent);
     }
 
     &:where([data-variant="link"]):hover:not([disabled], [aria-disabled="true"]) {

--- a/specs/button.yaml
+++ b/specs/button.yaml
@@ -145,8 +145,7 @@ privateTokens:
   - --_radius
   - --_dur
   - --_ease
-  - --_fill
-  - --_on-fill
+  - --_accent
   - --_bg
   - --_fg
   - --_shadow
@@ -168,18 +167,12 @@ privateTokens:
   - --_h-lg
   - --_pad-x-lg
   - --_font-size-lg
-  - --_intent-primary-fill
-  - --_intent-primary-on-fill
-  - --_intent-neutral-fill
-  - --_intent-neutral-on-fill
-  - --_intent-success-fill
-  - --_intent-success-on-fill
-  - --_intent-warning-fill
-  - --_intent-warning-on-fill
-  - --_intent-danger-fill
-  - --_intent-danger-on-fill
-  - --_intent-info-fill
-  - --_intent-info-on-fill
+  - --_intent-primary-accent
+  - --_intent-neutral-accent
+  - --_intent-success-accent
+  - --_intent-warning-accent
+  - --_intent-danger-accent
+  - --_intent-info-accent
 
 a11y:
   role: button


### PR DESCRIPTION
## What

Collapses Button's per-intent slot pairs to a single `--_accent` per intent. Foreground is derived inline from `--_accent` via the OKLCH threshold formula from RFC-0004 phase 4 (pure white when `L < 0.62`, pure black otherwise).

- Intent slot count: 12 → 6 (drops the per-intent `--_*-on-fill` block).
- Adding a new intent now costs one slot declaration + one selector line.
- Consumer `--t-button-bg` / `--t-button-fg` overrides still win at the cascade root.
- Resulting fg colors are identical to before for every intent: the inline formula matches the `--t-on-X` derivation in RFC-0004 phase 4.

## Why

The per-intent `--_intent-X-fill` + `--_intent-X-on-fill` pair was 12 declarations and 12 selector lines for 6 intents. Per Button being the only intent-driven component today, the slot duplication generalizes — Tag, Input, IconButton will hit the same pattern. Collapse + computed fg make the per-component intent footprint a single slot.

Closes #806.

## Test plan

- [x] `pnpm lint` — `component-css: clean`, `spec: clean`, `contract-snapshots: clean`.
- [x] `pnpm typecheck` — clean.
- [x] `pnpm test` — 1166/1166 pass.
- [x] `pnpm gen` — docs regenerates with bundle size 8.92 → 7.36 KB raw, 1.83 → 1.69 KB gz, 1.54 → 1.43 KB brotli; `--t-on-X` rows drop from the inferred-tokens table (Button no longer references them).
- [x] Public consumer-observable colors per intent verified identical (the inline OKLCH formula on `--_accent` evaluates to the same color as the corresponding `--t-on-X` token, since both apply the same threshold to the same lightness).

## Out of scope

- Same collapse for Tag / Input / IconButton — each its own issue once the shape settles here.
- Visual-state vocabulary (#866) — separate parking lot.