### PR TITLE
fix(codeblock): snap line-height to --t-unit via --t-leading-normal

### DIFF
--- a/.changeset/881-codeblock-grid.md
+++ b/.changeset/881-codeblock-grid.md
@@ -1,0 +1,5 @@
+---
+"@teseor/css": patch
+---
+
+Codeblock now snaps `line-height` to the `--t-unit` grid via `--t-leading-normal` instead of the raw `1.5` ratio. With the default `font-size: 0.875rem` (14px), this raises rendered line height from 21px to 24px so each `pre.t-codeblock` lands on the 4px vertical rhythm grid.

--- a/apps/docs/src/pages/components/codeblock.astro
+++ b/apps/docs/src/pages/components/codeblock.astro
@@ -46,7 +46,7 @@ import Base from "../../layouts/Base.astro";
       <table>
         <thead><tr><th>Artifact</th><th>Raw</th><th>Gzip</th><th>Brotli</th></tr></thead>
         <tbody>
-        <tr><td><a href="https://github.com/teseor/teseor/blob/main/packages/css/src/components/codeblock/codeblock.css"><Code>@teseor/css/components/codeblock.css</Code></a></td><td>1.10 KB</td><td>0.52 KB</td><td>0.45 KB</td></tr>
+        <tr><td><a href="https://github.com/teseor/teseor/blob/main/packages/css/src/components/codeblock/codeblock.css"><Code>@teseor/css/components/codeblock.css</Code></a></td><td>1.19 KB</td><td>0.55 KB</td><td>0.49 KB</td></tr>
         </tbody>
       </table>
     </section>

--- a/packages/css/src/components/codeblock/codeblock.css
+++ b/packages/css/src/components/codeblock/codeblock.css
@@ -5,6 +5,7 @@
     --_pad: var(--t-codeblock-pad, var(--t-space-3));
     --_radius: var(--t-codeblock-radius, var(--t-radius-md));
     --_font: var(--t-codeblock-font, var(--t-font-mono));
+    --_leading: var(--t-leading-normal);
   }
 }
 
@@ -18,7 +19,7 @@
     border-radius: var(--_radius);
     font-family: var(--_font);
     font-size: 0.875rem;
-    line-height: 1.5;
+    line-height: var(--_leading);
     overflow-x: auto;
 
     & code {

--- a/specs/codeblock.yaml
+++ b/specs/codeblock.yaml
@@ -30,6 +30,7 @@ privateTokens:
   - --_pad
   - --_radius
   - --_font
+  - --_leading
 
 examples:
   - id: default


### PR DESCRIPTION
## What

Codeblock CSS now snaps its `line-height` to the `--t-unit` grid via `--t-leading-normal` (which uses `round(up, …, var(--t-unit))`) instead of a raw `1.5` ratio. A private `--_leading` slot in the `.tokens` layer aliases the global token so the `.styles` layer reads `--_*` only, in line with the component-CSS token-interface rule.

## Why

PR #884 added a runtime grid-rhythm audit that asserts `main` height lands on the `--t-unit` grid for every docs page. Codeblock was one of four blockers: with the previous `font-size: 0.875rem` (14px) and `line-height: 1.5`, every `pre.t-codeblock` rendered at `12 + 21 + 12 = 45px` — 1px off the 4px grid. Snapping leading via the token raises the rendered line height to 24px so the block lands on grid (`12 + 24 + 12 = 48px`).

## Test plan

- `pnpm lint && pnpm typecheck && pnpm test` — green locally.
- `pnpm test:e2e tests/docs/grid-rhythm.spec.ts --project=docs-prod` (under PR #884) — pages containing a Codeblock are 1px closer to on-grid after this fix.

## Out of scope

The other three grid-rhythm blockers identified for #884 (text leading, docs tables, etc.) are tracked separately. This PR only addresses the Codeblock contribution.

Closes #881