### PR TITLE
feat(codegen): polymorphic asChild for atomic specs

### DIFF
--- a/.changeset/911-slot-polymorphic-asChild.md
+++ b/.changeset/911-slot-polymorphic-asChild.md
@@ -1,0 +1,10 @@
+---
+"@teseor/react": minor
+"@teseor/vue": minor
+---
+
+Atomic specs may now opt into `asChild`-based polymorphism via the new `polymorphic: 'asChild'` field. When set, the generator adds an `asChild?: boolean` prop and renders via the shared `Slot` helper instead of the spec's root element when `asChild={true}`. The Slot components themselves are unchanged — this PR extends the schema and atomic React / Vue generators so any Wave 1 atomic component (Divider, Heading, Text, List, Link, Blockquote, Image, Kbd) can opt in by declaring `polymorphic: 'asChild'` in its spec.
+
+A semantic check rejects `polymorphic` alongside a sibling `as` prop (mutually exclusive polymorphism strategies) and on void-element roots (Slot needs a child to clone into). The docs prop table auto-emits the `asChild` row for any atomic spec that opts in, matching the existing composite-trigger row.
+
+No existing wrapper changes — every shipped spec stays opted out, so the generated React and Vue outputs are byte-identical to main.

--- a/scripts/codegen/src/generators/gen-docs/_shared/sections.test.ts
+++ b/scripts/codegen/src/generators/gen-docs/_shared/sections.test.ts
@@ -156,6 +156,33 @@ describe("renderProps", () => {
     expect(out).not.toContain("<Code>ref</Code>");
     expect(out).not.toContain("Forwarded ref to the popover content element.");
   });
+
+  test("appends asChild for atomic specs with `polymorphic: 'asChild'`", () => {
+    const spec: DocsSpec = {
+      name: "divider",
+      kind: "atomic",
+      element: "div",
+      polymorphic: "asChild",
+      props: {},
+      tokens: {},
+      visualStates: {},
+    };
+    const out = renderProps(spec);
+    expect(out).toContain("<Code>asChild</Code>");
+  });
+
+  test("omits asChild for atomic specs without polymorphic", () => {
+    const spec: DocsSpec = {
+      name: "divider",
+      kind: "atomic",
+      element: "div",
+      props: {},
+      tokens: {},
+      visualStates: {},
+    };
+    const out = renderProps(spec);
+    expect(out).not.toContain("<Code>asChild</Code>");
+  });
 });
 
 describe("hasFromChildrenPart", () => {

--- a/scripts/codegen/src/generators/gen-docs/_shared/sections.ts
+++ b/scripts/codegen/src/generators/gen-docs/_shared/sections.ts
@@ -91,7 +91,11 @@ export function hasOverlayPart(spec: DocsSpec): boolean {
 export function renderProps(spec: DocsSpec): string {
   const hasRepeating =
     spec.kind === "composite" && Array.isArray(spec.repeating) && spec.repeating.length > 0;
-  if ((!spec.props || Object.keys(spec.props).length === 0) && !hasRepeating) return "";
+  const exposesAsChildOnly =
+    (spec.kind === "composite" && hasFromChildrenPart(spec)) ||
+    (spec.kind === "atomic" && spec.polymorphic === "asChild");
+  if ((!spec.props || Object.keys(spec.props).length === 0) && !hasRepeating && !exposesAsChildOnly)
+    return "";
   // `pattern: controllable` expands to a triple (`name`, `defaultName`,
   // `onNameChange`) in every emitted wrapper / contract. The docs table
   // mirrors that expansion so the documented API matches the consumer's
@@ -133,10 +137,14 @@ export function renderProps(spec: DocsSpec): string {
       esc(def.description ?? ""),
     ]);
   }
-  // Composite components with a `fromChildren` part automatically expose
-  // `asChild` to opt out of the default `<span>` wrapper. The flag isn't a
-  // spec prop — it's emitted by the generator — so the docs append it here.
-  if (spec.kind === "composite" && hasFromChildrenPart(spec)) {
+  // Two paths surface an emitted `asChild` prop the spec doesn't declare:
+  // composite specs with a `fromChildren` part (Tooltip, Modal) and atomic
+  // specs that opt in via `polymorphic: 'asChild'`. Either way the flag is
+  // generator-emitted, so the docs append it here.
+  const exposesAsChild =
+    (spec.kind === "composite" && hasFromChildrenPart(spec)) ||
+    (spec.kind === "atomic" && spec.polymorphic === "asChild");
+  if (exposesAsChild) {
     rows.push([
       `<Code>asChild</Code>`,
       `<Code>boolean</Code>`,

--- a/scripts/codegen/src/generators/gen-react/_shared/props.ts
+++ b/scripts/codegen/src/generators/gen-react/_shared/props.ts
@@ -68,15 +68,24 @@ export function renderOwnProps(
     : [];
   const sizeLines = spec.sizes ? renderCanonicalProp("size", sizeType, propDescriptions) : [];
   const hasAs = "as" in (spec.props ?? {});
-  const refType = hasAs
-    ? "Ref<HTMLElement>"
-    : `Ref<HTMLElementTagNameMap[${quote(spec.element ?? "div")}]>`;
+  const isPolymorphic = spec.polymorphic === "asChild";
+  const refType =
+    hasAs || isPolymorphic
+      ? "Ref<HTMLElement>"
+      : `Ref<HTMLElementTagNameMap[${quote(spec.element ?? "div")}]>`;
+  const asChildLines = isPolymorphic
+    ? [
+        `  /** Render directly on the consumer's child element via Slot (cloneElement) instead of wrapping in a \`<${spec.element ?? "div"}>\`. Single-child invariant. */`,
+        `  asChild?: boolean;`,
+      ]
+    : [];
   return [
     `type ${Name}OwnProps = {`,
     ...variantLines,
     ...intentLines,
     ...sizeLines,
     ...propLines,
+    ...asChildLines,
     `  children?: ReactNode;`,
     `  ref?: ${refType};`,
     `};`,
@@ -92,6 +101,7 @@ export function renderDestructure(spec: Spec): string {
     spec.intents ? "intent" : null,
     spec.sizes ? "size" : null,
     ...Object.keys(spec.props ?? {}),
+    spec.polymorphic === "asChild" ? "asChild" : null,
     "children",
     "ref",
     "className",

--- a/scripts/codegen/src/generators/gen-react/kinds/atomic.test.ts
+++ b/scripts/codegen/src/generators/gen-react/kinds/atomic.test.ts
@@ -80,4 +80,40 @@ describe("renderAtomicReactWrapper", () => {
     const out = renderAtomicReactWrapper(atomicSpec({ element: "div" }), {});
     expect(out).not.toContain("<code>");
   });
+
+  describe("polymorphic: 'asChild'", () => {
+    test("imports Slot, adds the asChild prop, and selects Component conditionally", () => {
+      const out = renderAtomicReactWrapper(
+        atomicSpec({ element: "div", polymorphic: "asChild" }),
+        {},
+      );
+      expect(out).toContain(`import { Slot } from "./components/Slot.tsx";`);
+      expect(out).toContain("asChild?: boolean;");
+      expect(out).toContain(`const Component = asChild ? Slot : "div";`);
+      expect(out).toContain("<Component\n");
+      expect(out).toContain("</Component>");
+    });
+
+    test("widens the ref type to HTMLElement (consumer-chosen element)", () => {
+      const out = renderAtomicReactWrapper(
+        atomicSpec({ element: "p", polymorphic: "asChild" }),
+        {},
+      );
+      expect(out).toContain("ref?: Ref<HTMLElement>;");
+    });
+
+    test("includes asChild in the destructure", () => {
+      const out = renderAtomicReactWrapper(
+        atomicSpec({ element: "div", polymorphic: "asChild" }),
+        {},
+      );
+      expect(out).toMatch(/const\s*\{[^}]*\basChild\b[^}]*\}\s*=\s*props;/s);
+    });
+
+    test("omits Slot import and asChild prop when polymorphic is unset", () => {
+      const out = renderAtomicReactWrapper(atomicSpec({ element: "div" }), {});
+      expect(out).not.toContain(`import { Slot }`);
+      expect(out).not.toContain("asChild?: boolean;");
+    });
+  });
 });

--- a/scripts/codegen/src/generators/gen-react/kinds/atomic.ts
+++ b/scripts/codegen/src/generators/gen-react/kinds/atomic.ts
@@ -31,6 +31,7 @@ export function renderAtomicReactWrapper(
   const hasAs = "as" in propMap;
   const hasDisabled = "disabled" in propMap;
   const hasLoading = "loading" in propMap;
+  const isPolymorphic = spec.polymorphic === "asChild";
   const slots = collectSlots(spec);
 
   const sizeIsResponsive = Boolean(spec.sizes) && RESPONSIVE_ENUM_PROPS.has("size");
@@ -49,10 +50,11 @@ export function renderAtomicReactWrapper(
     .join(" || ");
 
   const rootExpr = hasAs ? `as ?? ${quote(spec.element ?? "div")}` : quote(spec.element ?? "div");
-  const componentTag = hasAs ? "Component" : (spec.element ?? "div");
+  const componentTag = hasAs || isPolymorphic ? "Component" : (spec.element ?? "div");
 
   const helperBlock = [
     hasAs ? `  const Component = asElement(${rootExpr});` : null,
+    isPolymorphic ? `  const Component = asChild ? Slot : ${quote(spec.element ?? "div")};` : null,
     hasDisabled && hasAs ? `  const isButton = Component === "button";` : null,
     inactiveExpr ? `  const inactive = ${inactiveExpr};` : null,
     `  const mergedClassName = mergeClass("${rootClass}", className);`,
@@ -105,6 +107,7 @@ export function renderAtomicReactWrapper(
         : responsiveProps.length > 0
           ? `import { mergeClass, type Responsive, responsiveDataAttrs } from "./_runtime.ts";`
           : `import { mergeClass } from "./_runtime.ts";`,
+    isPolymorphic ? `import { Slot } from "./components/Slot.tsx";` : null,
   ]
     .filter((l): l is string => l !== null)
     .join("\n");

--- a/scripts/codegen/src/generators/gen-vue/_shared/props.ts
+++ b/scripts/codegen/src/generators/gen-vue/_shared/props.ts
@@ -40,12 +40,20 @@ export function renderPropsType(
     ? renderCanonicalProp("intent", `${Name}Intent`, propDescriptions)
     : [];
   const sizeLines = spec.sizes ? renderCanonicalProp("size", sizeType, propDescriptions) : [];
+  const asChildLines =
+    spec.polymorphic === "asChild"
+      ? [
+          `  /** Render directly on the consumer's child VNode via Slot (cloneVNode) instead of wrapping in a \`<${spec.element ?? "div"}>\`. Single-child invariant. */`,
+          `  asChild?: boolean;`,
+        ]
+      : [];
   return [
     `type ${Name}Props = {`,
     ...variantLines,
     ...intentLines,
     ...sizeLines,
     ...lines,
+    ...asChildLines,
     `};`,
   ].join("\n");
 }
@@ -58,7 +66,7 @@ export function renderPropsBlock(spec: Spec, Name: string): string {
   if (spec.variants) enumPropNames.push("variant");
   if (spec.intents) enumPropNames.push("intent");
   if (spec.sizes) enumPropNames.push("size");
-  if (enumPropNames.length === 0 && nonSlotProps.length === 0) {
+  if (enumPropNames.length === 0 && nonSlotProps.length === 0 && spec.polymorphic !== "asChild") {
     return `defineProps<${Name}Props>();`;
   }
   const lines = [
@@ -71,6 +79,7 @@ export function renderPropsBlock(spec: Spec, Name: string): string {
       }
       return `  ${name},`;
     }),
+    ...(spec.polymorphic === "asChild" ? ["  asChild,"] : []),
   ];
   return `const {
 ${lines.join("\n")}

--- a/scripts/codegen/src/generators/gen-vue/kinds/atomic.test.ts
+++ b/scripts/codegen/src/generators/gen-vue/kinds/atomic.test.ts
@@ -69,4 +69,33 @@ describe("renderAtomicVueWrapper", () => {
     const out = renderAtomicVueWrapper(atomicSpec({ element: "div" }), {});
     expect(out).not.toContain("<code>");
   });
+
+  describe("polymorphic: 'asChild'", () => {
+    test("imports Slot, adds the asChild prop, and switches root via `:is`", () => {
+      const out = renderAtomicVueWrapper(
+        atomicSpec({ element: "div", polymorphic: "asChild" }),
+        {},
+      );
+      expect(out).toContain(`import { Slot } from "./components/Slot.ts";`);
+      expect(out).toContain("asChild?: boolean;");
+      expect(out).toContain(
+        `<component :is="asChild ? Slot : "div"" class="t-button" v-bind="attrs">`,
+      );
+      expect(out).toContain("</component>");
+    });
+
+    test("includes asChild in the defineProps destructure", () => {
+      const out = renderAtomicVueWrapper(
+        atomicSpec({ element: "div", polymorphic: "asChild" }),
+        {},
+      );
+      expect(out).toMatch(/const\s*\{[^}]*\basChild\b[^}]*\}\s*=\s*defineProps/s);
+    });
+
+    test("omits Slot import and asChild prop when polymorphic is unset", () => {
+      const out = renderAtomicVueWrapper(atomicSpec({ element: "div" }), {});
+      expect(out).not.toContain(`import { Slot }`);
+      expect(out).not.toContain("asChild?: boolean;");
+    });
+  });
 });

--- a/scripts/codegen/src/generators/gen-vue/kinds/atomic.ts
+++ b/scripts/codegen/src/generators/gen-vue/kinds/atomic.ts
@@ -26,6 +26,7 @@ export function renderAtomicVueWrapper(
   const hasAs = "as" in propMap;
   const hasDisabled = "disabled" in propMap;
   const hasLoading = "loading" in propMap;
+  const isPolymorphic = spec.polymorphic === "asChild";
   const slots = collectSlots(spec);
 
   const sizeIsResponsive = Boolean(spec.sizes) && RESPONSIVE_ENUM_PROPS.has("size");
@@ -40,7 +41,10 @@ export function renderAtomicVueWrapper(
     .filter((p): p is string => p !== null)
     .join(" || ");
 
-  const componentTag = hasAs ? "component" : (spec.element ?? "div");
+  const componentTag = hasAs || isPolymorphic ? "component" : (spec.element ?? "div");
+  const polymorphicIsExpr = isPolymorphic
+    ? `asChild ? Slot : ${JSON.stringify(spec.element ?? "div")}`
+    : null;
 
   const helperLines = [
     hasDisabled && hasAs ? `const isButton = computed(() => as === "button");` : null,
@@ -73,14 +77,15 @@ export function renderAtomicVueWrapper(
     !isVoid && spec.kind === "atomic" && spec.slotElement
       ? `  <${spec.slotElement}>\n${innerBody}\n  </${spec.slotElement}>`
       : innerBody;
+  const isExpr = polymorphicIsExpr ?? (hasAs ? "as" : null);
   const rootOpen = isVoid
-    ? hasAs
-      ? `<component :is="as" class="${rootClass}" v-bind="attrs" />`
+    ? isExpr
+      ? `<component :is="${isExpr}" class="${rootClass}" v-bind="attrs" />`
       : `<${componentTag} class="${rootClass}" v-bind="attrs" />`
-    : hasAs
-      ? `<component :is="as" class="${rootClass}" v-bind="attrs">`
+    : isExpr
+      ? `<component :is="${isExpr}" class="${rootClass}" v-bind="attrs">`
       : `<${componentTag} class="${rootClass}" v-bind="attrs">`;
-  const rootClose = isVoid ? "" : hasAs ? `</component>` : `</${componentTag}>`;
+  const rootClose = isVoid ? "" : isExpr ? `</component>` : `</${componentTag}>`;
 
   const imports = [
     `import "@teseor/css/components/${spec.name}.css";`,
@@ -88,6 +93,7 @@ export function renderAtomicVueWrapper(
     responsiveProps.length > 0
       ? `import { type Responsive, responsiveDataAttrs } from "./_runtime.ts";`
       : null,
+    isPolymorphic ? `import { Slot } from "./components/Slot.ts";` : null,
   ]
     .filter((l): l is string => l !== null)
     .join("\n");

--- a/scripts/codegen/src/lib/flatten.ts
+++ b/scripts/codegen/src/lib/flatten.ts
@@ -80,6 +80,9 @@ export type FlatSpec = {
   parts?: Record<string, SpecPart>;
   element?: string;
   slotElement?: string;
+  /** Atomic-only: when `'asChild'`, the wrapper accepts an `asChild?: boolean`
+   *  prop and renders via the shared Slot helper instead of the root element. */
+  polymorphic?: "asChild";
   rootClass?: string;
   variants?: Record<string, { description: string }>;
   intents?: Record<string, { description: string; tokens?: Record<string, string> }>;
@@ -137,6 +140,7 @@ export function flattenSpec(spec: Spec): FlatSpec {
       coverage: spec.coverage,
       element: spec.element,
       slotElement: spec.slotElement,
+      polymorphic: spec.polymorphic,
       rootClass: spec.rootClass,
       variants: spec.variants,
       intents: spec.intents,

--- a/scripts/codegen/src/schema.test.ts
+++ b/scripts/codegen/src/schema.test.ts
@@ -377,4 +377,24 @@ describe("Spec schema — shape layer", () => {
     });
     expect(result.success).toBe(false);
   });
+
+  test("accepts `polymorphic: 'asChild'` on an atomic spec", () => {
+    const result = Spec.safeParse({ ...minimalAtomic(), polymorphic: "asChild" });
+    expect(result.success).toBe(true);
+  });
+
+  test("rejects an unknown `polymorphic` value", () => {
+    const result = Spec.safeParse({ ...minimalAtomic(), polymorphic: "asProp" });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects `polymorphic:` on a composite spec", () => {
+    const result = Spec.safeParse({
+      name: "tooltip",
+      kind: "composite",
+      polymorphic: "asChild",
+      parts: { trigger: { element: "span" } },
+    });
+    expect(result.success).toBe(false);
+  });
 });

--- a/scripts/codegen/src/schema.ts
+++ b/scripts/codegen/src/schema.ts
@@ -269,6 +269,7 @@ const atomicSpec = z.strictObject({
   kind: z.literal("atomic"),
   ...componentNodeFields,
   slotElement: z.string().optional(),
+  polymorphic: z.enum(["asChild"]).optional(),
 });
 
 const compositeSpec = z.strictObject({

--- a/scripts/codegen/src/semantic-checks.test.ts
+++ b/scripts/codegen/src/semantic-checks.test.ts
@@ -14,6 +14,7 @@ import {
   checkExamplesPresent,
   checkExamplesReferences,
   checkMotionSymmetry,
+  checkPolymorphicAtomic,
   checkPrivateTokens,
   checkRepeatingParts,
   checkResponsiveExplicit,
@@ -851,6 +852,88 @@ describe("checkVoidElementConstraints", () => {
     const issues = checkVoidElementConstraints(spec);
     expect(issues).toHaveLength(1);
     expect(issues[0]?.path).toBe("parts.separator.props.loading");
+  });
+});
+
+describe("checkPolymorphicAtomic", () => {
+  test("passes when polymorphic is unset", () => {
+    const spec = makeSpec({
+      name: "divider",
+      kind: "atomic",
+      element: "div",
+    });
+    expect(checkPolymorphicAtomic(spec)).toEqual([]);
+  });
+
+  test("passes when polymorphic is set on a child-bearing element with no `as` prop", () => {
+    const spec = makeSpec({
+      name: "divider",
+      kind: "atomic",
+      element: "div",
+      polymorphic: "asChild",
+    });
+    expect(checkPolymorphicAtomic(spec)).toEqual([]);
+  });
+
+  test("rejects polymorphic + sibling `as` prop", () => {
+    const spec = makeSpec({
+      name: "divider",
+      kind: "atomic",
+      element: "div",
+      polymorphic: "asChild",
+      props: {
+        as: {
+          type: "string",
+          values: ["div", "span"],
+          description: "Polymorphic.",
+        },
+      },
+    });
+    const issues = checkPolymorphicAtomic(spec);
+    expect(issues).toHaveLength(1);
+    expect(issues[0]?.path).toBe("polymorphic");
+    expect(issues[0]?.message).toMatch(/mutually exclusive/);
+  });
+
+  test("rejects polymorphic + declared `asChild` prop (would emit twice)", () => {
+    const spec = makeSpec({
+      name: "divider",
+      kind: "atomic",
+      element: "div",
+      polymorphic: "asChild",
+      props: {
+        asChild: { type: "boolean", description: "Manually declared." },
+      },
+    });
+    const issues = checkPolymorphicAtomic(spec);
+    expect(issues).toHaveLength(1);
+    expect(issues[0]?.path).toBe("props.asChild");
+  });
+
+  test("rejects polymorphic on a void-element root", () => {
+    const spec = makeSpec({
+      name: "divider",
+      kind: "atomic",
+      element: "hr",
+      polymorphic: "asChild",
+    });
+    const issues = checkPolymorphicAtomic(spec);
+    expect(issues).toHaveLength(1);
+    expect(issues[0]?.path).toBe("polymorphic");
+    expect(issues[0]?.message).toMatch(/void element/);
+  });
+
+  test("ignores composite specs (polymorphic is atomic-only)", () => {
+    const spec = makeSpec({
+      name: "tooltip",
+      kind: "composite",
+      parts: {
+        trigger: {
+          element: "span",
+        },
+      },
+    });
+    expect(checkPolymorphicAtomic(spec)).toEqual([]);
   });
 });
 

--- a/scripts/codegen/src/semantic-checks.ts
+++ b/scripts/codegen/src/semantic-checks.ts
@@ -921,6 +921,53 @@ export function checkAsIsConstrained(spec: Spec): Issue[] {
   return issues;
 }
 
+// ── Atomic `polymorphic: 'asChild'` constraints ────────────────────────────
+
+/**
+ * Atomic specs may opt into Slot-based polymorphism with
+ * `polymorphic: 'asChild'`. Two combinations are rejected:
+ *
+ * - `polymorphic` + a sibling `as` prop. `as` is the rejected pattern per
+ *   the patterns doc §1.6; the two are mutually exclusive — declaring both
+ *   on the same spec is a spec authoring error.
+ * - `polymorphic` on a void-element root (`hr`, `img`, …). Slot expects a
+ *   single child element to clone into; a void root has no children path,
+ *   so Slot would always warn.
+ */
+export function checkPolymorphicAtomic(spec: Spec): Issue[] {
+  if (!isAtomic(spec)) return [];
+  if (spec.polymorphic !== "asChild") return [];
+  const issues: Issue[] = [];
+  if (spec.props && "as" in spec.props) {
+    issues.push(
+      issue(
+        spec.name,
+        "polymorphic",
+        "`polymorphic: 'asChild'` is mutually exclusive with a sibling `as` prop — pick one polymorphism strategy",
+      ),
+    );
+  }
+  if (spec.props && "asChild" in spec.props) {
+    issues.push(
+      issue(
+        spec.name,
+        "props.asChild",
+        "`asChild` is emitted automatically by the polymorphic flag; remove the declared prop or drop `polymorphic`",
+      ),
+    );
+  }
+  if (spec.element && isVoidElement(spec.element)) {
+    issues.push(
+      issue(
+        spec.name,
+        "polymorphic",
+        `\`polymorphic: 'asChild'\` requires a child-bearing root element; '${spec.element}' is a void element`,
+      ),
+    );
+  }
+  return issues;
+}
+
 // ── Void HTML elements reject child-bearing prop declarations ───────────────
 
 /**
@@ -2364,6 +2411,7 @@ export function runSemanticChecks(
     ...checkVariantChoiceKeys(spec),
     ...checkResponsiveExplicit(spec),
     ...checkAsIsConstrained(spec),
+    ...checkPolymorphicAtomic(spec),
     ...checkVoidElementConstraints(spec),
     ...checkRepeatingParts(spec),
     ...checkExamplesPresent(spec),


### PR DESCRIPTION
## What

Adds `polymorphic: 'asChild'` to the atomic-spec schema. When set, the React and Vue atomic generators emit an `asChild?: boolean` prop and render via the shared `Slot` helper instead of the spec's root element when `asChild={true}`. The Slot components themselves (`packages/{react,vue}/src/components/Slot.*`) were already shipped for composite-overlay triggers (Tooltip, Modal). This PR generalizes the opt-in to atomic specs.

A semantic check rejects three combinations:

- `polymorphic` + sibling `as` prop (mutually exclusive polymorphism strategies)
- `polymorphic` + declared `asChild` prop (would emit twice)
- `polymorphic` on a void-element root (Slot needs a child element to clone)

The docs prop table auto-emits the `asChild` row for any atomic spec that opts in, matching the existing composite-trigger row.

## Why

Patterns doc §1.6 settled on `asChild` over `as` for polymorphism. Every Wave 1 component (Divider, Heading, Text, List, Link, Blockquote, Image, Kbd) wants `asChild`. Adding it after the fact would be a breaking change to every wrapper's prop surface. This PR is the substrate — atomic specs can declare `polymorphic: 'asChild'` and the generators handle the rest.

## Test plan

- [x] `npx vitest run scripts/codegen` — 732 passed
- [x] `pnpm test` — 1203 passed
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm gen` — no drift in `packages/*/src/` (no shipped spec opts in yet)
- [x] Codegen-surface audit acknowledged

## Out of scope

- Per-component adoption — each Wave 1 spec opts in separately
- Slot composition across nested children
- Renaming the composite `fromChildren` field to align with `polymorphic`

Closes #911