### PR TITLE
docs(docs): canonical cross-component patterns derived from component survey

### DIFF
--- a/docs/research/_component-survey/extract-patterns.mjs
+++ b/docs/research/_component-survey/extract-patterns.mjs
@@ -1,0 +1,255 @@
+// Extract cross-component patterns from consolidated.json into patterns.json.
+// Output drives the data tables in docs/research/component-survey-patterns.md.
+// The Markdown file is hand-edited (it carries editorial decisions); re-run
+// this when consolidated.json changes and reconcile any drifted tables.
+//
+// Categories:
+//   1. Shared prop vocabulary (prop name -> components × systems)
+//   2. ARIA pattern counts (separator, dialog, listbox, ...)
+//   3. Keyboard pattern counts (escape, arrow, type-ahead, ...)
+//   4. Design-choice pattern counts (asChild, render-prop, controlled, roving)
+//   5. Naming-convention pairs (open vs isOpen, etc.)
+//   6. Alias clusters (3+ aliases observed)
+
+import fs from "node:fs";
+
+const consolidated = JSON.parse(
+  fs.readFileSync(".local/component-survey/consolidated.json", "utf8"),
+);
+
+const PROP_NAME_RE = /^[a-zA-Z][a-zA-Z0-9]*$/;
+
+function normPropName(raw) {
+  const name = String(raw).split(/[\s(]/)[0].trim();
+  return PROP_NAME_RE.test(name) ? name : null;
+}
+
+function add(map, key, sub) {
+  let bucket = map.get(key);
+  if (!bucket) {
+    bucket = new Map();
+    map.set(key, bucket);
+  }
+  bucket.set(sub, (bucket.get(sub) || 0) + 1);
+}
+
+function sortDesc(entries) {
+  return entries.sort((a, b) => b[1] - a[1]);
+}
+
+// 1. Shared prop vocabulary
+
+const propIndex = new Map();
+for (const r of consolidated.ranked) {
+  for (const [system, info] of r.systems) {
+    if (!info.key_props) continue;
+    for (const raw of info.key_props) {
+      const name = normPropName(raw);
+      if (!name) continue;
+      if (!propIndex.has(name)) propIndex.set(name, new Map());
+      const compMap = propIndex.get(name);
+      if (!compMap.has(r.canon)) compMap.set(r.canon, new Set());
+      compMap.get(r.canon).add(system);
+    }
+  }
+}
+
+const sharedProps = [];
+for (const [prop, compMap] of propIndex) {
+  const components = [];
+  let totalSystemHits = 0;
+  for (const [canon, sysSet] of compMap) {
+    components.push({ canon, sysCount: sysSet.size, systems: [...sysSet] });
+    totalSystemHits += sysSet.size;
+  }
+  components.sort((a, b) => b.sysCount - a.sysCount);
+  sharedProps.push({
+    prop,
+    componentCount: components.length,
+    totalSystemHits,
+    components,
+  });
+}
+sharedProps.sort((a, b) => {
+  if (b.componentCount !== a.componentCount) return b.componentCount - a.componentCount;
+  return b.totalSystemHits - a.totalSystemHits;
+});
+
+// 2 + 3. ARIA and keyboard pattern counts
+
+const ARIA_PATTERNS = [
+  { key: "role=separator", re: /role[=\s"]*separator/i },
+  { key: "role=dialog", re: /role[=\s"]*(alert)?dialog/i },
+  { key: "role=listbox", re: /role[=\s"]*listbox/i },
+  { key: "role=combobox", re: /role[=\s"]*combobox/i },
+  { key: "role=menu", re: /role[=\s"]*menu(?!item|bar)/i },
+  { key: "role=menubar", re: /role[=\s"]*menubar/i },
+  { key: "role=tablist", re: /role[=\s"]*tablist/i },
+  { key: "role=tab", re: /role[=\s"]*tab\b/i },
+  { key: "role=tabpanel", re: /role[=\s"]*tabpanel/i },
+  { key: "role=tooltip", re: /role[=\s"]*tooltip/i },
+  { key: "role=alert", re: /role[=\s"]*alert(?!dialog)/i },
+  { key: "role=switch", re: /role[=\s"]*switch/i },
+  { key: "role=slider", re: /role[=\s"]*slider/i },
+  { key: "role=progressbar", re: /role[=\s"]*progressbar/i },
+  { key: "role=status", re: /role[=\s"]*status/i },
+  { key: "role=radiogroup", re: /role[=\s"]*radiogroup/i },
+  { key: "role=tree", re: /role[=\s"]*tree/i },
+  { key: "role=grid", re: /role[=\s"]*grid/i },
+  { key: "aria-orientation", re: /aria-orientation/i },
+  { key: "aria-expanded", re: /aria-expanded/i },
+  { key: "aria-controls", re: /aria-controls/i },
+  { key: "aria-haspopup", re: /aria-haspopup/i },
+  { key: "aria-selected", re: /aria-selected/i },
+  { key: "aria-checked", re: /aria-checked/i },
+  { key: "aria-pressed", re: /aria-pressed/i },
+  { key: "aria-disabled", re: /aria-disabled/i },
+  { key: "aria-invalid", re: /aria-invalid/i },
+  { key: "aria-describedby", re: /aria-describedby/i },
+  { key: "aria-labelledby", re: /aria-labelledby/i },
+  { key: "aria-modal", re: /aria-modal/i },
+  { key: "aria-live", re: /aria-live/i },
+  { key: "aria-activedescendant", re: /aria-activedescendant/i },
+  { key: "aria-busy", re: /aria-busy/i },
+  { key: "aria-hidden", re: /aria-hidden/i },
+];
+
+const KEYBOARD_PATTERNS = [
+  { key: "Escape closes", re: /\b(escape|esc)\b/i },
+  { key: "arrow keys navigate", re: /\barrow(s)?\b/i },
+  { key: "Home/End", re: /\b(home\/end|home and end)\b/i },
+  {
+    key: "Enter/Space activates",
+    re: /\b(enter\/space|enter and space|enter or space|space\/enter)\b/i,
+  },
+  { key: "Tab traps focus", re: /\b(focus trap|focus-trap|trap(s|ped|ping)? focus)\b/i },
+  { key: "Roving tabindex", re: /\broving\b/i },
+  { key: "Type-ahead", re: /\b(type[- ]?ahead|typeahead)\b/i },
+];
+
+const ariaIndex = new Map();
+const kbIndex = new Map();
+for (const r of consolidated.ranked) {
+  for (const [, info] of r.systems) {
+    const text = `${info.a11y_aria || ""} ${info.design_choices || ""}`;
+    for (const { key, re } of ARIA_PATTERNS) if (re.test(text)) add(ariaIndex, key, r.canon);
+    for (const { key, re } of KEYBOARD_PATTERNS) if (re.test(text)) add(kbIndex, key, r.canon);
+  }
+}
+
+function summarizePatternIndex(map) {
+  const out = [];
+  for (const [pattern, compMap] of map) {
+    const components = sortDesc([...compMap]).map(([canon, sysCount]) => ({ canon, sysCount }));
+    out.push({
+      pattern,
+      componentCount: components.length,
+      totalSystemHits: components.reduce((s, c) => s + c.sysCount, 0),
+      components,
+    });
+  }
+  return out.sort((a, b) => {
+    if (b.componentCount !== a.componentCount) return b.componentCount - a.componentCount;
+    return b.totalSystemHits - a.totalSystemHits;
+  });
+}
+
+// 4. Design-choice signals (free-text scan over design_choices)
+
+const DESIGN_PATTERNS = [
+  { key: "asChild slot", re: /\b(aschild|as-child|as child slot)\b/i },
+  { key: "render-prop slot", re: /\b(render[- ]prop|render slot|renderprop)\b/i },
+  { key: "polymorphic (as)", re: /\bpolymorphic\b/i },
+  {
+    key: "controlled+uncontrolled",
+    re: /\b(controlled\s*(\+|and|\/)\s*uncontrolled|uncontrolled\s*(\+|and|\/)\s*controlled)\b/i,
+  },
+  { key: "controlled-only", re: /\bcontrolled[- ]only\b/i },
+  { key: "part-based composition", re: /\b(part[- ]based|root\/.+\/.+|multi[- ]part)\b/i },
+  { key: "portal / overlay", re: /\b(portal|overlay)\b/i },
+  {
+    key: "floating positioning",
+    re: /\b(floating[- ]ui|anchor[- ]position|positioning|popper)\b/i,
+  },
+  { key: "data-state attribute", re: /\bdata-state\b/i },
+  { key: "scroll lock", re: /\bscroll[- ]lock\b/i },
+  { key: "form integration", re: /\b(form integration|name prop|hidden input)\b/i },
+];
+
+const designIndex = new Map();
+for (const r of consolidated.ranked) {
+  for (const [, info] of r.systems) {
+    const text = info.design_choices || "";
+    for (const { key, re } of DESIGN_PATTERNS) if (re.test(text)) add(designIndex, key, r.canon);
+  }
+}
+
+// 5. Naming-convention pairs
+
+const NAMING_PAIRS = [
+  ["open", "isOpen"],
+  ["disabled", "isDisabled"],
+  ["loading", "isLoading"],
+  ["selected", "isSelected"],
+  ["checked", "isChecked"],
+  ["invalid", "isInvalid"],
+  ["required", "isRequired"],
+  ["readOnly", "isReadOnly"],
+  ["defaultOpen", "defaultIsOpen"],
+  ["defaultValue", "defaultSelected"],
+  ["onChange", "onValueChange"],
+  ["onOpenChange", "onOpen"],
+  ["size", "sx"],
+  ["variant", "kind"],
+  ["variant", "appearance"],
+  ["variant", "type"],
+  ["color", "colorScheme"],
+  ["icon", "iconBefore"],
+];
+
+const namingPairs = NAMING_PAIRS.map(([a, b]) => {
+  const aCount = propIndex.get(a)?.size || 0;
+  const bCount = propIndex.get(b)?.size || 0;
+  return {
+    pair: [a, b],
+    aComponentCount: aCount,
+    bComponentCount: bCount,
+    aSystemHits: aCount ? [...propIndex.get(a).values()].reduce((s, set) => s + set.size, 0) : 0,
+    bSystemHits: bCount ? [...propIndex.get(b).values()].reduce((s, set) => s + set.size, 0) : 0,
+  };
+});
+
+// 6. Alias clusters
+
+const aliasClusters = consolidated.ranked
+  .filter((r) => r.aliases && r.aliases.length > 1)
+  .map((r) => ({
+    canon: r.canon,
+    sysCount: r.sysCount,
+    teseor: r.teseor,
+    aliases: r.aliases,
+    aliasCount: r.aliases.length,
+  }))
+  .sort((a, b) => b.aliasCount - a.aliasCount);
+
+const out = {
+  meta: {
+    totalSystems: consolidated.summary.totalSystems,
+    consensusComponents: consolidated.summary.consensusComponents,
+  },
+  sharedProps: sharedProps.filter((p) => p.componentCount >= 3),
+  ariaPatterns: summarizePatternIndex(ariaIndex),
+  keyboardPatterns: summarizePatternIndex(kbIndex),
+  designPatterns: summarizePatternIndex(designIndex),
+  namingPairs,
+  aliasClusters: aliasClusters.filter((c) => c.aliasCount >= 3),
+};
+
+fs.writeFileSync(".local/component-survey/patterns.json", JSON.stringify(out, null, 2));
+
+console.log("wrote .local/component-survey/patterns.json");
+console.log("- shared props (3+ components):", out.sharedProps.length);
+console.log("- aria patterns:", out.ariaPatterns.length);
+console.log("- keyboard patterns:", out.keyboardPatterns.length);
+console.log("- design patterns:", out.designPatterns.length);
+console.log("- alias clusters (3+ aliases):", out.aliasClusters.length);

--- a/docs/research/component-survey-patterns.md
+++ b/docs/research/component-survey-patterns.md
@@ -1,0 +1,271 @@
+# Component survey — cross-component patterns
+
+Derived from the 50-system component survey (`component-survey.md` /
+`component-survey-cards.md`). Inputs: `.local/component-survey/consolidated.json`
+(158 consensus components, 1025 system×component entries with `key_props`).
+Extractor: `.local/component-survey/extract-patterns.mjs`.
+
+This doc fixes the cross-cutting decisions once so every per-component issue
+inherits them. Per-component issues defer to this table for prop names, state
+naming, slot pattern, and which runtime mechanism (`@teseor/primitives` entry,
+codegen template, or missing) wires the behavior.
+
+Renames of existing Teseor exports are NOT decided here. Those land per
+component, with explicit user sign-off per CLAUDE.md "ask before breaking
+changes to public API."
+
+---
+
+## 1. Canonical prop vocabulary
+
+### 1.1 Boolean state — never `is`-prefixed
+
+Every state boolean uses the HTML attribute name. The non-prefixed form wins by
+both component count and system count in every pair, and it lets the prop pass
+through to the underlying element without a rename layer.
+
+| Concept | Canon | Frequency | Loses to | Loser frequency |
+| --- | --- | --- | --- | --- |
+| Open/closed | `open` | 27c × 90s | `isOpen` | 7c × 15s |
+| Default open | `defaultOpen` | 14c × 37s | `defaultIsOpen` | 0c |
+| Disabled | `disabled` | 31c × 115s | `isDisabled` | 21c × 29s |
+| Loading | `loading` | 11c × 15s | `isLoading` | 3c × 4s |
+| Selected | `selected` | 13c × 17s | `isSelected` | 3c × 9s |
+| Checked | `checked` | 5c × 32s | `isChecked` | 3c × 3s |
+| Invalid | `invalid` | 12c × 23s | `isInvalid` | 5c × 7s |
+| Required | `required` | 6c × 15s | `isRequired` | 7c × 8s |
+| Read-only | `readOnly` | — | `isReadOnly` | 3c × 3s |
+
+Rule: prefer the HTML attribute spelling. `required` is the only pair where the
+`is` form leads on component count, but loses on system count and breaks the
+"matches HTML" rule — drop the prefix anyway.
+
+### 1.2 Controlled / uncontrolled trio
+
+| Concept | Value trio | Open/close trio | Selection trio |
+| --- | --- | --- | --- |
+| Current | `value` (44c × 227s) | `open` (27c × 90s) | `selected` (13c × 17s) |
+| Default | `defaultValue` (26c × 63s) | `defaultOpen` (14c × 37s) | `defaultSelected` (4c × 7s) |
+| Change | `onChange` (40c × 155s) **or** `onValueChange` (26c × 65s) | `onOpenChange` (19c × 61s) | `onSelectionChange` |
+
+`onChange` vs `onValueChange` is the only ambiguity. Rule: use `onChange` when
+there is no native `onChange` on the underlying element; use `onValueChange`
+when the underlying element fires its own `onChange` (Input, Textarea, Select)
+to avoid the name collision. Radix-family adopts `onValueChange` everywhere for
+consistency — we accept the small redundancy on collision-prone elements only.
+
+### 1.3 Style scale
+
+| Prop | Canon | Frequency | Notes |
+| --- | --- | --- | --- |
+| Size | `size` | 62c × 166s | Token-driven scale: `xs \| sm \| md \| lg \| xl`. No competing name. |
+| Style switch | `variant` | 46c × 79s | Beats `appearance` (20c × 26s), `kind` (7c × 9s). Values are component-specific. |
+| HTML type | `type` | 28c × 65s | Keep separate from `variant`. `type` carries HTML semantics (`button`, `submit`, `email`). `variant` carries visual style. |
+| Color | `color` | 34c × 70s | Beats `colorScheme` (0). Token-driven semantic palette. |
+
+### 1.4 Layout
+
+| Prop | Canon | Frequency | Notes |
+| --- | --- | --- | --- |
+| Axis | `orientation` | 23c × 75s | `'horizontal' \| 'vertical'`. Universal. |
+| Cross-axis align | `align` | 13c × 19s | Adopt where the component genuinely has axis-cross alignment (Popover, Tooltip, Menu). |
+
+### 1.5 Form vocabulary
+
+| Prop | Canon | Frequency | Notes |
+| --- | --- | --- | --- |
+| Form-control name | `name` | 30c × 72s | Passes through to the underlying form element. |
+| Accessible label | `label` | 36c × 58s | Two-way: prop accepts a string; `<label>` element accepts children. |
+| Placeholder | `placeholder` | 11c × 23s | Native HTML attribute on input-like elements. |
+| Description / help | `description` | 11c × 17s | Beats `helperText` (3c × 3s). Renders as `aria-describedby` target. |
+| Error message | (component-specific) | — | No canon emerges; tracked per-component (FormField etc.). |
+
+### 1.6 Polymorphism — `asChild` adopted
+
+Two patterns competed:
+
+- `as` prop (24c × 34s) — Chakra/React Aria/MUI style. Polymorphic element via a
+  prop: `<Button as={Link} />`. Heavy generic types; every prop intersects with
+  the target element's props.
+- `asChild` slot (21c × 22s) — Radix / shadcn / Base UI style. Render-as-child
+  via a wrapper that hoists its child's tag and props: `<Button asChild><Link
+  /></Button>`. Simple types; child controls its own props.
+
+Decision: **`asChild`.** Reasons: (a) no generic-types contortion in the
+codegen output, (b) class merging works without a `className` intersection, (c)
+matches the Radix-derived primitives Teseor already follows (`@teseor/primitives`
+uses Radix-style escape stack and modality semantics).
+
+`as` is rejected. Components that need polymorphism use `asChild` + Slot. The
+Slot codegen template is added when the first asChild-bearing component lands
+(Divider, Wave 1).
+
+---
+
+## 2. Shared mechanisms — primitives map
+
+Each row maps a recurring behavior to its runtime source. The "Status" column
+distinguishes:
+
+- **shipped primitive** — `@teseor/primitives` exposes a public hook/helper today
+- **codegen pattern** — emitted into generated React/Vue wrappers, no runtime
+  primitive needed
+- **missing primitive** — recurring behavior with no Teseor implementation;
+  needs a primitive issue before the consuming component can ship
+
+| Mechanism | Used by | Source | Status |
+| --- | --- | --- | --- |
+| Escape-to-dismiss (stacked) | Dialog, Drawer, Modal, Popover, Tooltip, Menu, Select, Combobox, Toast, … (12 components, 32 systems) | `dismissable-layer/onEscapeKeyDown` | shipped |
+| Outside-click-to-dismiss | (every overlay) | `dismissable-layer/onInteractOutside` | shipped |
+| Focus trap | Dialog (13), Drawer (8), Modal (8), AlertDialog (5), CommandPalette (1), LoadingOverlay (1) | `focus-trap` | shipped |
+| Scroll lock / sibling inert | Dialog, Modal, Drawer | `modality` (inert siblings) | shipped |
+| Portal | Overlays, Toast, Tooltip | `portal` | shipped |
+| Floating positioning | Popover (5), Tooltip (3), Select (2), DropdownMenu (2) | — | **missing** |
+| Roving tabindex | RadioGroup (5), ToggleGroup (4), DropdownMenu (3), Toolbar (3), Menubar (2), Tabs (1), ContextMenu (1) | — | **missing** |
+| Type-ahead selection | DropdownMenu (7), Select (5), Menubar (3), Tree (2), ListBox (2), ContextMenu (2), Autocomplete (1) | — | **missing** |
+| Controlled+uncontrolled state | Accordion (3), Checkbox, Tabs, Switch, Tooltip, Dialog, Collapsible, NumberInput, Autocomplete, Input | codegen template (per-spec hook) | pattern |
+| `asChild` slot | Button, Checkbox, Switch, Badge, Dialog, Accordion, Divider, Label, AlertDialog, VisuallyHidden, … (21 components) | codegen template (Slot wrapper) | pattern (per §1.6) |
+| `data-state` attribute | Per-component (open/closed/active/etc.) | codegen template (state→attribute reflection) | pattern |
+
+**Action items derived from this section:**
+
+- File primitive issues: floating-positioning, roving-tabindex, type-ahead. Each
+  blocks ≥4 downstream components from shipping cleanly.
+- Codegen patterns (asChild Slot, controlled/uncontrolled hook, data-state
+  reflection) are template work in `scripts/codegen/` — track separately from
+  primitive issues; they ride along with the first component that needs them.
+
+These three missing primitives are the only base-code work that the survey
+output justifies. Everything else routes through existing primitives or
+codegen.
+
+---
+
+## 3. ARIA + keyboard signal table
+
+Per pattern, the components that surface it most strongly in the survey. Use
+this as a checklist when writing the a11y section of a per-component issue —
+if the consensus says a primitive emits `aria-expanded`, the issue should
+specify the prop or state that drives it.
+
+### ARIA attributes
+
+| Pattern | Components | System hits |
+| --- | --- | --- |
+| `aria-expanded` | 11 | 40 |
+| `aria-describedby` | 10 | 39 |
+| `aria-pressed` | 7 | 18 |
+| `aria-hidden` | 7 | 11 |
+| `aria-invalid` | 6 | 25 |
+| `role=dialog` | 6 | 25 |
+| `aria-activedescendant` | 6 | 14 |
+| `aria-labelledby` | 6 | 14 |
+| `aria-busy` | 5 | 10 |
+| `aria-selected` | 5 | 10 |
+| `role=progressbar` | 4 | 23 |
+| `role=radiogroup` | 4 | 17 |
+| `role=status` | 4 | 10 |
+| `aria-haspopup` | 4 | 6 |
+| `role=alert` | 3 | 19 |
+| `aria-checked` | 3 | 17 |
+| `role=tooltip` | 3 | 10 |
+| `aria-live` | 3 | 10 |
+| `aria-controls` | 3 | 6 |
+
+### Keyboard
+
+| Pattern | Components | System hits |
+| --- | --- | --- |
+| Arrow keys navigate | 27 | 85 |
+| Tab traps focus | 6 | 36 |
+| Escape closes | 12 | 32 |
+| Type-ahead | 7 | 22 |
+| Roving tabindex | 7 | 19 |
+| Home/End | 5 | 12 |
+| Enter/Space activates | 2 | 4 |
+
+---
+
+## 4. Alias clusters
+
+Components observed under multiple names across systems. Each cluster gets
+resolved at issue time, not here. The doc only flags the clusters worth
+surfacing during per-component synthesis.
+
+### 4.1 Same component, different name (confirmed fold)
+
+These are the survey's strongest "obviously one component" candidates. Per-
+component issue picks the canon and folds the rest:
+
+| Canon | Aliases (selection) | Sys | Teseor |
+| --- | --- | --- | --- |
+| Divider | `Divider`, `Separator`, `Dividers` | 16 | missing |
+| HorizontalRule (folds into Divider) | `Horizontal rule (hr)`, `HorizontalRule`, `prose hr` | 7 | missing |
+| Menu | `Menu`, `Dropdown`, `Dropdown menu`, `DropdownMenu`, `ActionMenu` | 24 | missing |
+| RadioGroup | `Radio`, `Radio Group`, `RadioGroup`, `RadioButtonGroup` | 23 | missing |
+| List | `List`, `OrderedList`, `UnorderedList`, `prose ul`, `prose ol`, `prose li` | 18 | missing |
+| Heading | `Heading`, `Title`, `prose h1..h6` | 16 | missing |
+
+### 4.2 Different names that need an editorial call
+
+Visually similar, semantically distinct in some systems and merged in others.
+Per-component issue surfaces the call:
+
+| Cluster | Tension |
+| --- | --- |
+| **Alert vs Callout vs Admonition** | Alert (17 sys) is in-app status; Callout/Admonition (19 alias surface) is in-prose. Same visual treatment, different context. Pick: one component with a `context` prop, or two? |
+| **Modal vs Dialog** | Modal (Teseor existing) shipped as `Modal`; Dialog dominant elsewhere. Survey calls both "Dialog." Rename held — surface per CLAUDE.md. |
+| **Tabs vs Tablist** | Teseor ships `Tablist`; survey canon is `Tabs`. Rename held. |
+| **Cluster vs Group vs Inline** | Teseor ships `Cluster`; competing names include `Group`, `Inline`, `HStack`. Rename held. |
+| **Snackbar vs Toast** | Toast canon (15 sys). Snackbar is the Material name only. Fold to Toast. |
+| **DateField vs DatePicker vs Calendar** | DatePicker (14 sys) is the composite popover; DateField is the input alone; Calendar is the grid primitive. Likely three separate components in Teseor, with shared Calendar primitive. |
+
+### 4.3 Sub-variants of a base component (fold via prop)
+
+Could be separate components or one base + variants. Lean toward the base:
+
+| Cluster | Suggested fold |
+| --- | --- |
+| Button + IconButton + ToggleButton + SplitButton + ActionIcon + CopyButton + FileButton | Base `Button` with `variant`, `pressed` (for toggle), wrapper for split. IconButton = Button with icon-only content. |
+| OrderedList + UnorderedList | Base `List` with `ordered: boolean` prop. Renders `<ol>` vs `<ul>`. |
+| Divider + HorizontalRule | One `Divider` (see §4.1). |
+
+### 4.4 Notable single-system patterns to ignore
+
+Worth noting that we considered them and chose not to adopt:
+
+- `overrides` (42 components, all BaseWeb) — BaseWeb's component-overrides API.
+  Not a vocabulary; an architectural pattern. Skip.
+- `HTMLAttributes` (14 components, mostly Tiptap) — Tiptap's render-attr
+  passthrough. Skip.
+- `sx` prop (3 components, MUI) — runtime style API. Not Teseor's model. Skip.
+
+---
+
+## 5. Inputs to the per-component issue template
+
+Every issue body filed from the survey should answer:
+
+1. **Behavior.** 2–4 sentences. What it does. Composing parts if any.
+2. **Props table.** Per prop: type, default, source (§1 if shared canon, or
+   component-specific). Note when a canonical prop is missing because the
+   component doesn't need it.
+3. **Mechanism wiring.** For each behavior in §2 (escape, focus trap, …), name
+   the primitive or codegen pattern. If `missing`, the issue is blocked on
+   filing the primitive issue first.
+4. **A11y signature.** Roles + ARIA attributes the component emits. Cross-check
+   against §3.
+5. **Aliases / rename.** §4 cluster the component belongs to. Editorial call
+   surfaced explicitly if it touches Teseor's existing exports.
+6. **Out of scope.** Features observed in ≤3 systems are deferred by default.
+   Issue lists them, doesn't include them.
+7. **References.** Source URLs (from `component-survey-cards.md`).
+
+---
+
+## 6. Drift policy
+
+This doc derives from the survey snapshot. If a per-component synthesis reveals
+the canon was wrong (e.g. a prop pattern reverses), update the row here in the
+same PR as the component issue, with the new frequency justification. Never
+silently diverge.


### PR DESCRIPTION
## What

Adds `docs/research/component-survey-patterns.md` — a synthesis derived from the 50-system component survey landed in #900. It settles the cross-cutting decisions every future per-component issue would otherwise re-litigate: shared prop vocabulary, controlled/uncontrolled trio, polymorphism shape, mechanism→primitive map, ARIA + keyboard signal table, alias clusters.

Also adds `docs/research/_component-survey/extract-patterns.mjs` — the reproducibility script that emits the data tables into `.local/component-survey/patterns.json`, alongside the existing `consolidate.mjs` / `render-cards.mjs` / `render-doc.mjs`.

## Why

Filing per-component issues without a canon means re-deciding state-bool naming, polymorphism, mechanism wiring, and rename clusters once per component. The patterns doc fixes those decisions once.

Four decisions are locked here:

- Boolean state drops the `is`-prefix (matches HTML attribute names).
- Polymorphism is `asChild`, not `as`.
- `variant` / `size` are token-driven; `description` beats `helperText`.
- Three primitives surface as missing (floating-positioning, roving-tabindex, type-ahead) — each will be filed as its own issue against this canon.

## Test plan

- [x] Markdown lints clean.
- [x] `node docs/research/_component-survey/extract-patterns.mjs` runs from repo root and writes `patterns.json`.
- [x] Data tables in the Markdown match the latest `patterns.json` output.

## Out of scope

- Filing the per-component or per-primitive issues themselves (next session).
- Renaming existing Teseor exports (Modal→Dialog, Tablist→Tabs) — those ship as deliberate breaking-change PRs per component, with explicit sign-off per CLAUDE.md.

Closes #901