### PR TITLE
feat(spec): expand variant vocabulary to include semantic-color values

### DIFF
--- a/specs/_vocabulary.yaml
+++ b/specs/_vocabulary.yaml
@@ -85,12 +85,18 @@ propDescriptions:
   loading: Shows loading; disables interaction.
   error: Error state.
 
-# Variant values (visual hierarchy).
+# Variant values. Canonical superset: visual hierarchy (solid|outline|ghost|link)
+# plus semantic-color (default|muted|highlight). Each spec declares its own
+# subset in `spec.variants` — Button uses the hierarchy values, Text uses the
+# semantic-color values.
 variants:
   - solid
   - outline
   - ghost
   - link
+  - default
+  - muted
+  - highlight
 
 # Intent values (semantic color role).
 intents:


### PR DESCRIPTION
## What

Add `default`, `muted`, and `highlight` to `vocabulary.variants` in `specs/_vocabulary.yaml` alongside the existing visual-hierarchy values (`solid`, `outline`, `ghost`, `link`). The canonical list becomes the union of all permitted variant values across the library; each spec continues to declare its own subset via `spec.variants`.

## Why

Wave 1 dispatch surfaced that Text needs a semantic-color knob (`muted`, `highlight`). Maintainer chose one canonical prop name (`variant`) with broader value vocabulary over introducing a parallel `tone` prop.

## Test plan

- `pnpm lint` — `lint:spec` validates `spec.variants` membership against the canonical list; existing Button spec continues to declare its `solid|outline|ghost|link` subset.
- `pnpm test` — codegen unit tests pass.
- `pnpm gen` — re-generates with no drift.

## Out of scope

- Per-component variant-value restrictions (each spec declares its own subset; no global per-component map).
- Text spec rewrite to use the new values — separate PR, rebased on top.

Closes #922