### PR TITLE
feat(repo): pre-push hook checks sync-labels drift on spec changes

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -47,6 +47,9 @@ pre-push:
           git --no-pager diff
           exit 1
         fi
+    sync-labels-drift:
+      glob: "specs/*.yaml"
+      run: node scripts/repo/sync-labels.ts --check
     verify-no-dev-leak:
       run: pnpm -r --if-present run build && node scripts/hooks/verify-no-dev-leak.js
     measure:

--- a/scripts/repo/sync-labels.ts
+++ b/scripts/repo/sync-labels.ts
@@ -51,8 +51,7 @@ function renderComponentLabels(components: string[]): string {
     .join("\n");
 }
 
-function replaceAutoRegion(path: string, body: string): void {
-  const current = readFileSync(path, "utf8");
+function injectAutoRegion(current: string, body: string, path: string): string {
   const beginIdx = current.indexOf(AUTO_BEGIN);
   const endIdx = current.indexOf(AUTO_END);
   if (beginIdx === -1 || endIdx === -1) {
@@ -60,13 +59,27 @@ function replaceAutoRegion(path: string, body: string): void {
   }
   const before = current.slice(0, beginIdx + AUTO_BEGIN.length);
   const after = current.slice(endIdx);
-  writeFileSync(path, `${before}${body}${after}`);
+  return `${before}${body}${after}`;
+}
+
+function replaceAutoRegion(path: string, body: string): void {
+  const current = readFileSync(path, "utf8");
+  writeFileSync(path, injectAutoRegion(current, body, path));
+}
+
+function labelerBody(components: string[]): string {
+  const generated = renderComponentEntries(components);
+  return generated ? `\n${generated}` : "\n";
+}
+
+function labelsBody(components: string[]): string {
+  const generated = renderComponentLabels(components);
+  return generated ? `\n${generated}\n` : "\n";
 }
 
 function regenerateLabeler(): void {
   const components = readComponents();
-  const generated = renderComponentEntries(components);
-  replaceAutoRegion(labelerPath, generated ? `\n${generated}` : "\n");
+  replaceAutoRegion(labelerPath, labelerBody(components));
   console.log(
     `labeler.yml: regenerated ${components.length} component entr${components.length === 1 ? "y" : "ies"}`,
   );
@@ -74,11 +87,28 @@ function regenerateLabeler(): void {
 
 function regenerateLabels(): void {
   const components = readComponents();
-  const generated = renderComponentLabels(components);
-  replaceAutoRegion(labelsPath, generated ? `\n${generated}\n` : "\n");
+  replaceAutoRegion(labelsPath, labelsBody(components));
   console.log(
     `labels.yml: regenerated ${components.length} component label${components.length === 1 ? "" : "s"}`,
   );
+}
+
+function checkDrift(): boolean {
+  const components = readComponents();
+  const labelerCurrent = readFileSync(labelerPath, "utf8");
+  const labelsCurrent = readFileSync(labelsPath, "utf8");
+  const labelerExpected = injectAutoRegion(labelerCurrent, labelerBody(components), labelerPath);
+  const labelsExpected = injectAutoRegion(labelsCurrent, labelsBody(components), labelsPath);
+  const drifted: string[] = [];
+  if (labelerCurrent !== labelerExpected) drifted.push(".github/labeler.yml");
+  if (labelsCurrent !== labelsExpected) drifted.push(".github/labels.yml");
+  if (drifted.length === 0) return false;
+  console.error(
+    `sync-labels drift detected in: ${drifted.join(", ")}\n` +
+      `Run: node scripts/repo/sync-labels.ts --mode=generate\n` +
+      `Then commit the regenerated files.`,
+  );
+  return true;
 }
 
 function parseLabelsYaml(): Label[] {
@@ -153,6 +183,10 @@ function upsertLabels(): void {
     updated += 1;
   }
   console.log(`labels: ${created} created, ${updated} updated, ${unchanged} unchanged`);
+}
+
+if (process.argv.includes("--check")) {
+  process.exit(checkDrift() ? 1 : 0);
 }
 
 const modeArg = process.argv.find((arg) => arg.startsWith("--mode="));


### PR DESCRIPTION
## What

Adds a `--check` flag to `scripts/repo/sync-labels.ts` that computes the expected `.github/labeler.yml` and `.github/labels.yml` AUTO regions and exits non-zero if either file is out of date, without mutating anything. Adds a lefthook `pre-push` command `sync-labels-drift` with `glob: "specs/*.yaml"` that invokes the new flag.

## Why

Adding or removing a `specs/*.yaml` requires regenerating `component:<name>` entries in `.github/labeler.yml` and `.github/labels.yml`. The handover's dispatch model has this as step 10, but it's pure discipline; the CI `sync-labels / check` job catches the miss only after push. PRs #934 and #935 each hit this. A pre-push check turns the round-trip into "run this command and try again."

## Test plan

- [x] `--check` passes on clean main.
- [x] `--check` exits 1 with a clear message when a fake `specs/zzz-fake.yaml` is added without regenerating; no files are mutated by the check.
- [x] `lefthook dump` confirms `sync-labels-drift` is wired under `pre-push` with the correct glob.
- [x] Push without any spec change skips the hook (this PR's own push proved it).
- [x] Drift hook will fire on the next spec-add PR; CI `sync-labels` job remains the backstop.

## Out of scope

- Folding `sync-labels --mode=generate` into `pnpm gen`. The issue notes this trade-off: it expands gen scope and would couple repo metadata regeneration to component codegen. Deferred until the pre-push check proves the trigger is well-modeled.

Closes #937