### PR TITLE
fix(scripts): switch codegen-audit-ack guard to content stamp

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,8 +31,12 @@ configs (`biome.json`, `.stylelintrc.cjs`, `tsconfig.json`, `lefthook.yml`,
   `scripts/codegen/src/schema.ts`, `scripts/codegen/src/lib/flatten.ts`), run the
   four-category audit from memory `project_codegen_surface_audit` and acknowledge
   it either via `audit: codegen-surface` in the latest commit subject, or by
-  touching `.claude/codegen-audit-ack` after the last commit. The
-  `claude-codegen-audit-guard` PreToolUse hook refuses the push otherwise.
+  writing a current timestamp (ISO 8601, or Unix seconds / milliseconds) as the
+  first line of `.claude/codegen-audit-ack` after the last commit — for example:
+  `node -e 'require("node:fs").writeFileSync(".claude/codegen-audit-ack", new Date().toISOString() + "\n")'`.
+  The `claude-codegen-audit-guard` PreToolUse hook refuses the push otherwise.
+  (Earlier versions used the ack file's mtime, which is unreliable under Claude
+  Code's sandboxed Bash — the content-stamp keeps the ack path usable there.)
 
 ## Ask before
 

--- a/scripts/hooks/claude-codegen-audit-guard.js
+++ b/scripts/hooks/claude-codegen-audit-guard.js
@@ -1,21 +1,16 @@
 #!/usr/bin/env node
 // Claude Code PreToolUse guard fired before `git push`.
-//
-// If the push range touches codegen surface, require the most recent commit
-// subject to contain the literal token `audit: codegen-surface`, OR a fresh
-// `.claude/codegen-audit-ack` file (mtime newer than the most recent commit).
-//
-// Without the acknowledgement, refuse the push by exiting non-zero and writing
-// a structured PreToolUse decision to stdout. The four categories below come
-// from the project memory `project_codegen_surface_audit`.
-//
-// Bypass for one-off commits that genuinely don't touch the codegen surface:
-// the path filter below handles that — the guard only fires when at least one
-// changed file matches a codegen path.
+// Requires the most recent commit subject to include `audit: codegen-surface`,
+// or `.claude/codegen-audit-ack` to contain a timestamp (ISO 8601 or Unix
+// seconds / milliseconds) on its first line newer than the most recent commit.
+// Content-stamp (not mtime) because Claude Code's sandboxed Bash does not bump
+// mtime on `touch` / `rm + echo >`. Four-category audit reference lives in the
+// project memory `project_codegen_surface_audit`.
 
 import { execFileSync } from "node:child_process";
-import { existsSync, readFileSync, statSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 
 const CODEGEN_PATTERNS = [
   /^scripts\/codegen\/src\/generators\//,
@@ -139,17 +134,34 @@ function lastCommitTimestamp() {
   return Number(gitOut(["log", "-1", "--pretty=%ct"])) * 1000;
 }
 
-function ackFileFresh(repoRoot) {
-  const path = resolve(repoRoot, ACK_FILE);
-  if (!existsSync(path)) return false;
+export function parseAckStamp(firstLine) {
+  const line = firstLine.trim();
+  if (!line) return Number.NaN;
+  // Integer-only token: treat as Unix seconds (10 digits) or milliseconds (13+).
+  if (/^\d+$/.test(line)) {
+    const n = Number(line);
+    return line.length <= 10 ? n * 1000 : n;
+  }
+  // Otherwise fall back to ISO 8601 / any Date-parseable string.
+  return Date.parse(line);
+}
+
+export function isAckFresh(ackPath, commitTimestampMs) {
+  if (!existsSync(ackPath)) return false;
   try {
-    const ackMtime = statSync(path).mtimeMs;
-    // `>=` so coarse-resolution filesystems (FAT32 = 2s) don't reject an ack
-    // touched in the same second as the commit.
-    return ackMtime >= lastCommitTimestamp();
+    const firstLine = readFileSync(ackPath, "utf8").split("\n")[0];
+    const stamp = parseAckStamp(firstLine);
+    if (!Number.isFinite(stamp)) return false;
+    // `>=` so coarse-resolution timestamps don't reject an ack written in the
+    // same second as the commit.
+    return stamp >= commitTimestampMs;
   } catch {
     return false;
   }
+}
+
+function ackFileFresh(repoRoot) {
+  return isAckFresh(resolve(repoRoot, ACK_FILE), lastCommitTimestamp());
 }
 
 function denyMessage() {
@@ -169,7 +181,9 @@ function denyMessage() {
     "",
     "Acknowledge by either:",
     `  - including \`${AUDIT_TOKEN}\` in the most recent commit subject, or`,
-    `  - touching \`${ACK_FILE}\` after the last commit.`,
+    `  - writing a current timestamp into \`${ACK_FILE}\` as the first line:`,
+    '      node -e \'require("node:fs").writeFileSync(".claude/codegen-audit-ack", new Date().toISOString() + "\\n")\'',
+    "    (ISO 8601, or Unix seconds / milliseconds — must be >= last commit time)",
     "",
   ].join("\n");
 }
@@ -220,4 +234,7 @@ function main() {
   process.exit(2);
 }
 
-main();
+// Run only when invoked as a script, not when imported by tests.
+if (process.argv[1] && fileURLToPath(import.meta.url) === resolve(process.argv[1])) {
+  main();
+}

--- a/scripts/hooks/claude-codegen-audit-guard.test.ts
+++ b/scripts/hooks/claude-codegen-audit-guard.test.ts
@@ -1,0 +1,91 @@
+import { mkdtempSync, utimesSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import { isAckFresh, parseAckStamp } from "./claude-codegen-audit-guard.js";
+
+function makeAck(content: string): string {
+  const dir = mkdtempSync(resolve(tmpdir(), "ack-guard-"));
+  const path = resolve(dir, "ack");
+  writeFileSync(path, content);
+  // Pin mtime far in the past to prove the content stamp — not mtime — drives
+  // the freshness decision (the reason this hook had to change).
+  utimesSync(path, 1000, 1000);
+  return path;
+}
+
+describe("parseAckStamp", () => {
+  it("parses ISO 8601 strings", () => {
+    expect(parseAckStamp("2026-06-21T12:00:00Z")).toBe(Date.parse("2026-06-21T12:00:00Z"));
+  });
+
+  it("treats a 10-digit integer as Unix seconds", () => {
+    expect(parseAckStamp("1782000000")).toBe(1782000000 * 1000);
+  });
+
+  it("treats a 13-digit integer as Unix milliseconds", () => {
+    expect(parseAckStamp("1782000000000")).toBe(1782000000000);
+  });
+
+  it("trims surrounding whitespace", () => {
+    expect(parseAckStamp("  2026-06-21T12:00:00Z\t")).toBe(Date.parse("2026-06-21T12:00:00Z"));
+  });
+
+  it("returns NaN for an empty line", () => {
+    expect(Number.isNaN(parseAckStamp(""))).toBe(true);
+    expect(Number.isNaN(parseAckStamp("   "))).toBe(true);
+  });
+
+  it("returns NaN for unparseable input", () => {
+    expect(Number.isNaN(parseAckStamp("not-a-date"))).toBe(true);
+  });
+});
+
+describe("isAckFresh", () => {
+  const commitMs = Date.parse("2026-06-21T12:00:00Z");
+
+  it("returns true when the ack timestamp is newer than the commit", () => {
+    const ack = makeAck("2026-06-21T13:00:00Z\n");
+    expect(isAckFresh(ack, commitMs)).toBe(true);
+  });
+
+  it("returns true when the ack timestamp matches the commit (>= boundary)", () => {
+    const ack = makeAck("2026-06-21T12:00:00Z\n");
+    expect(isAckFresh(ack, commitMs)).toBe(true);
+  });
+
+  it("returns false when the ack timestamp is older than the commit", () => {
+    const ack = makeAck("2026-06-21T11:00:00Z\n");
+    expect(isAckFresh(ack, commitMs)).toBe(false);
+  });
+
+  it("ignores mtime entirely — content-stamp drives the decision", () => {
+    // mtime is pinned to 1970 (utimesSync above); the ack must still pass
+    // because its first line is in the future. This is the regression guard
+    // for issue #861 — under Claude Code's sandbox, mtime stays pinned even
+    // after a rewrite, so a stale mtime can no longer reject a fresh ack.
+    const ack = makeAck("2026-06-21T13:00:00Z\n");
+    expect(isAckFresh(ack, commitMs)).toBe(true);
+  });
+
+  it("accepts Unix seconds on the first line", () => {
+    const ack = makeAck(`${Math.floor(commitMs / 1000) + 60}\n`);
+    expect(isAckFresh(ack, commitMs)).toBe(true);
+  });
+
+  it("returns false when the ack file is missing", () => {
+    expect(isAckFresh(resolve(tmpdir(), "does-not-exist-xyz"), commitMs)).toBe(false);
+  });
+
+  it("returns false when the first line is unparseable", () => {
+    const ack = makeAck("nope\n2026-06-21T13:00:00Z\n");
+    expect(isAckFresh(ack, commitMs)).toBe(false);
+  });
+
+  it("only reads the first line", () => {
+    // First line valid but older than the commit; a fresher second line must
+    // NOT rescue the ack — the format is strictly first-line.
+    const ack = makeAck("2026-06-21T11:00:00Z\n2026-06-21T13:00:00Z\n");
+    expect(isAckFresh(ack, commitMs)).toBe(false);
+  });
+});


### PR DESCRIPTION
## What

`scripts/hooks/claude-codegen-audit-guard.js` now reads the first line of `.claude/codegen-audit-ack` as a timestamp (ISO 8601, or Unix seconds / milliseconds) instead of trusting the file's mtime. The deny message and `CLAUDE.md` workflow note are updated to match, and a colocated `claude-codegen-audit-guard.test.ts` covers `parseAckStamp` and `isAckFresh` — including the regression for mtime-pinned files.

## Why

Under Claude Code's sandboxed Bash, `touch` and `rm + echo >` don't bump mtime — it stays pinned at first-write. The ack-file path was effectively dead and the only working ack channel was the commit-subject token, which led to empty audit-ack commits piling onto PRs that touched the codegen surface (cited examples: #851, #857, #859). Parsing a content stamp keeps the ack-file workflow alive without depending on the filesystem's mtime semantics.

## Test plan

- `pnpm lint` — clean
- `pnpm typecheck` — clean
- `pnpm test` — 1182 / 1182 passing; the new file adds 14 cases (parser + freshness), one of which explicitly pins mtime to 1970 to prove content drives the decision
- Manual: piping a `{"tool_input":{"command":"git push"}}` payload through the hook exits 0 when the push range doesn't touch the codegen surface
- Repro under `.local/repro-mtime-stuck.mjs` (gitignored) demonstrates the old guard rejects a stamp-old-mtime file while the new one accepts it

## Out of scope

- The `events.ts` pre-existing biome warning on `main` (codegen surface — explicitly off-limits for this fix)
- Lefthook / commit-msg / verify-no-dev-leak hooks — unrelated
- Migration of any in-flight ack files — the file is gitignored and recreated per push

Closes #861