### PR TITLE
fix(css): snap inline code line-box to --t-unit grid

### DIFF
--- a/.changeset/889-td-residual.md
+++ b/.changeset/889-td-residual.md
@@ -1,0 +1,5 @@
+---
+"@teseor/css": patch
+---
+
+Snap inline `<Code>` line-boxes to the `--t-unit` grid. Force `line-height: 1` on `.t-code` so the monospace strut doesn't push parent line-boxes beyond the rhythm, and floor the block-size to `--t-row-1` so the element still lands on grid when it ends up as the sole child of a flex / grid container.

--- a/apps/docs/src/pages/components/code.astro
+++ b/apps/docs/src/pages/components/code.astro
@@ -46,7 +46,7 @@ import Base from "../../layouts/Base.astro";
       <table>
         <thead><tr><th>Artifact</th><th>Raw</th><th>Gzip</th><th>Brotli</th></tr></thead>
         <tbody>
-        <tr><td><a href="https://github.com/teseor/teseor/blob/main/packages/css/src/components/code/code.css"><Code>@teseor/css/components/code.css</Code></a></td><td>0.96 KB</td><td>0.46 KB</td><td>0.42 KB</td></tr>
+        <tr><td><a href="https://github.com/teseor/teseor/blob/main/packages/css/src/components/code/code.css"><Code>@teseor/css/components/code.css</Code></a></td><td>1.05 KB</td><td>0.50 KB</td><td>0.43 KB</td></tr>
         </tbody>
       </table>
     </section>

--- a/packages/css/src/components/code/code.css
+++ b/packages/css/src/components/code/code.css
@@ -5,6 +5,7 @@
     --_pad-x: var(--t-code-pad-x, var(--t-space-1));
     --_radius: var(--t-code-radius, var(--t-radius-sm));
     --_font: var(--t-code-font, var(--t-font-mono));
+    --_min-h: var(--t-row-1);
   }
 }
 
@@ -18,5 +19,7 @@
     border-radius: var(--_radius);
     font-family: var(--_font);
     font-size: 0.9em;
+    line-height: 1;
+    min-block-size: var(--_min-h);
   }
 }

--- a/specs/code.yaml
+++ b/specs/code.yaml
@@ -29,6 +29,7 @@ privateTokens:
   - --_pad-x
   - --_radius
   - --_font
+  - --_min-h
 
 examples:
   - id: default


### PR DESCRIPTION
## What

Drop the monospace strut overshoot in `.t-code` so wrapping `<Code>` inside `<td>` no longer bumps the line-box by 1px per line. `line-height: 1` lets the parent line-height drive the strut; `min-block-size: var(--t-row-1)` floors the box when `<Code>` ends up as a sole flex / grid item (e.g. the Examples cluster on `/components/code`).

## Why

After #886 closed #882, the grid-rhythm audit still flagged 8/9 component docs pages as off-grid by 1-2px. Probe showed `td` cells holding a `<Code>` element ran 41px / 66px instead of 40px / 64px: the mono font ascent+descent pushes the line-box ~1px above the sans-serif strut, accumulating across rows.

## Test plan

- [x] `pnpm test:e2e tests/docs/grid-rhythm.spec.ts --project=docs-prod` (audit branch) — 9/9 pages on-grid
- [x] `pnpm lint && pnpm typecheck && pnpm test` — clean

## Out of scope

`<thead>` rows still measure 35.5px (off by 0.5) because `border-collapse: collapse` splits the bottom 1px border between adjacent rows; that doesn't push `<main>` height off-grid so it's left alone.

Closes #889