### PR TITLE
fix(css): snap table cells to --t-unit grid

### DIFF
--- a/.changeset/882-tables-grid.md
+++ b/.changeset/882-tables-grid.md
@@ -1,0 +1,5 @@
+---
+"@teseor/css": patch
+---
+
+Snap bare `<th>` / `<td>` to the `--t-unit` grid. `base.css` now sets `padding-block: var(--t-space-2)`, `padding-inline: var(--t-space-3)`, and `line-height: var(--t-leading-normal)` on cells so each row resolves to a unit-multiple at the default unit and density-scales with the rest of the spatial system.

--- a/apps/docs/src/layouts/Base.astro
+++ b/apps/docs/src/layouts/Base.astro
@@ -100,8 +100,8 @@ const isDev = import.meta.env.DEV;
 
       .content th,
       .content td {
-        padding: var(--t-space-2) var(--t-space-3);
-        border-block-end: 1px solid var(--t-neutral-30);
+        padding-block-end: calc(var(--t-space-2) - var(--t-border-thin));
+        border-block-end: var(--t-border-thin) solid var(--t-neutral-30);
         text-align: start;
         vertical-align: top;
       }

--- a/packages/css/src/base.css
+++ b/packages/css/src/base.css
@@ -75,6 +75,13 @@
     margin-block: var(--t-space-5);
   }
 
+  th,
+  td {
+    padding-block: var(--t-space-2);
+    padding-inline: var(--t-space-3);
+    line-height: var(--t-leading-normal);
+  }
+
   *:focus-visible {
     outline: 2px solid var(--t-focus-ring);
     outline-offset: 2px;


### PR DESCRIPTION
## What

Add a baseline rule in `base.css` that gives `<th>` / `<td>` unit-aligned `padding-block`, `padding-inline`, and `line-height: var(--t-leading-normal)` so cell rows resolve to `--t-unit` multiples on bare tables. In docs, the `.content th, .content td` rule now sets `padding-block-end: calc(var(--t-space-2) - var(--t-border-thin))` to absorb the 1px row separator back into the row, keeping every prop-table row on-grid under `border-collapse: collapse`.

## Why

Docs prop tables were drifting 0.5–2px per row because the bare `<table>` markup picked up the reset's `padding: 0` plus an unaligned `font-size: 0.875rem` line box, and `.content` cells layered an 8/12 padding plus a 1px row border that pushed each row 1px off the 4px grid. The asymmetric padding-block in `.content` is the minimal change that makes the row sum (padding-start + line + padding-end + border) a `--t-unit` multiple at any density. `--t-leading-normal` already snaps up to `--t-unit` for the cell font-size, so the inner line box was on-grid already; only the cell box needed adjustment.

## Test plan

- [x] `pnpm lint`, `pnpm typecheck` clean.
- [x] `pnpm test` runs the same passing suite as `main`; the 2 pre-existing CSS-dist resolution failures (Tooltip / unrelated) are unchanged.
- [x] `pnpm --filter @teseor/css run build` produces the new `th, td` rule in `dist/base.css`.
- [x] `pnpm --filter @teseor/docs run build` produces all 11 pages.
- [ ] `pnpm test:e2e tests/docs/grid-rhythm.spec.ts --project=docs-prod` — runs after #884's spec lands.

## Out of scope

- Adding a `.t-table` class or touching `scripts/codegen/src/generators/gen-docs/_shared/sections.ts` (would expand the codegen surface).
- The other `<main>`-off-grid contributors tracked in #880, #881, #883.
- Generalising `border-collapse` absorption into a `@teseor/css` token (no second consumer yet).

Closes #882.