### PR TITLE
chore(codegen): use optional chain in events runtime check

### DIFF
--- a/scripts/codegen/src/semantic-checks.test.ts
+++ b/scripts/codegen/src/semantic-checks.test.ts
@@ -2198,6 +2198,7 @@ describe("checkEventsRuntimeSupport", () => {
       const issues = checkEventsRuntimeSupport(spec);
       expect(issues.map((i) => i.path)).toEqual(["events.dismiss.payload.reason"]);
       expect(issues[0]?.message).toMatch(/type 'enum'/);
+      expect(issues[0]?.message).toMatch(/must declare a 'reason' field/);
     }
   });
 

--- a/scripts/codegen/src/semantic-checks.ts
+++ b/scripts/codegen/src/semantic-checks.ts
@@ -1443,7 +1443,7 @@ export function checkEventsRuntimeSupport(spec: Spec): Issue[] {
     const entry = events[name];
     const reasonEntry = entry?.payload?.reason;
     const expectedList = [...expectedReasons].map((v) => `'${v}'`).join(", ");
-    if (!reasonEntry || reasonEntry.type !== "enum") {
+    if (reasonEntry?.type !== "enum") {
       issues.push(
         issue(
           spec.name,


### PR DESCRIPTION
## What

Replace `!reasonEntry || reasonEntry.type !== "enum"` with `reasonEntry?.type !== "enum"` in `checkEventsRuntimeSupport` and strengthen the colocated test to assert the error message wording.

## Why

Clears one of two pre-existing biome `lint/complexity/useOptionalChain` warnings in the codegen tree. The second warning lives under `scripts/codegen/src/generators/**` (the codegen-gated surface) and ships in a separate PR. Tracked under #890.

## Test plan

- `pnpm lint` — clean for `semantic-checks.ts` (remaining warning is in `events.ts`, addressed separately).
- `pnpm typecheck` — clean.
- `pnpm test` — 105 files / 1168 tests pass, including the strengthened `checkEventsRuntimeSupport` reason-field assertions.

## Out of scope

- The `useOptionalChain` warning at `scripts/codegen/src/generators/gen-react/_shared/events.ts:120` — codegen-gated surface, separate PR.

Closes #890