### PR TITLE
chore(codegen): events useOptionalChain

### DIFF
--- a/scripts/codegen/src/generators/gen-react/_shared/events.test.ts
+++ b/scripts/codegen/src/generators/gen-react/_shared/events.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "vitest";
+import type { Spec } from "../../gen-contract.ts";
+import { renderEventHandlerBodies } from "./events.ts";
+
+function specWith(events: Spec["events"]): Spec {
+  return {
+    name: "modal",
+    kind: "composite",
+    props: {},
+    tokens: {},
+    visualStates: {},
+    events,
+  };
+}
+
+describe("renderEventHandlerBodies", () => {
+  test("returns empty string when the spec declares no events", () => {
+    expect(renderEventHandlerBodies(specWith(undefined), [])).toBe("");
+  });
+
+  test("emits a handleDismiss useCallback when events.dismiss declares an enum reason", () => {
+    const out = renderEventHandlerBodies(
+      specWith({
+        dismiss: {
+          description: "Closed.",
+          payload: { reason: { type: "enum", values: ["outside", "escape", "button"] } },
+        },
+      }),
+      [],
+    );
+    expect(out).toContain("const handleDismiss = useCallback(");
+    expect(out).toContain(`(reason: "outside" | "escape" | "button") =>`);
+    expect(out).toContain(`onDismiss?.({ reason });`);
+    expect(out).toContain(`onEvent?.({ type: "dismiss", reason });`);
+  });
+
+  test("throws when events.dismiss is declared but payload.reason is missing", () => {
+    expect(() =>
+      renderEventHandlerBodies(specWith({ dismiss: { description: "Closed.", payload: {} } }), []),
+    ).toThrow(/events\.dismiss must declare a payload field 'reason' of type enum/);
+  });
+
+  test("throws when events.dismiss declares payload.reason with a non-enum type", () => {
+    expect(() =>
+      renderEventHandlerBodies(
+        specWith({
+          dismiss: { description: "Closed.", payload: { reason: { type: "string" } } },
+        }),
+        [],
+      ),
+    ).toThrow(/events\.dismiss must declare a payload field 'reason' of type enum/);
+  });
+});

--- a/scripts/codegen/src/generators/gen-react/_shared/events.ts
+++ b/scripts/codegen/src/generators/gen-react/_shared/events.ts
@@ -117,7 +117,7 @@ export function renderEventHandlerBodies(
 
   if (Object.hasOwn(events, "dismiss")) {
     const reasonEntry = events.dismiss?.payload?.reason;
-    if (!reasonEntry || reasonEntry.type !== "enum") {
+    if (reasonEntry?.type !== "enum") {
       throw new Error(
         `events.dismiss must declare a payload field 'reason' of type enum (runtime adapter requires the enum values to type the reason argument).`,
       );


### PR DESCRIPTION
## What

Replace `if (!reasonEntry || reasonEntry.type !== "enum")` with `if (reasonEntry?.type !== "enum")` in `scripts/codegen/src/generators/gen-react/_shared/events.ts`. The two forms narrow identically (anything that is not the enum branch falls through), but biome's `useOptionalChain` warning flagged the longer form. Adds a colocated `events.test.ts` exercising both the happy path and the throw path, satisfying the codegen-tests lint pairing rule.

## Why

Closes #890. Biome warning was the only lint violation on the codebase as of the issue filing. The fix mirrors PR #894 which closed the same warning in `semantic-checks.ts`.

## Test plan

- `pnpm lint` clean (warning gone).
- `pnpm typecheck` clean.
- `pnpm test` clean (1172 tests pass, including the 4 new cases in `events.test.ts`).
- `pnpm gen` produces no drift.

## Out of scope

- Any other biome `useOptionalChain` sites; this PR is the single warning at the issue's line reference.
- Test coverage for the controllable-boolean loop in `renderEventHandlerBodies`; the new tests target the dismiss branch where the rewritten condition lives.

## Codegen surface audit

- **schema-accepts/codegen-drops gaps** — N/A. No schema change; codegen logic unchanged in shape, only the boolean expression was simplified.
- **raw-string-as-identifier** — N/A. No new identifiers; no changes to emitted prop names, type names, or JSX attribute names.
- **inherited-type collisions** — N/A. No types added or modified; emitted types are byte-identical.
- **doc symmetry** — N/A. No codegen-emitted prop changed; `gen-docs/_shared/sections.ts:renderProps` is unaffected.

Closes #890