### PR TITLE
feat(token): register --t-unit via @property

### DIFF
--- a/.changeset/817-property-t-unit.md
+++ b/.changeset/817-property-t-unit.md
@@ -1,0 +1,5 @@
+---
+"@teseor/css": minor
+---
+
+Register `--t-unit` via `@property` (`<length>` syntax, inherits, initial-value `0.25rem`). Non-length overrides now fall back to the initial value instead of corrupting every derived token, and `transition: --t-unit ...` becomes meaningful so density toggles can animate spacing and sizing in lockstep.

--- a/docs/RFC/0003-tokens-v4-unit-derived.md
+++ b/docs/RFC/0003-tokens-v4-unit-derived.md
@@ -256,7 +256,6 @@ All three phases become the default immediately. There is no "opt out of unit-de
 - **Compact density value.** Picked `0.21875rem` (3.5px) for symmetry with comfortable's `0.28125rem` (4.5px). Either could be `0.1875rem` (3px) / `0.3125rem` (5px) for 25% steps. Reviewer preference.
 - **Leading carve-out scope for `text-box-trim`.** Default applied to `p, li, dd, blockquote`. Headings have their own visual story (`text-wrap: balance`); applying `text-box-trim` to them might over-tighten the leading visually. Decide during Phase 2 implementation against visual snapshots.
 - **`--t-text-base` linkage to `--t-unit`.** Currently `--t-text-base: calc(var(--t-unit) * 4)` — so font scales with unit. Some consumers may prefer text-size to stay fixed when only spacing rescales. Decided yes for now (consistent single-knob), but worth revisiting if real-world feedback diverges.
-- **`@property` adoption for `--t-unit`.** Would type the knob, validate, enable animation. Not blocking this RFC; file as follow-up.
 - **Runtime audit attachment point.** Legacy ran against docs dev server. v3 should run against `docs-prod` build (already present in CI). Detail for the follow-up issue.
 
 ## What this doesn't propose

--- a/packages/css/src/tokens.css
+++ b/packages/css/src/tokens.css
@@ -1,6 +1,12 @@
 /* Teseor tokens — Tier 1 scale + Tier 2 semantic aliases. */
 
 @layer tokens.scale {
+  @property --t-unit {
+    syntax: "<length>";
+    inherits: true;
+    initial-value: 0.25rem;
+  }
+
   :root {
     /* ===== Colors — oklch; seed-derived cascade (Baseline 2025). ===== */
     --t-seed: oklch(58% 0.2 268deg);


### PR DESCRIPTION
## What

Adds a single `@property` registration for `--t-unit` at the top of `@layer tokens.scale` in `packages/css/src/tokens.css`:

```css
@property --t-unit {
  syntax: "<length>";
  inherits: true;
  initial-value: 0.25rem;
}
```

Also drops the now-resolved `@property` line from RFC-0003's "Unresolved questions" section.

## Why

`--t-unit` is the sole knob the spatial token system rotates around. Without `@property`:

- A consumer override of `--t-unit: red` silently corrupts every derived spacing / row-height / radius / text-size token, with no diagnostic.
- The knob is non-animatable, so density toggles (`[data-density="compact"]` etc.) snap instead of transitioning.
- Editors with `@property`-aware introspection see an untyped custom property.

With `@property`:

- Non-`<length>` overrides are rejected by the browser and fall back to the `initial-value` (`0.25rem`).
- `transition: --t-unit 200ms` becomes meaningful — spacing / leading / row heights can animate in lockstep when density flips.
- IDE / linter ecosystems can show the consumer a valid type.

`@property` is Baseline 2024. Safe to ship.

Closes #817.

## Test plan

- [x] `pnpm lint` — clean.
- [x] `pnpm typecheck` — clean.
- [x] `pnpm test` — 1166/1166 pass.
- [x] `pnpm gen` — no drift.
- [x] Existing density overrides (`[data-density="compact"]` and `comfortable` in `tokens.css`) verified compatible: both resolve to `<length>` via `calc(var(--t-unit) * <number>)`.

## Out of scope

- Registering every `--t-*` token. The unit is the entry point; derived tokens inherit the type guard transitively via `calc()`.
- The UX call about whether density toggles should actually animate — separate exploration; this PR only unblocks it.