### PR TITLE
feat(codegen): polymorphic asChild and elementByProp combo for atomic specs

### DIFF
--- a/.changeset/923-polymorphic-elementbyprop.md
+++ b/.changeset/923-polymorphic-elementbyprop.md
@@ -1,0 +1,13 @@
+---
+"@teseor/react": minor
+"@teseor/vue": minor
+---
+
+Extend the atomic codegen so a single spec can declare both `polymorphic: 'asChild'` and `elementByProp` together, and so an `elementByProp.map` can mix HTML element types (e.g. `span | p | em` or `ul | ol`) without breaking JSX ref-type inference. Substrate change — no new component ships in this PR.
+
+Behavior changes for the existing Heading wrapper (only consumer of `elementByProp` today):
+
+- `ref?: Ref<HTMLElementTagNameMap["h1" | "h2" | "h3" | "h4" | "h5" | "h6"]>` widens to `ref?: Ref<HTMLElement>`. The narrower union rejected consumer refs like `<Heading asChild><a ref={anchorRef}>…` even though `asChild` is designed to accept any element; the wider type matches the polymorphism contract.
+- `const Component: ElementType = asChild ? Slot : tagMap[level ?? "2"]` becomes `const Component = asChild ? Slot : asElement(tagMap[level ?? "2"])`. The runtime widener replaces the type annotation; the rendered tag and JSX output are unchanged.
+
+`semantic-checks.ts` now accepts `polymorphic: 'asChild'` together with `elementByProp.prop: 'as'`. Free `as` polymorphism (no `elementByProp`) still conflicts with `asChild`.

--- a/packages/react/src/Heading.tsx
+++ b/packages/react/src/Heading.tsx
@@ -4,8 +4,8 @@
 // Source: specs/heading.yaml
 
 import "@teseor/css/components/heading.css";
-import type { ComponentProps, ElementType, ReactNode, Ref } from "react";
-import { mergeClass, type Responsive, responsiveDataAttrs } from "./_runtime.ts";
+import type { ComponentProps, ReactNode, Ref } from "react";
+import { asElement, mergeClass, type Responsive, responsiveDataAttrs } from "./_runtime.ts";
 import { Slot } from "./components/Slot.tsx";
 
 type HeadingSize = "xs" | "sm" | "md" | "lg" | "xl";
@@ -20,7 +20,7 @@ type HeadingOwnProps = {
   /** Render directly on the consumer's child element via Slot (cloneElement) instead of wrapping in a `<div>`. Single-child invariant. */
   asChild?: boolean;
   children?: ReactNode;
-  ref?: Ref<HTMLElementTagNameMap["h1" | "h2" | "h3" | "h4" | "h5" | "h6"]>;
+  ref?: Ref<HTMLElement>;
 };
 
 export type HeadingProps = Readonly<
@@ -49,7 +49,7 @@ export function Heading(props: HeadingProps) {
   const { size, level, asChild, children, ref, className, ...rest } = props;
 
   const tagMap = { "1": "h1", "2": "h2", "3": "h3", "4": "h4", "5": "h5", "6": "h6" } as const;
-  const Component: ElementType = asChild ? Slot : tagMap[level ?? "2"];
+  const Component = asChild ? Slot : asElement(tagMap[level ?? "2"]);
   const mergedClassName = mergeClass("t-heading", className);
 
   return (

--- a/scripts/codegen/src/generators/gen-react/_shared/props.ts
+++ b/scripts/codegen/src/generators/gen-react/_shared/props.ts
@@ -67,11 +67,17 @@ export function renderOwnProps(
     ? renderCanonicalProp("intent", `${Name}Intent`, propDescriptions)
     : [];
   const sizeLines = spec.sizes ? renderCanonicalProp("size", sizeType, propDescriptions) : [];
-  const hasAs = "as" in (spec.props ?? {});
-  const isPolymorphic = spec.polymorphic === "asChild";
   const isElementByProp = Boolean(spec.elementByProp);
+  // `as` as a free polymorphism root widens the ref to HTMLElement. When `as`
+  // is the `elementByProp` control, the closed map drives the ref type below.
+  const hasAs = "as" in (spec.props ?? {}) && !isElementByProp;
+  const isPolymorphic = spec.polymorphic === "asChild";
+  // `asChild` accepts ANY consumer element; the ref must widen to
+  // `HTMLElement` even when an elementByProp map narrows the default tag
+  // set — a narrow union (e.g. `HTMLSpanElement | HTMLParagraphElement`)
+  // rejects a consumer `<a ref={…}>` at the `<Component ref={ref}>` site.
   const refType =
-    hasAs || (isPolymorphic && !isElementByProp)
+    hasAs || isPolymorphic
       ? "Ref<HTMLElement>"
       : isElementByProp && spec.elementByProp
         ? `Ref<HTMLElementTagNameMap[${[...new Set(Object.values(spec.elementByProp.map))]

--- a/scripts/codegen/src/generators/gen-react/kinds/atomic.test.ts
+++ b/scripts/codegen/src/generators/gen-react/kinds/atomic.test.ts
@@ -135,21 +135,20 @@ describe("renderAtomicReactWrapper", () => {
     test("emits a tagMap constant and selects Component from the prop value", () => {
       const out = renderAtomicReactWrapper(headingSpec(), {});
       expect(out).toContain(`const tagMap = { "1": "h1", "2": "h2", "3": "h3" } as const;`);
-      expect(out).toContain(`const Component: ElementType = tagMap[level ?? "1"];`);
+      expect(out).toContain(`const Component = asElement(tagMap[level ?? "1"]);`);
       expect(out).toContain("<Component\n");
       expect(out).toContain("</Component>");
     });
 
-    test("narrows the ref type to the union of map values", () => {
+    test("narrows the ref type to the union of map values when not polymorphic", () => {
       const out = renderAtomicReactWrapper(headingSpec(), {});
       expect(out).toContain(`ref?: Ref<HTMLElementTagNameMap["h1" | "h2" | "h3"]>;`);
     });
 
-    test("imports ElementType when elementByProp is set", () => {
+    test("imports asElement from the runtime when elementByProp is set", () => {
       const out = renderAtomicReactWrapper(headingSpec(), {});
-      expect(out).toContain(
-        `import type { ComponentProps, ElementType, ReactNode, Ref } from "react";`,
-      );
+      expect(out).toContain(`import type { ComponentProps, ReactNode, Ref } from "react";`);
+      expect(out).toContain(`import { asElement, mergeClass`);
     });
 
     test("falls back to the first map key when the prop has no `default`", () => {
@@ -161,15 +160,16 @@ describe("renderAtomicReactWrapper", () => {
         }),
         {},
       );
-      expect(out).toContain(`const Component: ElementType = tagMap[level ?? "1"];`);
+      expect(out).toContain(`const Component = asElement(tagMap[level ?? "1"]);`);
     });
 
     test("composes with `polymorphic: 'asChild'` (asChild wins, else tag from prop)", () => {
       const out = renderAtomicReactWrapper(headingSpec({ polymorphic: "asChild" }), {});
       expect(out).toContain(`const tagMap =`);
-      expect(out).toContain(
-        `const Component: ElementType = asChild ? Slot : tagMap[level ?? "1"];`,
-      );
+      expect(out).toContain(`const Component = asChild ? Slot : asElement(tagMap[level ?? "1"]);`);
+      // asChild accepts any consumer element — ref widens to HTMLElement so a
+      // narrow tag-map union doesn't reject e.g. `<a ref={…}>`.
+      expect(out).toContain(`ref?: Ref<HTMLElement>;`);
     });
 
     test("omits tagMap when elementByProp is unset", () => {

--- a/scripts/codegen/src/generators/gen-react/kinds/atomic.ts
+++ b/scripts/codegen/src/generators/gen-react/kinds/atomic.ts
@@ -28,11 +28,14 @@ export function renderAtomicReactWrapper(
   const Name = pascalCase(spec.name);
   const rootClass = spec.rootClass ?? `t-${spec.name}`;
   const propMap = spec.props ?? {};
-  const hasAs = "as" in propMap;
+  const elementByProp = spec.elementByProp;
+  // When `as` is the `elementByProp` control it indexes a closed tag map at
+  // runtime — `asElement(as ?? "div")` is the wrong path. Suppress the free
+  // polymorphism branch so the elementByProp branch wins.
+  const hasAs = "as" in propMap && !elementByProp;
   const hasDisabled = "disabled" in propMap;
   const hasLoading = "loading" in propMap;
   const isPolymorphic = spec.polymorphic === "asChild";
-  const elementByProp = spec.elementByProp;
   const slots = collectSlots(spec);
 
   const sizeIsResponsive = Boolean(spec.sizes) && RESPONSIVE_ENUM_PROPS.has("size");
@@ -68,17 +71,20 @@ export function renderAtomicReactWrapper(
       ? `tagMap[${elementByProp.prop} ?? ${quote(elementByPropDefault)}]`
       : null;
 
-  // With elementByProp the rendered tag is one of the map values; annotating
-  // Component as ElementType widens the JSX inference past the literal-string
-  // union, so the consumer-facing `ref?: Ref<HTMLElement>` passes through.
+  // With elementByProp the rendered tag is one of the map values; `asElement`
+  // widens the narrow literal-string union back to ElementType so JSX's ref
+  // slot isn't pinned to one HTMLElement subtype. The same widening covers
+  // heterogeneous maps (e.g. `span | p | em`) where the union is not a single
+  // shared HTMLElement subclass — JSX would otherwise infer the last entry's
+  // ref type and reject `Ref<HTMLElement>` from the consumer.
   const componentLine = isPolymorphic
     ? tagFromProp
-      ? `  const Component: ElementType = asChild ? Slot : ${tagFromProp};`
+      ? `  const Component = asChild ? Slot : asElement(${tagFromProp});`
       : `  const Component = asChild ? Slot : ${quote(spec.element ?? "div")};`
     : hasAs
       ? `  const Component = asElement(${rootExpr});`
       : tagFromProp
-        ? `  const Component: ElementType = ${tagFromProp};`
+        ? `  const Component = asElement(${tagFromProp});`
         : null;
 
   const helperBlock = [
@@ -130,14 +136,17 @@ export function renderAtomicReactWrapper(
   // via renderOwnProps.
   const propsTypeLine = renderPropsTypeIntersection(Name, spec.element ?? "div");
 
+  // `asElement` is the runtime widener for any spec that resolves its root
+  // tag from a value (free `as` polymorphism or `elementByProp` map). Without
+  // it the JSX ref slot pins to a single HTMLElement subtype and rejects the
+  // consumer-facing `Ref<HTMLElement>`.
+  const usesAsElement = hasAs || Boolean(elementByProp);
   const imports = [
     `import "@teseor/css/components/${spec.name}.css";`,
-    elementByProp
-      ? `import type { ComponentProps, ElementType, ReactNode, Ref } from "react";`
-      : `import type { ComponentProps, ReactNode, Ref } from "react";`,
-    hasAs && responsiveProps.length > 0
+    `import type { ComponentProps, ReactNode, Ref } from "react";`,
+    usesAsElement && responsiveProps.length > 0
       ? `import { asElement, mergeClass, type Responsive, responsiveDataAttrs } from "./_runtime.ts";`
-      : hasAs
+      : usesAsElement
         ? `import { asElement, mergeClass } from "./_runtime.ts";`
         : responsiveProps.length > 0
           ? `import { mergeClass, type Responsive, responsiveDataAttrs } from "./_runtime.ts";`

--- a/scripts/codegen/src/generators/gen-vue/kinds/atomic.ts
+++ b/scripts/codegen/src/generators/gen-vue/kinds/atomic.ts
@@ -23,11 +23,14 @@ export function renderAtomicVueWrapper(
   const Name = pascalCase(spec.name);
   const rootClass = spec.rootClass ?? `t-${spec.name}`;
   const propMap = spec.props ?? {};
-  const hasAs = "as" in propMap;
+  const elementByProp = spec.elementByProp;
+  // When `as` is the `elementByProp` control it indexes a closed tag map at
+  // runtime — the free `<component :is="as">` polymorphism path is the wrong
+  // one. Suppress so the elementByProp branch wins.
+  const hasAs = "as" in propMap && !elementByProp;
   const hasDisabled = "disabled" in propMap;
   const hasLoading = "loading" in propMap;
   const isPolymorphic = spec.polymorphic === "asChild";
-  const elementByProp = spec.elementByProp;
   const slots = collectSlots(spec);
 
   const sizeIsResponsive = Boolean(spec.sizes) && RESPONSIVE_ENUM_PROPS.has("size");

--- a/scripts/codegen/src/semantic-checks.ts
+++ b/scripts/codegen/src/semantic-checks.ts
@@ -1014,7 +1014,12 @@ export function checkPolymorphicAtomic(spec: Spec): Issue[] {
   if (!isAtomic(spec)) return [];
   if (spec.polymorphic !== "asChild") return [];
   const issues: Issue[] = [];
-  if (spec.props && "as" in spec.props) {
+  // `as` as a free polymorphism control (`asElement(as ?? "div")`) collides
+  // with `asChild` — two competing root-tag mechanisms. When `as` is the
+  // closed `elementByProp` control instead, Slot wraps the resolved tag and
+  // both mechanisms co-exist cleanly.
+  const asIsElementByPropControl = spec.elementByProp?.prop === "as";
+  if (spec.props && "as" in spec.props && !asIsElementByPropControl) {
     issues.push(
       issue(
         spec.name,


### PR DESCRIPTION
## What

Extend the atomic codegen so a single spec can declare both `polymorphic: 'asChild'` and `elementByProp` together, and so an `elementByProp.map` can mix HTML element types (e.g. `span | p | em` or `ul | ol`) without breaking JSX ref-type inference.

Substrate change — no new component ships in this PR. Unblocks Text (#905) and List (#906) re-attempts.

### Changes

- `scripts/codegen/src/semantic-checks.ts` — `checkPolymorphicAtomic` accepts `polymorphic: 'asChild'` together with `elementByProp.prop: 'as'`. Free `as` polymorphism (no `elementByProp`) still conflicts with `asChild`.
- `scripts/codegen/src/generators/gen-react/_shared/props.ts` — `hasAs` is suppressed when `elementByProp` is set; ref type widens to `HTMLElement` whenever `polymorphic` is set (with or without `elementByProp`).
- `scripts/codegen/src/generators/gen-react/kinds/atomic.ts` — `hasAs` suppressed when `elementByProp` is set; tag-from-prop expressions route through `asElement(...)` so heterogeneous maps (e.g. `ul → HTMLUListElement` and `ol → HTMLOListElement`) don't pin the JSX ref slot to one subtype; drops the conditional `ElementType` import.
- `scripts/codegen/src/generators/gen-vue/kinds/atomic.ts` — `hasAs` suppressed when `elementByProp` is set.
- `scripts/codegen/src/generators/gen-react/kinds/atomic.test.ts` — assertions updated for the new emission shape; new assertion locks in `Ref<HTMLElement>` for the polymorphic+elementByProp combo.

### Behavior change for existing Heading wrapper

Heading is the only current consumer of `elementByProp`. After this PR:

- `ref?: Ref<HTMLElementTagNameMap["h1" | "h2" | "h3" | "h4" | "h5" | "h6"]>` widens to `ref?: Ref<HTMLElement>`. The narrower union rejected consumer refs like `<Heading asChild><a ref={anchorRef}>…` even though `asChild` is designed to accept any element; the wider type matches the polymorphism contract.
- `const Component: ElementType = asChild ? Slot : tagMap[level ?? "2"]` becomes `const Component = asChild ? Slot : asElement(tagMap[level ?? "2"])`. Runtime widener replaces the type annotation; rendered tag and JSX output are unchanged.

## Why

Wave 1 dispatch surfaced this gap via Text (#905) and List (#906) — both agents hand-rolled the same codegen extension in their worktrees, but their `atomic.ts` edits conflicted on merge. Pulling the substrate out as its own PR removes the conflict and unblocks both component PRs to rebase cleanly on top.

## Test plan

- `pnpm test` — 1230/1230 pass; updated `atomic.test.ts` assertions cover the new emission paths and ref-widening behavior.
- `pnpm gen` — re-generates with stable drift (only Heading.tsx changes; second run is a no-op).
- `pnpm typecheck` — clean across `@teseor/react` and `@teseor/vue`.
- `pnpm lint` — all 26 stages clean.

audit: codegen-surface — four-category audit walked. (1) schema-accepts gap: `elementByProp.map` with heterogeneous tag types now generates compiling output (resolved). (2) raw-string identifiers: no new spec strings interpolated as JS identifiers. (3) inherited-type collisions: `Ref<HTMLElement>` widening for polymorphic is broader, not stricter — no regression. (4) doc symmetry: Heading's JSDoc and docs page already describe `asChild` accepting any consumer element; ref widening now matches the documented surface.

## Out of scope

- Void-element `elementByProp` (one branch `hr`, other branch `div`) — separate issue #924.
- Boolean-typed `elementByProp` controlling prop (`ordered: boolean` → `ul|ol`) — separate issue (List rebase covers via string-typed prop).
- Text and List spec rewrites — separate PRs, rebased on top.

Closes #923