### PR TITLE
feat(css): opt-in prefers-contrast preset

### DIFF
--- a/.changeset/787-prefers-contrast.md
+++ b/.changeset/787-prefers-contrast.md
@@ -1,0 +1,5 @@
+---
+"@teseor/css": minor
+---
+
+Add opt-in `@teseor/css/prefers-contrast.css` preset. Consumers who import the file get a `@media (prefers-contrast: more)` branch that re-aliases `--t-fg`, `--t-border`, `--t-border-strong`, `--t-focus-ring`, and `--t-accent` to denser steps on the existing scale. Default `teseor.css` is unchanged.

--- a/docs/ADR/0003-postcss-build-step.md
+++ b/docs/ADR/0003-postcss-build-step.md
@@ -73,6 +73,12 @@ Custom-property inheritance propagates those system-color values to every `var()
 
 Components never hand-write `@media (forced-colors: active)` blocks for color overrides — the plugin synthesizes them from the token contract. Components may still hand-write forced-colors blocks for *non-color* concerns (e.g. `outline-width`, `forced-color-adjust: none`) where the rule isn't expressible through token literals.
 
+## Preference branches beyond forced-colors
+
+Forced-colors is the only preference branch the plugin synthesizes. Other preference-driven branches (`prefers-contrast: more`, `prefers-color-scheme: dark`, `prefers-reduced-transparency: reduce`, …) ship as standalone opt-in CSS files under the `@teseor/css/<preference>.css` convention, following the #773 preset family pattern. Each preset declares its branch at `:root` inside `@layer tokens.semantic`; cascade propagates the override to every component, full-bundle or standalone per-component, without per-component synthesis.
+
+The plugin stays single-branch. Adding a preference does not change `tokens.css`, `teseor.css`, or any per-component bundle; it adds one input file and one output file. Default `pnpm build:css` is byte-identical to the same build before the preset was introduced.
+
 ## Why not SCSS
 
 - SCSS is a whole language with its own syntax (`#{...}`, `@use as`, `@mixin`, `%placeholder`). Switching from CSS syntax raises the cognitive cost for contributors and AI agents.

--- a/packages/css/__tests__/build-output.test.ts
+++ b/packages/css/__tests__/build-output.test.ts
@@ -77,3 +77,20 @@ test("the bundle includes the motion keyframes", () => {
   const bundle = readFileSync(join(distDir, "teseor.css"), "utf8");
   expect(bundle).toContain("@keyframes scale-in");
 });
+
+test("prefers-contrast preset re-aliases semantic tokens to denser scale steps", () => {
+  const preset = readFileSync(join(distDir, "prefers-contrast.css"), "utf8");
+  expect(preset).toMatch(
+    /@layer tokens\.semantic\s*\{\s*@media \(prefers-contrast: more\) and \(not \(forced-colors: active\)\)/,
+  );
+  expect(preset).toContain("--t-fg:var(--t-neutral-100)");
+  expect(preset).toContain("--t-border:var(--t-neutral-70)");
+  expect(preset).toContain("--t-border-strong:var(--t-neutral-90)");
+  expect(preset).toContain("--t-focus-ring:var(--t-accent-800)");
+  expect(preset).toContain("--t-accent:var(--t-accent-700)");
+});
+
+test("prefers-contrast preset is not bundled into teseor.css", () => {
+  const bundle = readFileSync(join(distDir, "teseor.css"), "utf8");
+  expect(bundle).not.toContain("@media (prefers-contrast: more)");
+});

--- a/packages/css/build.mjs
+++ b/packages/css/build.mjs
@@ -31,6 +31,7 @@ const TOP_LEVEL_ENTRIES = [
   { from: "base.css", to: "base.css" },
   { from: "utilities.css", to: "utilities.css" },
   { from: "tailwind.css", to: "tailwind.css" },
+  { from: "prefers-contrast.css", to: "prefers-contrast.css" },
 ];
 
 // Pass 1 expands @import/@each/@custom-media. Pass 2 (postcss-teseor-floor)

--- a/packages/css/src/prefers-contrast.css
+++ b/packages/css/src/prefers-contrast.css
@@ -1,0 +1,11 @@
+@layer tokens.semantic {
+  @media (prefers-contrast: more) and (not (forced-colors: active)) {
+    :root {
+      --t-fg: var(--t-neutral-100);
+      --t-border: var(--t-neutral-70);
+      --t-border-strong: var(--t-neutral-90);
+      --t-focus-ring: var(--t-accent-800);
+      --t-accent: var(--t-accent-700);
+    }
+  }
+}


### PR DESCRIPTION
## What

Adds `@teseor/css/prefers-contrast.css` — a standalone opt-in CSS file that consumers import explicitly to honour OS "Increase contrast" (`@media (prefers-contrast: more)`). The preset re-aliases five semantic tokens to denser steps on the existing scale (`--t-fg → --t-neutral-100`, `--t-border → --t-neutral-70`, `--t-border-strong → --t-neutral-90`, `--t-focus-ring → --t-accent-800`, `--t-accent → --t-accent-700`). Guarded with `and (not (forced-colors: active))` so forced-colors remains strictly stronger when both preferences are on.

Default `teseor.css` byte-identical. The postcss plugin stays single-branch (forced-colors only). New top-level entry in the CSS build emits `dist/prefers-contrast.css`; package.json `exports` wildcard already resolves it.

ADR-0003 records the standalone-opt-in shape for preference branches beyond forced-colors. Closes #787.

## Why

OS-level "Increase contrast" is a signal distinct from `forced-colors: active`. Today the design system ignores it. Per-component synthesis at build time would multiply dist sizes per preference, so the preset opts in via a single explicit import — consumers who want it pay one file; everyone else pays nothing. Re-aliasing to existing scale steps avoids introducing fresh OKLCH literals, and the resulting design surface is just "is this step enough?" rather than "what oklch?".

## Test plan

- `pnpm test` — `packages/css/__tests__/build-output.test.ts` asserts the preset's @media line, layer wrapper, the five re-aliases, and that `teseor.css` does not include the branch.
- `pnpm typecheck`, `pnpm lint` — clean.
- Manual: macOS System Settings → Accessibility → Display → Increase contrast. Imports of `@teseor/css/prefers-contrast.css` should darken borders + accent fills.

## Out of scope

- Intent-color AAA tuning for success/warning/danger/info — separate design pass.
- Visual snapshot under the preference — lands with `test:visual` at v0.2.
- `prefers-contrast: less` / `: custom`.
- Other opt-in presets (#772 classless, #774 dark, etc.) — pattern set, not shipped here.