### PR TITLE
feat(docs): dev-mode grid overlay for vertical-rhythm checks

### DIFF
--- a/.changeset/807-docs-grid-overlay.md
+++ b/.changeset/807-docs-grid-overlay.md
@@ -1,0 +1,4 @@
+---
+---
+
+Add a dev-only grid overlay to the docs app for verifying vertical rhythm by eye. Toggle button in the sidenav + `?grid=on` URL persistence; renders a `--t-unit`-stepped horizontal gradient over the page. Gated on `import.meta.env.DEV` so the production build is unaffected.

--- a/apps/docs/src/layouts/Base.astro
+++ b/apps/docs/src/layouts/Base.astro
@@ -17,6 +17,7 @@ const navItems = [
 ];
 
 const currentPath = Astro.url.pathname.replace(/\/$/, "") || "/";
+const isDev = import.meta.env.DEV;
 ---
 
 <!doctype html>
@@ -116,6 +117,47 @@ const currentPath = Astro.url.pathname.replace(/\/$/, "") || "/";
       .content h1 {
         margin-block-start: 0;
       }
+
+      .grid-overlay {
+        position: fixed;
+        inset: 0;
+        z-index: 9999;
+        display: none;
+        pointer-events: none;
+        background-image: repeating-linear-gradient(
+          to bottom,
+          transparent 0,
+          transparent calc(var(--t-unit) - 1px),
+          color-mix(in oklch, var(--t-neutral-70) 35%, transparent) calc(var(--t-unit) - 1px),
+          color-mix(in oklch, var(--t-neutral-70) 35%, transparent) var(--t-unit)
+        );
+      }
+
+      body.grid-on .grid-overlay {
+        display: block;
+      }
+
+      .grid-toggle {
+        margin-block-start: var(--t-space-4);
+        padding: var(--t-space-2) var(--t-space-3);
+        border: 1px solid var(--t-neutral-30);
+        border-radius: var(--t-radius-sm);
+        background: transparent;
+        color: var(--t-neutral-70);
+        font: inherit;
+        font-size: 0.75rem;
+        cursor: pointer;
+      }
+
+      .grid-toggle:hover {
+        background: var(--t-neutral-20);
+      }
+
+      body.grid-on .grid-toggle {
+        background: var(--t-neutral-90);
+        color: var(--t-neutral-10);
+        border-color: var(--t-neutral-90);
+      }
     </style>
   </head>
   <body>
@@ -137,10 +179,53 @@ const currentPath = Astro.url.pathname.replace(/\/$/, "") || "/";
             })
           }
         </ul>
+        {
+          isDev && (
+            <button class="grid-toggle" data-grid-toggle type="button" aria-pressed="false">
+              Grid overlay
+            </button>
+          )
+        }
       </aside>
       <div class="content">
         <slot />
       </div>
+      {isDev && <div class="grid-overlay" aria-hidden="true" />}
     </div>
+    <script>
+      if (import.meta.env.DEV) {
+        const apply = () => {
+          const params = new URLSearchParams(window.location.search);
+          const on = params.get("grid") === "on";
+          document.body.classList.toggle("grid-on", on);
+          const btn = document.querySelector<HTMLButtonElement>("[data-grid-toggle]");
+          if (btn) btn.setAttribute("aria-pressed", on ? "true" : "false");
+        };
+        const attach = () => {
+          const btn = document.querySelector<HTMLButtonElement>("[data-grid-toggle]");
+          if (!btn || btn.dataset.bound) return;
+          btn.dataset.bound = "1";
+          btn.addEventListener("click", () => {
+            const params = new URLSearchParams(window.location.search);
+            const next = params.get("grid") === "on" ? null : "on";
+            if (next) params.set("grid", next);
+            else params.delete("grid");
+            const qs = params.toString();
+            window.history.replaceState(
+              null,
+              "",
+              window.location.pathname + (qs ? "?" + qs : "") + window.location.hash,
+            );
+            apply();
+          });
+        };
+        apply();
+        attach();
+        document.addEventListener("astro:page-load", () => {
+          apply();
+          attach();
+        });
+      }
+    </script>
   </body>
 </html>


### PR DESCRIPTION
## What

Adds a dev-only grid overlay to the docs app for verifying vertical rhythm by eye:

- New CSS for `.grid-overlay` in `apps/docs/src/layouts/Base.astro`: fixed-position, `pointer-events: none`, `z-index: 9999`, `repeating-linear-gradient` with a 1px line every `--t-unit` (semi-transparent neutral-70 via `color-mix`).
- "Grid overlay" toggle button at the bottom of the sidenav. `aria-pressed` reflects the active state.
- Inline script reads `?grid=on` from the URL on initial load and on `astro:page-load` (SPA transitions). The toggle click flips both the body class and the URL via `history.replaceState`.
- Everything is gated on `import.meta.env.DEV` — the button, the overlay div, and the script body all dead-code-eliminate in production.

## Why

RFC-0003 / tokens-v4 lands "everything on the grid" as a goal. Without a visual checker, drift is invisible until someone audits manually. Legacy v2 had this; v3 didn't. Filed as #807 to keep the gap visible.

Closes #807.

## Test plan

- [x] `pnpm lint` — clean.
- [x] `pnpm typecheck` — clean.
- [x] `pnpm test` — 1166/1166 pass.
- [x] `pnpm astro check` from `apps/docs` — the one error (`Cannot find type for @teseor/css side-effect import`) is pre-existing on main; confirmed by stash + recheck.
- [ ] **Browser spot-check needed** — I cannot drive `pnpm dev` to verify the toggle / overlay visually. Reviewer to spot-check: toggle appears in the sidenav, click toggles the overlay, `?grid=on` in a fresh URL activates it.

## Out of scope

- Production-build availability — explicitly dev-only per the issue.
- Per-element rhythm inspector / measurement tooltip — separate follow-up.
- Major / minor gridline weighting — single 1px line per unit is enough to verify rhythm.