### PR TITLE
docs(spec): flip ADR-0009 status to record ADR-0020 partial supersession

### DIFF
--- a/docs/ADR/0009-spec-schema-and-validation.md
+++ b/docs/ADR/0009-spec-schema-and-validation.md
@@ -1,6 +1,8 @@
 # ADR-0009 — Spec schema and validation
 
-- **Status:** Proposed.
+- **Status:** Proposed. Partially superseded by ADR-0020 (field
+  placement for `interactions:` and `overlay:`; the
+  schema-and-validation decision itself stands).
 - **Deciders:** repo owner (letanure).
 
 ## Decision

--- a/docs/ADR/README.md
+++ b/docs/ADR/README.md
@@ -16,7 +16,7 @@ a numbered, durable file.
 | [0006](0006-enum-typed-string-props.md) | Enum-typed string props | Accepted |
 | [0007](0007-astro-for-the-docs-site.md) | Astro for the docs site | Accepted |
 | [0008](0008-token-driven-component-css.md) | Token-driven component CSS | Accepted |
-| [0009](0009-spec-schema-and-validation.md) | Spec schema and validation | Proposed |
+| [0009](0009-spec-schema-and-validation.md) | Spec schema and validation | Proposed (partially superseded by [0020](0020-states-live-on-parts.md)) |
 | [0010](0010-coverage-expansion-pairwise.md) | Coverage expansion: pairwise for contract fixtures | Proposed |
 | [0011](0011-css-anchor-positioning-for-overlays.md) | CSS Anchor Positioning + Popover API for overlays | Accepted |
 | [0012](0012-wrapper-internal-seam.md) | Wrapper-internal seam: generated `_runtime.ts` + framework-conventional folders | Accepted |


### PR DESCRIPTION
## What

Update ADR-0009's status header to record that ADR-0020 partially supersedes it, and reflect the same in the ADR index.

## Why

ADR-0020 (#875) already mentions the partial supersession in its body — the field-placement specifics for `interactions:` and `overlay:` from ADR-0009 flipped to per-part. ADR-0009's status header never got the cross-link, so anyone reading ADR-0009 first sees only "Proposed" and misses the newer placement rules. The schema-and-validation decision itself stands; only the placement specifics flip.

## Test plan

- `pnpm lint` clean (markdown + `doc-paths` cover the touched files).
- Manual read of ADR-0009 + ADR-0020 + README: cross-links resolve and the supersession scope is stated consistently in all three places.

## Out of scope

Flipping ADR-0009 from `Proposed` to `Accepted`. The validator shipped in #636, so the decision is in force, but moving the status is a separate deliberate scope pass.

Closes #891