### PR TITLE
feat(ci): block PR merge when head branch is base of another open PR

### DIFF
--- a/.github/workflows/pr-discipline.yml
+++ b/.github/workflows/pr-discipline.yml
@@ -95,6 +95,31 @@ jobs:
           rm -f "$body_file"
           exit "$fail"
 
+  head-branch-not-base-of-open-pr:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    steps:
+      - name: Fail if another open PR is based on this PR's head branch
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -e
+          dependents="$(gh pr list --base "$HEAD_REF" --state open --json number,title)"
+          count="$(echo "$dependents" | jq 'length')"
+          if [ "$count" -eq 0 ]; then
+            echo "No open PRs are based on '$HEAD_REF'. OK."
+            exit 0
+          fi
+          echo "Merging #$PR_NUMBER with --delete-branch would auto-close the following open PR(s) based on '$HEAD_REF':"
+          echo "$dependents" | jq -r '.[] | "  - #\(.number) \(.title)"'
+          echo ""
+          echo "Retarget the dependent PR(s) to a different base (usually 'main') before merging this one."
+          exit 1
+
   labeler:
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## What

Adds a `head-branch-not-base-of-open-pr` job to `.github/workflows/pr-discipline.yml`. On every `pull_request` event, the job runs `gh pr list --base "$HEAD_REF" --state open` and fails when any open PR uses this PR's head branch as its base. The failure message enumerates each dependent PR with the retarget instruction.

## Why

PR #933 was squash-merged with `--delete-branch`. PR #934 had #933's branch as its base, so GitHub auto-closed #934 the moment the branch disappeared, and the work had to be reopened as #935 from scratch (lost the review history). The handover's dispatch step 15 currently calls this out as discipline ("never `--delete-branch` on a substrate PR while a component PR is based on it"); this job is the durable safeguard.

## Test plan

- [x] Discovery query verified locally:
  - `gh pr list --base feat/lefthook-sync-labels-drift --state open` → 0 results (clean case).
  - `gh pr list --base main --state open` → 3 results (the message-rendering case).
- [x] Workflow YAML parses; `pnpm lint` clean.
- [ ] To validate end-to-end: once this PR merges and a future PR is opened with a non-`main` base pointing at another open PR's head, this job should fail there with the actionable message.

Caveat on timing: the check runs on the current PR's `pull_request` events only. If PR A is clean and then PR B is opened against A's branch later, A's check stays green until A is touched again. Pairing this with branch-protection's "Require branches to be up to date before merging" closes that gap by forcing a `synchronize` event prior to merge. Not in scope to configure here.

## Out of scope

- Auto-retargeting dependent PRs.
- Branch protection rule for default-target enforcement (referenced above as the natural complement).
- Cross-PR status reporting (setting a status on PR A from PR B's workflow run when B is the one being edited).

Closes #936