### PR TITLE
feat(codegen): elementByProp for prop-driven tag selection

### DIFF
--- a/.changeset/912-element-by-prop.md
+++ b/.changeset/912-element-by-prop.md
@@ -1,0 +1,10 @@
+---
+"@teseor/react": minor
+"@teseor/vue": minor
+---
+
+Atomic specs (and composite parts, via schema) may now declare `elementByProp: { prop, map }` to switch the rendered HTML tag at runtime based on a controlling prop's value. The React and Vue atomic generators emit a `tagMap` constant and resolve the root element via the prop. Wave 1 components Heading (`level: '1'..'6'` → `h1..h6`) and Text (`as: 'span' | 'p' | …`) consume this directly. List's boolean-driven case (`ordered → ol|ul`) is out of scope here — handled on the spec PR.
+
+A semantic check enforces: `elementByProp` and `element` are mutually exclusive; the controlling prop must exist on the same node with `type: 'string'`; the map's keys and the prop's `values:` must match exactly. `elementByProp` composes with `polymorphic: 'asChild'` — asChild wins when true, otherwise the prop drives the tag.
+
+The docs prop-table row for the controlling prop appends `Renders as <h1> for 1, <h2> for 2, …` so consumers see the mapping inline. No existing wrapper changes; every shipped spec stays opted out.

--- a/scripts/codegen/src/generators/gen-docs/_shared/sections.test.ts
+++ b/scripts/codegen/src/generators/gen-docs/_shared/sections.test.ts
@@ -183,6 +183,29 @@ describe("renderProps", () => {
     const out = renderProps(spec);
     expect(out).not.toContain("<Code>asChild</Code>");
   });
+
+  test("appends the tag map to the controlling prop's description for elementByProp", () => {
+    const spec: DocsSpec = {
+      name: "heading",
+      kind: "atomic",
+      elementByProp: { prop: "level", map: { "1": "h1", "2": "h2" } },
+      props: {
+        level: {
+          type: "string",
+          values: ["1", "2"],
+          description: "Heading level.",
+          __part: "",
+        },
+      },
+      tokens: {},
+      visualStates: {},
+    };
+    const out = renderProps(spec);
+    expect(out).toContain("Heading level.");
+    expect(out).toContain("Renders as");
+    expect(out).toContain("<Code>&lt;h1&gt;</Code>");
+    expect(out).toContain("<Code>&lt;h2&gt;</Code>");
+  });
 });
 
 describe("hasFromChildrenPart", () => {

--- a/scripts/codegen/src/generators/gen-docs/_shared/sections.ts
+++ b/scripts/codegen/src/generators/gen-docs/_shared/sections.ts
@@ -129,12 +129,21 @@ export function renderProps(spec: DocsSpec): string {
       continue;
     }
     const type = [def.type, def.slot ? "slot" : ""].filter(Boolean).join(", ");
+    // When this prop controls the root tag via `elementByProp`, append the
+    // value→tag mapping to its description so the docs page documents the
+    // runtime tag switch.
+    const isElementByPropControl = spec.kind === "atomic" && spec.elementByProp?.prop === name;
+    const tagMapHint = isElementByPropControl
+      ? ` Renders as ${Object.entries(spec.elementByProp?.map ?? {})
+          .map(([v, tag]) => `<Code>&lt;${esc(tag)}&gt;</Code> for <Code>${esc(v)}</Code>`)
+          .join(", ")}.`
+      : "";
     rows.push([
       `<Code>${esc(name)}</Code>`,
       `<Code>${esc(type)}</Code>`,
       responsiveMark(def.responsive),
       `<Code>${esc(formatValue(def.default))}</Code>`,
-      esc(def.description ?? ""),
+      esc(def.description ?? "") + tagMapHint,
     ]);
   }
   // Two paths surface an emitted `asChild` prop the spec doesn't declare:

--- a/scripts/codegen/src/generators/gen-react/_shared/props.ts
+++ b/scripts/codegen/src/generators/gen-react/_shared/props.ts
@@ -69,8 +69,9 @@ export function renderOwnProps(
   const sizeLines = spec.sizes ? renderCanonicalProp("size", sizeType, propDescriptions) : [];
   const hasAs = "as" in (spec.props ?? {});
   const isPolymorphic = spec.polymorphic === "asChild";
+  const isElementByProp = Boolean(spec.elementByProp);
   const refType =
-    hasAs || isPolymorphic
+    hasAs || isPolymorphic || isElementByProp
       ? "Ref<HTMLElement>"
       : `Ref<HTMLElementTagNameMap[${quote(spec.element ?? "div")}]>`;
   const asChildLines = isPolymorphic

--- a/scripts/codegen/src/generators/gen-react/kinds/atomic.test.ts
+++ b/scripts/codegen/src/generators/gen-react/kinds/atomic.test.ts
@@ -116,4 +116,44 @@ describe("renderAtomicReactWrapper", () => {
       expect(out).not.toContain("asChild?: boolean;");
     });
   });
+
+  describe("elementByProp", () => {
+    function headingSpec(extra: Partial<Spec> = {}): Spec {
+      return atomicSpec({
+        name: "heading",
+        elementByProp: {
+          prop: "level",
+          map: { "1": "h1", "2": "h2", "3": "h3" },
+        },
+        props: {
+          level: prop({ type: "string", values: ["1", "2", "3"], default: "1" }),
+        },
+        ...extra,
+      });
+    }
+
+    test("emits a tagMap constant and selects Component from the prop value", () => {
+      const out = renderAtomicReactWrapper(headingSpec(), {});
+      expect(out).toContain(`const tagMap = { "1": "h1", "2": "h2", "3": "h3" } as const;`);
+      expect(out).toContain("const Component = tagMap[String(level)];");
+      expect(out).toContain("<Component\n");
+      expect(out).toContain("</Component>");
+    });
+
+    test("widens the ref type to HTMLElement", () => {
+      const out = renderAtomicReactWrapper(headingSpec(), {});
+      expect(out).toContain("ref?: Ref<HTMLElement>;");
+    });
+
+    test("composes with `polymorphic: 'asChild'` (asChild wins, else tag from prop)", () => {
+      const out = renderAtomicReactWrapper(headingSpec({ polymorphic: "asChild" }), {});
+      expect(out).toContain(`const tagMap =`);
+      expect(out).toContain("const Component = asChild ? Slot : tagMap[String(level)];");
+    });
+
+    test("omits tagMap when elementByProp is unset", () => {
+      const out = renderAtomicReactWrapper(atomicSpec({ element: "div" }), {});
+      expect(out).not.toContain("const tagMap");
+    });
+  });
 });

--- a/scripts/codegen/src/generators/gen-react/kinds/atomic.ts
+++ b/scripts/codegen/src/generators/gen-react/kinds/atomic.ts
@@ -32,6 +32,7 @@ export function renderAtomicReactWrapper(
   const hasDisabled = "disabled" in propMap;
   const hasLoading = "loading" in propMap;
   const isPolymorphic = spec.polymorphic === "asChild";
+  const elementByProp = spec.elementByProp;
   const slots = collectSlots(spec);
 
   const sizeIsResponsive = Boolean(spec.sizes) && RESPONSIVE_ENUM_PROPS.has("size");
@@ -50,11 +51,29 @@ export function renderAtomicReactWrapper(
     .join(" || ");
 
   const rootExpr = hasAs ? `as ?? ${quote(spec.element ?? "div")}` : quote(spec.element ?? "div");
-  const componentTag = hasAs || isPolymorphic ? "Component" : (spec.element ?? "div");
+  const componentTag =
+    hasAs || isPolymorphic || elementByProp ? "Component" : (spec.element ?? "div");
+
+  const tagMapLine = elementByProp
+    ? `  const tagMap = { ${Object.entries(elementByProp.map)
+        .map(([k, v]) => `${quote(k)}: ${quote(v)}`)
+        .join(", ")} } as const;`
+    : null;
+  const tagFromProp = elementByProp ? `tagMap[String(${elementByProp.prop})]` : null;
+
+  const componentLine = isPolymorphic
+    ? tagFromProp
+      ? `  const Component = asChild ? Slot : ${tagFromProp};`
+      : `  const Component = asChild ? Slot : ${quote(spec.element ?? "div")};`
+    : hasAs
+      ? `  const Component = asElement(${rootExpr});`
+      : tagFromProp
+        ? `  const Component = ${tagFromProp};`
+        : null;
 
   const helperBlock = [
-    hasAs ? `  const Component = asElement(${rootExpr});` : null,
-    isPolymorphic ? `  const Component = asChild ? Slot : ${quote(spec.element ?? "div")};` : null,
+    tagMapLine,
+    componentLine,
     hasDisabled && hasAs ? `  const isButton = Component === "button";` : null,
     inactiveExpr ? `  const inactive = ${inactiveExpr};` : null,
     `  const mergedClassName = mergeClass("${rootClass}", className);`,
@@ -95,6 +114,10 @@ export function renderAtomicReactWrapper(
       ? `      <${spec.slotElement}>\n${innerBody}\n      </${spec.slotElement}>`
       : innerBody;
   const typeBlockPrefix = typeBlock ? `${typeBlock}\n` : "";
+  // With elementByProp the root tag is runtime-resolved across a set of
+  // elements; intersect against `div` for the consumer's pass-through props
+  // (the common HTMLAttributes surface). Refs widen to HTMLElement separately
+  // via renderOwnProps.
   const propsTypeLine = renderPropsTypeIntersection(Name, spec.element ?? "div");
 
   const imports = [

--- a/scripts/codegen/src/generators/gen-vue/kinds/atomic.test.ts
+++ b/scripts/codegen/src/generators/gen-vue/kinds/atomic.test.ts
@@ -98,4 +98,38 @@ describe("renderAtomicVueWrapper", () => {
       expect(out).not.toContain("asChild?: boolean;");
     });
   });
+
+  describe("elementByProp", () => {
+    function headingSpec(extra: Partial<Spec> = {}): Spec {
+      return atomicSpec({
+        name: "heading",
+        elementByProp: {
+          prop: "level",
+          map: { "1": "h1", "2": "h2", "3": "h3" },
+        },
+        props: {
+          level: prop({ type: "string", values: ["1", "2", "3"], default: "1" }),
+        },
+        ...extra,
+      });
+    }
+
+    test("emits a tagMap constant and a `:is` expression keyed by the prop", () => {
+      const out = renderAtomicVueWrapper(headingSpec(), {});
+      expect(out).toContain(`const tagMap = { "1": "h1", "2": "h2", "3": "h3" } as const;`);
+      expect(out).toContain(`<component :is="tagMap[String(level)]"`);
+      expect(out).toContain("</component>");
+    });
+
+    test("composes with `polymorphic: 'asChild'`", () => {
+      const out = renderAtomicVueWrapper(headingSpec({ polymorphic: "asChild" }), {});
+      expect(out).toContain(`const tagMap =`);
+      expect(out).toContain(`<component :is="asChild ? Slot : tagMap[String(level)]"`);
+    });
+
+    test("omits tagMap when elementByProp is unset", () => {
+      const out = renderAtomicVueWrapper(atomicSpec({ element: "div" }), {});
+      expect(out).not.toContain("const tagMap");
+    });
+  });
 });

--- a/scripts/codegen/src/generators/gen-vue/kinds/atomic.ts
+++ b/scripts/codegen/src/generators/gen-vue/kinds/atomic.ts
@@ -27,6 +27,7 @@ export function renderAtomicVueWrapper(
   const hasDisabled = "disabled" in propMap;
   const hasLoading = "loading" in propMap;
   const isPolymorphic = spec.polymorphic === "asChild";
+  const elementByProp = spec.elementByProp;
   const slots = collectSlots(spec);
 
   const sizeIsResponsive = Boolean(spec.sizes) && RESPONSIVE_ENUM_PROPS.has("size");
@@ -41,12 +42,21 @@ export function renderAtomicVueWrapper(
     .filter((p): p is string => p !== null)
     .join(" || ");
 
-  const componentTag = hasAs || isPolymorphic ? "component" : (spec.element ?? "div");
+  const componentTag =
+    hasAs || isPolymorphic || elementByProp ? "component" : (spec.element ?? "div");
+  const tagFromProp = elementByProp ? `tagMap[String(${elementByProp.prop})]` : null;
   const polymorphicIsExpr = isPolymorphic
-    ? `asChild ? Slot : ${JSON.stringify(spec.element ?? "div")}`
+    ? `asChild ? Slot : ${tagFromProp ?? JSON.stringify(spec.element ?? "div")}`
+    : (tagFromProp ?? null);
+
+  const tagMapLine = elementByProp
+    ? `const tagMap = { ${Object.entries(elementByProp.map)
+        .map(([k, v]) => `${JSON.stringify(k)}: ${JSON.stringify(v)}`)
+        .join(", ")} } as const;`
     : null;
 
   const helperLines = [
+    tagMapLine,
     hasDisabled && hasAs ? `const isButton = computed(() => as === "button");` : null,
     inactiveExpr ? `const inactive = computed(() => ${inactiveExpr});` : null,
   ]

--- a/scripts/codegen/src/lib/flatten.ts
+++ b/scripts/codegen/src/lib/flatten.ts
@@ -83,6 +83,9 @@ export type FlatSpec = {
   /** Atomic-only: when `'asChild'`, the wrapper accepts an `asChild?: boolean`
    *  prop and renders via the shared Slot helper instead of the root element. */
   polymorphic?: "asChild";
+  /** Atomic-only: when set, the rendered tag is resolved at runtime from the
+   *  named prop's value via `map`. Mutually exclusive with `element`. */
+  elementByProp?: { prop: string; map: Record<string, string> };
   rootClass?: string;
   variants?: Record<string, { description: string }>;
   intents?: Record<string, { description: string; tokens?: Record<string, string> }>;
@@ -141,6 +144,7 @@ export function flattenSpec(spec: Spec): FlatSpec {
       element: spec.element,
       slotElement: spec.slotElement,
       polymorphic: spec.polymorphic,
+      elementByProp: spec.elementByProp,
       rootClass: spec.rootClass,
       variants: spec.variants,
       intents: spec.intents,

--- a/scripts/codegen/src/schema.test.ts
+++ b/scripts/codegen/src/schema.test.ts
@@ -397,4 +397,40 @@ describe("Spec schema — shape layer", () => {
     });
     expect(result.success).toBe(false);
   });
+
+  test("accepts `elementByProp` with a prop + map on an atomic spec", () => {
+    const result = Spec.safeParse({
+      name: "heading",
+      kind: "atomic",
+      rootClass: "t-heading",
+      elementByProp: {
+        prop: "level",
+        map: { "1": "h1", "2": "h2", "3": "h3", "4": "h4", "5": "h5", "6": "h6" },
+      },
+      props: {
+        level: {
+          type: "string",
+          values: ["1", "2", "3", "4", "5", "6"],
+          description: "Heading level.",
+        },
+      },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  test("rejects `elementByProp` without `prop`", () => {
+    const result = Spec.safeParse({
+      ...minimalAtomic(),
+      elementByProp: { map: { "1": "h1" } },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects `elementByProp` with an unknown nested field", () => {
+    const result = Spec.safeParse({
+      ...minimalAtomic(),
+      elementByProp: { prop: "level", map: { "1": "h1" }, typo: true },
+    });
+    expect(result.success).toBe(false);
+  });
 });

--- a/scripts/codegen/src/schema.ts
+++ b/scripts/codegen/src/schema.ts
@@ -65,8 +65,18 @@ const motionBlock = z.strictObject({
   exits: z.array(z.string()).optional(),
 });
 
+const elementByPropBlock = z.strictObject({
+  prop: z.string().min(1),
+  map: z.record(z.string().min(1), z.string().min(1)),
+});
+
 const componentNodeFields = {
   element: z.string().optional(),
+  /** Prop-driven root tag selection. The named prop's runtime value indexes
+   *  into `map` to produce the rendered HTML tag. Mutually exclusive with
+   *  `element`. The controlling prop must be `type: string` with `values:`
+   *  matching the map's keys exactly. */
+  elementByProp: elementByPropBlock.optional(),
   rootClass: z.string().optional(),
   variants: z.record(z.string(), variantEntry).optional(),
   intents: z.record(z.string(), intentEntry).optional(),
@@ -111,6 +121,7 @@ const stateDef = z.strictObject({
 // slots, where `cloneElement` fails silently.
 type ComponentPart = {
   element?: string;
+  elementByProp?: { prop: string; map: Record<string, string> };
   rootClass?: string;
   fromChildren?: boolean;
   repeating?: boolean;

--- a/scripts/codegen/src/semantic-checks.test.ts
+++ b/scripts/codegen/src/semantic-checks.test.ts
@@ -9,6 +9,7 @@ import {
   checkCoverageShape,
   checkCssImportAllowlist,
   checkDependencyCycles,
+  checkElementByProp,
   checkEvents,
   checkEventsRuntimeSupport,
   checkExamplesPresent,
@@ -852,6 +853,106 @@ describe("checkVoidElementConstraints", () => {
     const issues = checkVoidElementConstraints(spec);
     expect(issues).toHaveLength(1);
     expect(issues[0]?.path).toBe("parts.separator.props.loading");
+  });
+});
+
+describe("checkElementByProp", () => {
+  function headingSpec(overrides: Record<string, unknown> = {}): Spec {
+    return makeSpec({
+      name: "heading",
+      kind: "atomic",
+      rootClass: "t-heading",
+      elementByProp: {
+        prop: "level",
+        map: { "1": "h1", "2": "h2", "3": "h3" },
+      },
+      props: {
+        level: {
+          type: "string",
+          values: ["1", "2", "3"],
+          description: "Heading level.",
+        },
+      },
+      ...overrides,
+    });
+  }
+
+  test("passes when prop type + values match the map keys", () => {
+    expect(checkElementByProp(headingSpec())).toEqual([]);
+  });
+
+  test("rejects `elementByProp` siblinged with `element`", () => {
+    const spec = headingSpec({ element: "h1" });
+    const issues = checkElementByProp(spec);
+    expect(issues.some((i) => i.path === "elementByProp")).toBe(true);
+    expect(issues.find((i) => i.path === "elementByProp")?.message).toMatch(/mutually exclusive/);
+  });
+
+  test("rejects when the controlling prop is missing", () => {
+    const spec = makeSpec({
+      name: "heading",
+      kind: "atomic",
+      elementByProp: { prop: "level", map: { "1": "h1" } },
+      props: { other: { type: "string", description: "x." } },
+    });
+    const issues = checkElementByProp(spec);
+    expect(issues).toHaveLength(1);
+    expect(issues[0]?.path).toBe("elementByProp.prop");
+    expect(issues[0]?.message).toMatch(/not declared/);
+  });
+
+  test("rejects when the controlling prop is boolean (v1 is string-only)", () => {
+    const spec = makeSpec({
+      name: "list",
+      kind: "atomic",
+      elementByProp: { prop: "ordered", map: { true: "ol", false: "ul" } },
+      props: { ordered: { type: "boolean", description: "Ordered." } },
+    });
+    const issues = checkElementByProp(spec);
+    expect(issues.some((i) => i.path === "elementByProp.prop")).toBe(true);
+  });
+
+  test("rejects when a prop value is missing from the map", () => {
+    const spec = makeSpec({
+      name: "heading",
+      kind: "atomic",
+      elementByProp: { prop: "level", map: { "1": "h1" } },
+      props: {
+        level: { type: "string", values: ["1", "2"], description: "Level." },
+      },
+    });
+    const issues = checkElementByProp(spec);
+    expect(issues.some((i) => i.message.includes("[2] are not in the map"))).toBe(true);
+  });
+
+  test("rejects when a map key is missing from the prop values", () => {
+    const spec = makeSpec({
+      name: "heading",
+      kind: "atomic",
+      elementByProp: { prop: "level", map: { "1": "h1", "9": "h9" } },
+      props: {
+        level: { type: "string", values: ["1"], description: "Level." },
+      },
+    });
+    const issues = checkElementByProp(spec);
+    expect(issues.some((i) => i.message.includes("[9] are not declared"))).toBe(true);
+  });
+
+  test("walks composite parts", () => {
+    const spec = makeSpec({
+      name: "field",
+      kind: "composite",
+      parts: {
+        title: {
+          elementByProp: { prop: "level", map: { "1": "h1" } },
+          props: {
+            level: { type: "string", values: ["1", "2"], description: "Level." },
+          },
+        },
+      },
+    });
+    const issues = checkElementByProp(spec);
+    expect(issues.some((i) => i.path === "parts.title.elementByProp.map")).toBe(true);
   });
 });
 

--- a/scripts/codegen/src/semantic-checks.ts
+++ b/scripts/codegen/src/semantic-checks.ts
@@ -921,6 +921,82 @@ export function checkAsIsConstrained(spec: Spec): Issue[] {
   return issues;
 }
 
+// ── `elementByProp` constraints ────────────────────────────────────────────
+
+/**
+ * `elementByProp` resolves the rendered tag at runtime from a controlling
+ * prop's value. Four rules keep the generator output sound:
+ *
+ * - Mutually exclusive with sibling `element` (the tag has one source).
+ * - The named prop must exist on the same node.
+ * - The named prop must be `type: 'string'` — boolean / number / responsive
+ *   prop types are out of scope for the v1 surface.
+ * - The named prop's `values:` must enumerate exactly the map's keys (any
+ *   value the consumer can pass must hit the map; every map key must be a
+ *   valid prop value).
+ *
+ * Walks atomic root + composite parts via `visitNodes`.
+ */
+export function checkElementByProp(spec: Spec): Issue[] {
+  const issues: Issue[] = [];
+  visitNodes(spec, (node, path) => {
+    const ebp = node.elementByProp;
+    if (!ebp) return;
+    const base = path === "" ? "elementByProp" : `${path}.elementByProp`;
+    if (node.element) {
+      issues.push(
+        issue(
+          spec.name,
+          base,
+          "`elementByProp` and `element` are mutually exclusive — the rendered tag has one source",
+        ),
+      );
+    }
+    const controllingProp = node.props?.[ebp.prop];
+    if (!controllingProp) {
+      issues.push(
+        issue(spec.name, `${base}.prop`, `prop '${ebp.prop}' is not declared on this node`),
+      );
+      return;
+    }
+    if (controllingProp.type !== "string") {
+      issues.push(
+        issue(
+          spec.name,
+          `${base}.prop`,
+          `prop '${ebp.prop}' must be \`type: 'string'\`; got '${controllingProp.type}'`,
+        ),
+      );
+    }
+    const mapKeys = Object.keys(ebp.map).sort();
+    const values = (controllingProp.values ?? []).slice().sort();
+    if (mapKeys.length === 0) {
+      issues.push(issue(spec.name, `${base}.map`, "`map` must declare at least one entry"));
+    }
+    const missingFromMap = values.filter((v) => !Object.hasOwn(ebp.map, v));
+    const missingFromValues = mapKeys.filter((k) => !values.includes(k));
+    if (missingFromMap.length > 0) {
+      issues.push(
+        issue(
+          spec.name,
+          `${base}.map`,
+          `prop value(s) [${missingFromMap.join(", ")}] are not in the map`,
+        ),
+      );
+    }
+    if (missingFromValues.length > 0) {
+      issues.push(
+        issue(
+          spec.name,
+          `${base}.map`,
+          `map key(s) [${missingFromValues.join(", ")}] are not declared in \`${ebp.prop}.values\``,
+        ),
+      );
+    }
+  });
+  return issues;
+}
+
 // ── Atomic `polymorphic: 'asChild'` constraints ────────────────────────────
 
 /**
@@ -2411,6 +2487,7 @@ export function runSemanticChecks(
     ...checkVariantChoiceKeys(spec),
     ...checkResponsiveExplicit(spec),
     ...checkAsIsConstrained(spec),
+    ...checkElementByProp(spec),
     ...checkPolymorphicAtomic(spec),
     ...checkVoidElementConstraints(spec),
     ...checkRepeatingParts(spec),


### PR DESCRIPTION
## What

Adds `elementByProp: { prop, map }` to the spec schema. When set on an atomic root (or composite part), the rendered HTML tag is resolved at runtime from the named prop's value via the map. Wave 1 components Heading and Text consume this directly.

Generators emit a `tagMap` constant and route `Component` selection through it. Composes with `polymorphic: 'asChild'` — when `asChild={true}` the Slot wins; otherwise the prop drives the tag.

A semantic check enforces four rules:

- `elementByProp` and `element` are mutually exclusive (one source for the tag)
- The controlling prop must exist on the same node
- The controlling prop must be `type: 'string'`
- The prop's `values:` and the map's keys must match exactly

The docs prop-table row for the controlling prop appends `Renders as <h1> for 1, <h2> for 2, …` so the runtime tag switch is documented inline.

## Why

Patterns doc §4.3 decided that Heading and Text should be single base components with prop-driven tag selection rather than separate `H1..H6` / `Span`/`P`/etc. components. Without this schema field, every such spec either hand-rolls a generator (rejected) or ships as multiple components. This PR is the substrate so Wave 1 Heading and Text can fold cleanly.

List's boolean-driven case (`ordered → ol|ul`) is out of scope here — the v1 surface accepts string-typed controlling props only. The spec PR for List will decide whether to extend `elementByProp` to booleans or ship a separate field.

## Test plan

- [x] `npx vitest run scripts/codegen` — 750 passed
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm gen` — no drift in `packages/*/src/`
- [x] Codegen-surface audit acknowledged

## Out of scope

- Boolean controlling prop (List `ordered`)
- Per-component adoption (Heading, Text — their spec PRs)
- Composite-part wiring in generators (schema accepts it; React/Vue atomic generators are the only consumers in v1)

Closes #912