### PR TITLE
fix(css): drop text-box-trim so prose lands on the unit grid

### DIFF
--- a/.changeset/880-text-leading.md
+++ b/.changeset/880-text-leading.md
@@ -1,0 +1,5 @@
+---
+"@teseor/css": patch
+---
+
+Drop the `text-box-trim` block from `base.css`. The trim was meant to make `padding-block` produce the visually-expected gap, but it shrinks bare `<p>` and `<li>` to the font's ascent/descent extent (18px on system-ui at the base font size) instead of the rounded leading (24px). Without trim these elements land on the `--t-unit` grid again, restoring the rhythm contract surfaced by the docs grid-rhythm audit.

--- a/packages/css/src/base.css
+++ b/packages/css/src/base.css
@@ -79,21 +79,4 @@
     outline: 2px solid var(--t-focus-ring);
     outline-offset: 2px;
   }
-
-  /* text-box-trim strips the half-leading above the cap and below the baseline
-     so `padding-block` produces the visually-expected gap. Without it, rhythm
-     is approximate even when the leading lands on the grid. Scoped to body
-     prose elements where the trim is unambiguously desired; headings keep
-     their natural metrics for the `text-wrap: balance` story. Baseline 2025;
-     `@supports` gates the fallback. */
-  @supports (text-box-trim: trim-both) {
-    :where(p, li, dd, blockquote) {
-      text-box-trim: trim-both;
-      /* stylelint-disable-next-line declaration-property-value-no-unknown --
-         stylelint's CSS value database does not yet recognise `cap` for
-         text-box-edge; the value is valid per the CSS Inline Layout spec
-         (Baseline 2025). */
-      text-box-edge: cap;
-    }
-  }
 }


### PR DESCRIPTION
## What

Remove the `@supports (text-box-trim: trim-both)` block from `packages/css/src/base.css` that applied `text-box-trim: trim-both; text-box-edge: cap` to `p, li, dd, blockquote`.

## Why

`text-box-trim` shrinks the element's box to the font's ascent/descent extent. On the docs site at base font-size 16px (`system-ui`), that produced `<p>` and `<li>` heights of 18px instead of the rounded 24px leading derived from `--t-leading-normal`. 18px does not divide by `--t-unit` (4px), so every bare prose element drifted 2px off the rhythm grid and contributed to `<main>` being off-grid on every component docs page. `text-box-edge: cap` parses but does not yet take effect in Chromium, so the configured tightening never happened — only the box shrinkage did. Dropping the block restores grid-aligned heights and the rhythm contract documented in RFC-0003.

## Test plan

- `pnpm lint`, `pnpm typecheck`, `pnpm test` clean locally.
- `pnpm test:e2e tests/docs/grid-rhythm.spec.ts --project=docs-prod` (run against this branch with the audit cherry-picked from #884): `/components/pagination` and `/components/stack` now pass; the remaining 7 pages still fail on #881 (codeblock) and #882 (prop tables), which are tracked separately.

## Out of scope

- Codeblock composition drift (#881).
- Prop-table grid alignment (#882).
- `t-stack` / `t-cluster` composition drift (#883).
- Re-introducing leading-tightening via a different mechanism (would need its own RFC update / ADR).

Closes #880.