### PR TITLE
feat(codegen): void elementByProp and boolean state attrs

### DIFF
--- a/scripts/codegen/src/generators/gen-docs/_shared/examples.ts
+++ b/scripts/codegen/src/generators/gen-docs/_shared/examples.ts
@@ -1,4 +1,4 @@
-import { isVoidElement } from "../../../lib/html-void-elements.ts";
+import { specVoidStatus } from "../../../lib/html-void-elements.ts";
 import { esc } from "../../../lib/text-escape.ts";
 import type { Spec } from "../../gen-contract.ts";
 import { attr } from "./jsx-printer.ts";
@@ -14,8 +14,10 @@ export function renderExamples(spec: Spec, Name: string, opts: { isComposite: bo
     spec.kind === "composite" && Array.isArray(spec.repeating) && spec.repeating.length > 0;
   // Atomic specs wrapping a void HTML element (img, hr, …) can't carry
   // children; render the example tag self-closing in both the preview and
-  // the source snippet.
-  const isVoidAtomic = spec.kind === "atomic" && !!spec.element && isVoidElement(spec.element);
+  // the source snippet. A `mixed` elementByProp map (some void, some
+  // non-void) keeps the open-tag form so the non-void branches still show
+  // a child label.
+  const isVoidAtomic = spec.kind === "atomic" && specVoidStatus(spec) === "all";
   // Composite components with a `fromChildren` part don't render an element
   // themselves; the docs example wraps a Button as the trigger so the
   // composite has a real child to decorate (Tooltip + Popover pattern).

--- a/scripts/codegen/src/generators/gen-react/_shared/attrs.test.ts
+++ b/scripts/codegen/src/generators/gen-react/_shared/attrs.test.ts
@@ -19,23 +19,29 @@ describe("renderDataAttrs", () => {
       variants: { solid: { description: "" } },
       intents: { primary: { description: "" } },
     });
-    const out = renderDataAttrs(spec, [], false);
+    const out = renderDataAttrs(spec, [], false, []);
     expect(out).toContain("data-variant={variant}");
     expect(out).toContain("data-intent={intent}");
   });
 
   test("spreads `responsiveDataAttrs(name, name)` per responsive prop", () => {
-    const out = renderDataAttrs(atomicSpec(), ["size"], false);
+    const out = renderDataAttrs(atomicSpec(), ["size"], false, []);
     expect(out).toContain(`{...responsiveDataAttrs("size", size)}`);
   });
 
   test("emits the `data-loading` line when hasLoading is true", () => {
-    const out = renderDataAttrs(atomicSpec(), [], true);
+    const out = renderDataAttrs(atomicSpec(), [], true, []);
     expect(out).toContain(`data-loading={loading === true ? "true" : undefined}`);
   });
 
+  test("emits a `data-{name}` flag for each boolean state prop", () => {
+    const out = renderDataAttrs(atomicSpec(), [], false, ["decorative", "compact"]);
+    expect(out).toContain(`data-decorative={decorative === true ? "true" : undefined}`);
+    expect(out).toContain(`data-compact={compact === true ? "true" : undefined}`);
+  });
+
   test("renders an empty string when no attrs are needed", () => {
-    expect(renderDataAttrs(atomicSpec(), [], false)).toBe("");
+    expect(renderDataAttrs(atomicSpec(), [], false, [])).toBe("");
   });
 });
 

--- a/scripts/codegen/src/generators/gen-react/_shared/attrs.ts
+++ b/scripts/codegen/src/generators/gen-react/_shared/attrs.ts
@@ -2,18 +2,23 @@ import type { Spec } from "../../gen-contract.ts";
 import { quote } from "./type-printer.ts";
 
 /** Emit the JSX-attribute lines for variant/intent data-attrs, responsive
- *  data-attr spreads, and the `data-loading` flag — slotted into the wrapper
- *  root in the order defined by the spec. */
+ *  data-attr spreads, the `data-loading` flag, and per-prop `data-*` flags
+ *  for boolean state props — slotted into the wrapper root in the order
+ *  defined by the spec. */
 export function renderDataAttrs(
   spec: Spec,
   responsiveProps: string[],
   hasLoading: boolean,
+  booleanStateProps: string[],
 ): string {
   return [
     spec.variants ? `      data-variant={variant}` : null,
     spec.intents ? `      data-intent={intent}` : null,
     ...responsiveProps.map((name) => `      {...responsiveDataAttrs(${quote(name)}, ${name})}`),
     hasLoading ? `      data-loading={loading === true ? "true" : undefined}` : null,
+    ...booleanStateProps.map(
+      (name) => `      data-${name}={${name} === true ? "true" : undefined}`,
+    ),
   ]
     .filter((line): line is string => line !== null)
     .join("\n");

--- a/scripts/codegen/src/generators/gen-react/_shared/props.ts
+++ b/scripts/codegen/src/generators/gen-react/_shared/props.ts
@@ -1,4 +1,4 @@
-import { isVoidElement } from "../../../lib/html-void-elements.ts";
+import { specVoidStatus } from "../../../lib/html-void-elements.ts";
 import { pascalCase } from "../../../lib/pascal-case.ts";
 import type { Spec, SpecProp } from "../../gen-contract.ts";
 import { quote, reactPropType, responsiveType } from "./type-printer.ts";
@@ -95,9 +95,11 @@ export function renderOwnProps(
   // `children?: never` (instead of `ReactNode`) forbids consumers from passing
   // any children at the type layer — and the Omit on the inherited
   // `ComponentProps<element>` strips its own `children` via `keyof OwnProps`,
-  // so the published surface mirrors HTML semantics.
-  const isVoid = spec.element ? isVoidElement(spec.element) : false;
-  const childrenLine = isVoid ? `  children?: never;` : `  children?: ReactNode;`;
+  // so the published surface mirrors HTML semantics. A `mixed` elementByProp
+  // map (some void branches, some non-void) keeps `ReactNode` so the non-void
+  // path can still receive children; the void path drops them at runtime.
+  const childrenLine =
+    specVoidStatus(spec) === "all" ? `  children?: never;` : `  children?: ReactNode;`;
   return [
     `type ${Name}OwnProps = {`,
     ...variantLines,
@@ -118,9 +120,9 @@ export function renderDestructure(spec: Spec): string {
   // Void elements never render children — the inherited type forbids them,
   // but a consumer type-cast could still pass one. Renaming to `_children`
   // strips it from `...rest` (so it never reaches `<img children=…>`) while
-  // satisfying biome's `noUnusedVariables`.
-  const isVoid = spec.element ? isVoidElement(spec.element) : false;
-  const childrenName = isVoid ? "children: _children" : "children";
+  // satisfying biome's `noUnusedVariables`. A `mixed` elementByProp map keeps
+  // the live `children` name — the non-void branch consumes it at runtime.
+  const childrenName = specVoidStatus(spec) === "all" ? "children: _children" : "children";
   const names = [
     spec.variants ? "variant" : null,
     spec.intents ? "intent" : null,

--- a/scripts/codegen/src/generators/gen-react/kinds/atomic.test.ts
+++ b/scripts/codegen/src/generators/gen-react/kinds/atomic.test.ts
@@ -218,5 +218,107 @@ describe("renderAtomicReactWrapper", () => {
       const out = renderAtomicReactWrapper(atomicSpec({ name: "image", element: "img" }), {});
       expect(out).toContain("children: _children");
     });
+
+    describe("mixed elementByProp.map (void + non-void)", () => {
+      function dividerSpec(extra: Partial<Spec> = {}): Spec {
+        return atomicSpec({
+          name: "divider",
+          elementByProp: {
+            prop: "orientation",
+            map: { horizontal: "hr", vertical: "div" },
+          },
+          props: {
+            orientation: prop({
+              type: "string",
+              values: ["horizontal", "vertical"],
+              default: "horizontal",
+            }),
+          },
+          ...extra,
+        });
+      }
+
+      test("emits resolvedTag + isVoidResolved locals derived from the tagMap", () => {
+        const out = renderAtomicReactWrapper(dividerSpec(), {});
+        expect(out).toContain(`const tagMap = { "horizontal": "hr", "vertical": "div" } as const;`);
+        expect(out).toContain(`const resolvedTag = tagMap[orientation ?? "horizontal"];`);
+        expect(out).toContain(`const isVoidResolved = resolvedTag === "hr";`);
+      });
+
+      test("Component widens via asElement(resolvedTag) when not polymorphic", () => {
+        const out = renderAtomicReactWrapper(dividerSpec(), {});
+        expect(out).toContain(`const Component = asElement(resolvedTag);`);
+      });
+
+      test("renders a ternary that self-closes the void branch and opens the non-void one", () => {
+        const out = renderAtomicReactWrapper(dividerSpec(), {});
+        expect(out).toMatch(/isVoidResolved\s*\?\s*\(/);
+        expect(out).toContain("<Component\n");
+        expect(out).toContain("/>");
+        expect(out).toContain(">\n");
+        expect(out).toContain("</Component>");
+      });
+
+      test("keeps children as ReactNode (non-void branch may consume them)", () => {
+        const out = renderAtomicReactWrapper(dividerSpec(), {});
+        expect(out).toContain("children?: ReactNode;");
+        expect(out).not.toContain("children?: never;");
+        expect(out).not.toContain("children: _children");
+      });
+
+      test("guards asChild on the non-void branch so Slot never wraps a void tag", () => {
+        const out = renderAtomicReactWrapper(dividerSpec({ polymorphic: "asChild" }), {});
+        expect(out).toContain(
+          `const Component = asChild && !isVoidResolved ? Slot : asElement(resolvedTag);`,
+        );
+      });
+    });
+
+    describe("boolean state props", () => {
+      test("emits a `data-{name}` flag on the root for each boolean state prop", () => {
+        const out = renderAtomicReactWrapper(
+          atomicSpec({
+            element: "div",
+            props: {
+              decorative: prop({ type: "boolean", description: "" }),
+            },
+          }),
+          {},
+        );
+        expect(out).toContain(`data-decorative={decorative === true ? "true" : undefined}`);
+      });
+
+      test("does not emit a data-* flag for the elementByProp controlling prop", () => {
+        const out = renderAtomicReactWrapper(
+          atomicSpec({
+            elementByProp: {
+              prop: "ordered",
+              map: { false: "ul", true: "ol" },
+            },
+            props: {
+              ordered: prop({ type: "boolean", description: "" }),
+            },
+          }),
+          {},
+        );
+        expect(out).not.toContain("data-ordered=");
+      });
+
+      test("does not emit data-* for disabled / loading / responsive booleans", () => {
+        const out = renderAtomicReactWrapper(
+          atomicSpec({
+            element: "button",
+            props: {
+              disabled: prop({ type: "boolean" }),
+              loading: prop({ type: "boolean" }),
+              compact: prop({ type: "boolean", responsive: true }),
+            },
+          }),
+          {},
+        );
+        expect(out).not.toContain("data-disabled=");
+        expect(out).not.toContain(`data-compact={compact === true ?`);
+      });
+    });
   });
 });

--- a/scripts/codegen/src/generators/gen-react/kinds/atomic.ts
+++ b/scripts/codegen/src/generators/gen-react/kinds/atomic.ts
@@ -1,6 +1,6 @@
 import { collectSlots } from "../../../lib/collect-slots.ts";
 import { renderEnumType } from "../../../lib/enum-primitives.ts";
-import { isVoidElement } from "../../../lib/html-void-elements.ts";
+import { specVoidStatus, voidTagsInMap } from "../../../lib/html-void-elements.ts";
 import { reactJsDocFlavor, renderComponentJsDoc } from "../../../lib/jsdoc-shape.ts";
 import { pascalCase } from "../../../lib/pascal-case.ts";
 import type { Spec } from "../../gen-contract.ts";
@@ -53,6 +53,22 @@ export function renderAtomicReactWrapper(
       .map(([n]) => n),
   ];
 
+  // Boolean spec props become `data-{name}` flags on the root element. The
+  // controlling prop for `elementByProp`, the `disabled` / `loading` pair,
+  // controllable booleans, and responsive booleans are emitted by their
+  // dedicated paths and are excluded here.
+  const booleanStateProps: string[] = Object.entries(propMap)
+    .filter(
+      ([name, d]) =>
+        d.type === "boolean" &&
+        d.responsive !== true &&
+        d.pattern !== "controllable" &&
+        name !== "disabled" &&
+        name !== "loading" &&
+        name !== elementByProp?.prop,
+    )
+    .map(([name]) => name);
+
   const inactiveExpr = [
     hasDisabled ? "disabled === true" : null,
     hasLoading ? "loading === true" : null,
@@ -63,6 +79,10 @@ export function renderAtomicReactWrapper(
   const rootExpr = hasAs ? `as ?? ${quote(spec.element ?? "div")}` : quote(spec.element ?? "div");
   const componentTag =
     hasAs || isPolymorphic || elementByProp ? "Component" : (spec.element ?? "div");
+
+  const voidStatus = specVoidStatus(spec);
+  const isVoid = voidStatus === "all";
+  const isMixedVoid = voidStatus === "mixed";
 
   const tagMapLine = elementByProp
     ? `  const tagMap = { ${Object.entries(elementByProp.map)
@@ -78,24 +98,43 @@ export function renderAtomicReactWrapper(
       ? `tagMap[${elementByProp.prop} ?? ${quote(elementByPropDefault)}]`
       : null;
 
+  // For a `mixed` elementByProp map (some void, some non-void), the rendered
+  // tag's void-ness can only be known at runtime. Hoist the resolved tag into
+  // a local so JSX can branch self-closing vs with-children, and asChild can
+  // skip Slot on the void path (Slot wraps children, which void tags reject).
+  const resolvedTagLine =
+    isMixedVoid && tagFromProp ? `  const resolvedTag = ${tagFromProp};` : null;
+  const voidCheckExpr =
+    isMixedVoid && elementByProp
+      ? voidTagsInMap(elementByProp.map)
+          .map((tag) => `resolvedTag === ${quote(tag)}`)
+          .join(" || ")
+      : null;
+  const isVoidResolvedLine = voidCheckExpr ? `  const isVoidResolved = ${voidCheckExpr};` : null;
+
   // With elementByProp the rendered tag is one of the map values; `asElement`
   // widens the narrow literal-string union back to ElementType so JSX's ref
   // slot isn't pinned to one HTMLElement subtype. The same widening covers
   // heterogeneous maps (e.g. `span | p | em`) where the union is not a single
   // shared HTMLElement subclass — JSX would otherwise infer the last entry's
   // ref type and reject `Ref<HTMLElement>` from the consumer.
+  const tagExpr = isMixedVoid ? "resolvedTag" : tagFromProp;
   const componentLine = isPolymorphic
-    ? tagFromProp
-      ? `  const Component = asChild ? Slot : asElement(${tagFromProp});`
-      : `  const Component = asChild ? Slot : asElement(${quote(spec.element ?? "div")});`
+    ? isMixedVoid
+      ? `  const Component = asChild && !isVoidResolved ? Slot : asElement(resolvedTag);`
+      : tagExpr
+        ? `  const Component = asChild ? Slot : asElement(${tagExpr});`
+        : `  const Component = asChild ? Slot : asElement(${quote(spec.element ?? "div")});`
     : hasAs
       ? `  const Component = asElement(${rootExpr});`
-      : tagFromProp
-        ? `  const Component = asElement(${tagFromProp});`
+      : tagExpr
+        ? `  const Component = asElement(${tagExpr});`
         : null;
 
   const helperBlock = [
     tagMapLine,
+    resolvedTagLine,
+    isVoidResolvedLine,
     componentLine,
     hasDisabled && hasAs ? `  const isButton = Component === "button";` : null,
     inactiveExpr ? `  const inactive = ${inactiveExpr};` : null,
@@ -108,7 +147,7 @@ export function renderAtomicReactWrapper(
     `      {...rest}`,
     `      ref={ref}`,
     `      className={mergedClassName}`,
-    renderDataAttrs(spec, responsiveProps, hasLoading) || null,
+    renderDataAttrs(spec, responsiveProps, hasLoading, booleanStateProps) || null,
     renderStateAttrs(hasAs, hasDisabled, hasLoading) || null,
   ]
     .filter((l): l is string => l !== null && l !== "")
@@ -130,7 +169,6 @@ export function renderAtomicReactWrapper(
   // Void elements (hr, img, input, br, …) cannot have children — emit a
   // self-closing JSX form and skip the body. Slot/loading state on a void
   // spec is a spec authoring error and is not validated here.
-  const isVoid = spec.element ? isVoidElement(spec.element) : false;
   const innerBody = isVoid ? "" : renderBody(spec, slots, hasLoading);
   const bodyBlock =
     !isVoid && spec.kind === "atomic" && spec.slotElement
@@ -168,9 +206,20 @@ export function renderAtomicReactWrapper(
   const biomeIgnore = isVoid && spec.element ? VOID_ELEMENT_BIOME_IGNORES[spec.element] : undefined;
   const biomeIgnoreLine = biomeIgnore ? `    // biome-ignore ${biomeIgnore}\n` : "";
 
+  const indent = (text: string, prefix: string): string =>
+    text
+      .split("\n")
+      .map((line) => (line.length > 0 ? `${prefix}${line}` : line))
+      .join("\n");
+
   const renderElement = isVoid
     ? `${biomeIgnoreLine}    <${componentTag}\n${attrBlock}\n    />`
-    : `    <${componentTag}\n${attrBlock}\n    >\n${bodyBlock}\n    </${componentTag}>`;
+    : isMixedVoid
+      ? // Runtime branch on the resolved tag's void-ness: void tag → self-closing
+        // (children rejected by HTML); non-void tag → with-children, where Slot
+        // may have replaced Component when `asChild` is true.
+        `    isVoidResolved ? (\n      <${componentTag}\n${indent(attrBlock, "  ")}\n      />\n    ) : (\n      <${componentTag}\n${indent(attrBlock, "  ")}\n      >\n${indent(bodyBlock, "  ")}\n      </${componentTag}>\n    )`
+      : `    <${componentTag}\n${attrBlock}\n    >\n${bodyBlock}\n    </${componentTag}>`;
 
   return `"use client";
 

--- a/scripts/codegen/src/generators/gen-tests/_shared/fixture-bodies.ts
+++ b/scripts/codegen/src/generators/gen-tests/_shared/fixture-bodies.ts
@@ -1,9 +1,11 @@
-import { isVoidElement } from "../../../lib/html-void-elements.ts";
+import { specVoidStatus } from "../../../lib/html-void-elements.ts";
 import type { Spec } from "../../gen-contract.ts";
 import { jsLiteral, jsxAttr, quote, splitProps } from "./printers.ts";
 
+// `mixed` elementByProp maps render children on their non-void branch; only
+// fully-void specs use the self-closing fixture form.
 function isVoidAtomic(spec: Spec): boolean {
-  return spec.kind === "atomic" && !!spec.element && isVoidElement(spec.element);
+  return spec.kind === "atomic" && specVoidStatus(spec) === "all";
 }
 
 export function renderReactFixtureBody(

--- a/scripts/codegen/src/generators/gen-vue/_shared/attrs.test.ts
+++ b/scripts/codegen/src/generators/gen-vue/_shared/attrs.test.ts
@@ -19,31 +19,37 @@ describe("renderAttrEntries", () => {
       variants: { solid: { description: "" } },
       intents: { primary: { description: "" } },
     });
-    const out = renderAttrEntries(spec, [], false, false, false);
+    const out = renderAttrEntries(spec, [], false, false, false, []);
     expect(out).toContain(`"data-variant": variant,`);
     expect(out).toContain(`"data-intent": intent,`);
   });
 
   test("spreads `responsiveDataAttrs(name, name)` per responsive prop", () => {
-    const out = renderAttrEntries(atomicSpec(), ["size"], false, false, false);
+    const out = renderAttrEntries(atomicSpec(), ["size"], false, false, false, []);
     expect(out).toContain(`...responsiveDataAttrs("size", size),`);
   });
 
   test("emits both `disabled` and `aria-disabled` branches when `as` is present", () => {
-    const out = renderAttrEntries(atomicSpec(), [], false, true, true);
+    const out = renderAttrEntries(atomicSpec(), [], false, true, true, []);
     expect(out).toContain("isButton.value ? inactive.value : undefined,");
     expect(out).toContain(`"aria-disabled": !isButton.value && inactive.value`);
   });
 
   test("falls back to the bare `disabled: inactive.value` line without `as`", () => {
-    const out = renderAttrEntries(atomicSpec(), [], false, true, false);
+    const out = renderAttrEntries(atomicSpec(), [], false, true, false, []);
     expect(out).toContain("disabled: inactive.value,");
     expect(out).not.toContain("isButton.value");
   });
 
   test("includes the loading + aria-busy pair when hasLoading is true", () => {
-    const out = renderAttrEntries(atomicSpec(), [], true, false, false);
+    const out = renderAttrEntries(atomicSpec(), [], true, false, false, []);
     expect(out).toContain(`"data-loading": loading ? "true" : undefined,`);
     expect(out).toContain(`"aria-busy": loading ? "true" : undefined,`);
+  });
+
+  test("emits a `data-{name}` entry for each boolean state prop", () => {
+    const out = renderAttrEntries(atomicSpec(), [], false, false, false, ["decorative", "compact"]);
+    expect(out).toContain(`"data-decorative": decorative ? "true" : undefined,`);
+    expect(out).toContain(`"data-compact": compact ? "true" : undefined,`);
   });
 });

--- a/scripts/codegen/src/generators/gen-vue/_shared/attrs.ts
+++ b/scripts/codegen/src/generators/gen-vue/_shared/attrs.ts
@@ -3,20 +3,23 @@ import { quote } from "./type-printer.ts";
 
 /** Emit the entries of the `attrs` computed object for an atomic wrapper.
  *  Combines variant/intent data-attrs, responsive data-attr spreads, the
- *  loading flag, and the disabled/aria-disabled pair (whose shape depends on
- *  whether the element is polymorphic via `as`). */
+ *  loading flag, per-prop `data-*` flags for boolean state props, and the
+ *  disabled/aria-disabled pair (whose shape depends on whether the element
+ *  is polymorphic via `as`). */
 export function renderAttrEntries(
   spec: Spec,
   responsiveProps: string[],
   hasLoading: boolean,
   hasDisabled: boolean,
   hasAs: boolean,
+  booleanStateProps: string[],
 ): string {
   return [
     spec.variants ? `  "data-variant": variant,` : null,
     spec.intents ? `  "data-intent": intent,` : null,
     ...responsiveProps.map((name) => `  ...responsiveDataAttrs(${quote(name)}, ${name}),`),
     hasLoading ? `  "data-loading": loading ? "true" : undefined,` : null,
+    ...booleanStateProps.map((name) => `  "data-${name}": ${name} ? "true" : undefined,`),
     hasDisabled && hasAs ? `  disabled: isButton.value ? inactive.value : undefined,` : null,
     hasDisabled && hasAs
       ? `  "aria-disabled": !isButton.value && inactive.value ? "true" : undefined,`

--- a/scripts/codegen/src/generators/gen-vue/kinds/atomic.test.ts
+++ b/scripts/codegen/src/generators/gen-vue/kinds/atomic.test.ts
@@ -143,5 +143,79 @@ describe("renderAtomicVueWrapper", () => {
       const out = renderAtomicVueWrapper(atomicSpec({ element: "div" }), {});
       expect(out).not.toContain("const tagMap");
     });
+
+    describe("mixed elementByProp.map (void + non-void)", () => {
+      function dividerSpec(extra: Partial<Spec> = {}): Spec {
+        return atomicSpec({
+          name: "divider",
+          elementByProp: {
+            prop: "orientation",
+            map: { horizontal: "hr", vertical: "div" },
+          },
+          props: {
+            orientation: prop({
+              type: "string",
+              values: ["horizontal", "vertical"],
+              default: "horizontal",
+            }),
+          },
+          ...extra,
+        });
+      }
+
+      test("emits resolvedTag + isVoidResolved computeds derived from the tagMap", () => {
+        const out = renderAtomicVueWrapper(dividerSpec(), {});
+        expect(out).toContain(`const tagMap = { "horizontal": "hr", "vertical": "div" } as const;`);
+        expect(out).toContain(
+          `const resolvedTag = computed(() => tagMap[orientation ?? 'horizontal']);`,
+        );
+        expect(out).toContain(`const isVoidResolved = computed(() => resolvedTag.value === 'hr');`);
+      });
+
+      test("branches the template on isVoidResolved with v-if / v-else", () => {
+        const out = renderAtomicVueWrapper(dividerSpec(), {});
+        expect(out).toContain(`<template v-if="isVoidResolved">`);
+        expect(out).toContain(`<template v-else>`);
+        expect(out).toContain(`<component :is="resolvedTag" class="t-divider" v-bind="attrs" />`);
+        expect(out).toContain(`<component :is="resolvedTag" class="t-divider" v-bind="attrs">`);
+        expect(out).toContain("</component>");
+      });
+
+      test("guards asChild on the non-void branch so Slot never wraps a void tag", () => {
+        const out = renderAtomicVueWrapper(dividerSpec({ polymorphic: "asChild" }), {});
+        expect(out).toContain(`asChild && !isVoidResolved ? Slot : resolvedTag`);
+      });
+    });
+
+    describe("boolean state props", () => {
+      test("emits a `data-{name}` entry on the attrs object for boolean state props", () => {
+        const out = renderAtomicVueWrapper(
+          atomicSpec({
+            element: "div",
+            props: {
+              decorative: prop({ type: "boolean", description: "" }),
+            },
+          }),
+          {},
+        );
+        expect(out).toContain(`"data-decorative": decorative ? "true" : undefined,`);
+      });
+
+      test("does not emit a data-* entry for the elementByProp controlling prop", () => {
+        const out = renderAtomicVueWrapper(
+          atomicSpec({
+            elementByProp: {
+              prop: "ordered",
+              map: { false: "ul", true: "ol" },
+            },
+            props: {
+              ordered: prop({ type: "boolean", description: "" }),
+            },
+          }),
+          {},
+        );
+        expect(out).not.toContain(`"data-ordered":`);
+      });
+    });
   });
 });

--- a/scripts/codegen/src/generators/gen-vue/kinds/atomic.ts
+++ b/scripts/codegen/src/generators/gen-vue/kinds/atomic.ts
@@ -1,6 +1,6 @@
 import { collectSlots } from "../../../lib/collect-slots.ts";
 import { renderEnumType } from "../../../lib/enum-primitives.ts";
-import { isVoidElement } from "../../../lib/html-void-elements.ts";
+import { specVoidStatus, voidTagsInMap } from "../../../lib/html-void-elements.ts";
 import { renderComponentJsDoc, vueJsDocFlavor } from "../../../lib/jsdoc-shape.ts";
 import { pascalCase } from "../../../lib/pascal-case.ts";
 import type { Spec } from "../../gen-contract.ts";
@@ -41,6 +41,22 @@ export function renderAtomicVueWrapper(
       .map(([n]) => n),
   ];
 
+  // Boolean spec props become `data-{name}` flags on the root element. The
+  // controlling prop for `elementByProp`, the `disabled` / `loading` pair,
+  // controllable booleans, and responsive booleans are emitted by their
+  // dedicated paths and are excluded here.
+  const booleanStateProps: string[] = Object.entries(propMap)
+    .filter(
+      ([name, d]) =>
+        d.type === "boolean" &&
+        d.responsive !== true &&
+        d.pattern !== "controllable" &&
+        name !== "disabled" &&
+        name !== "loading" &&
+        name !== elementByProp?.prop,
+    )
+    .map(([name]) => name);
+
   const inactiveExpr = [hasDisabled ? "disabled" : null, hasLoading ? "loading" : null]
     .filter((p): p is string => p !== null)
     .join(" || ");
@@ -57,12 +73,28 @@ export function renderAtomicVueWrapper(
     elementByProp && elementByPropDefault !== null
       ? `tagMap[${elementByProp.prop} ?? '${elementByPropDefault}']`
       : null;
+
+  const voidStatus = specVoidStatus(spec);
+  const isVoid = voidStatus === "all";
+  const isMixedVoid = voidStatus === "mixed";
+
+  // For a `mixed` elementByProp map (some void, some non-void), the rendered
+  // tag's void-ness is only known at runtime. Resolve the tag into a computed
+  // and emit a parallel `isVoidResolved` computed so the template can switch
+  // between self-closing and with-children variants via v-if/v-else.
+  const resolvedTagExpr = isMixedVoid ? tagFromProp : null;
+
+  // For a `mixed` map the v-bind `:is` references the resolved tag computed
+  // (`resolvedTag`) rather than re-evaluating the tagMap lookup inline.
+  const tagBindExpr = isMixedVoid ? "resolvedTag" : tagFromProp;
   // Single-quoted literal so the expression nests inside v-bind's double-quoted
   // attribute (`:is="asChild ? Slot : 'a'"`); JSON.stringify would yield "a"
   // which collides with the surrounding double quotes.
   const polymorphicIsExpr = isPolymorphic
-    ? `asChild ? Slot : ${tagFromProp ?? `'${spec.element ?? "div"}'`}`
-    : (tagFromProp ?? null);
+    ? isMixedVoid
+      ? `asChild && !isVoidResolved ? Slot : ${tagBindExpr ?? `'${spec.element ?? "div"}'`}`
+      : `asChild ? Slot : ${tagBindExpr ?? `'${spec.element ?? "div"}'`}`
+    : (tagBindExpr ?? null);
 
   const tagMapLine = elementByProp
     ? `const tagMap = { ${Object.entries(elementByProp.map)
@@ -70,15 +102,38 @@ export function renderAtomicVueWrapper(
         .join(", ")} } as const;`
     : null;
 
+  const resolvedTagComputed =
+    isMixedVoid && resolvedTagExpr
+      ? `const resolvedTag = computed(() => ${resolvedTagExpr});`
+      : null;
+  const voidCheckExpr =
+    isMixedVoid && elementByProp
+      ? voidTagsInMap(elementByProp.map)
+          .map((tag) => `resolvedTag.value === '${tag}'`)
+          .join(" || ")
+      : null;
+  const isVoidResolvedComputed = voidCheckExpr
+    ? `const isVoidResolved = computed(() => ${voidCheckExpr});`
+    : null;
+
   const helperLines = [
     tagMapLine,
+    resolvedTagComputed,
+    isVoidResolvedComputed,
     hasDisabled && hasAs ? `const isButton = computed(() => as === "button");` : null,
     inactiveExpr ? `const inactive = computed(() => ${inactiveExpr});` : null,
   ]
     .filter((l): l is string => l !== null)
     .join("\n");
 
-  const attrEntries = renderAttrEntries(spec, responsiveProps, hasLoading, hasDisabled, hasAs);
+  const attrEntries = renderAttrEntries(
+    spec,
+    responsiveProps,
+    hasLoading,
+    hasDisabled,
+    hasAs,
+    booleanStateProps,
+  );
 
   const propEnumTypes = Object.entries(spec.props ?? {})
     .filter(([, d]) => Array.isArray(d.values) && d.values.length > 0)
@@ -96,13 +151,30 @@ export function renderAtomicVueWrapper(
   // Void elements (hr, img, input, br, …) cannot have children — emit a
   // self-closing template form and skip the body. Slot/loading state on a
   // void spec is a spec authoring error and is not validated here.
-  const isVoid = spec.element ? isVoidElement(spec.element) : false;
   const innerBody = isVoid ? "" : renderBody(spec, slots, hasLoading);
   const bodyBlock =
     !isVoid && spec.kind === "atomic" && spec.slotElement
       ? `  <${spec.slotElement}>\n${innerBody}\n  </${spec.slotElement}>`
       : innerBody;
   const isExpr = polymorphicIsExpr ?? (hasAs ? "as" : null);
+
+  // For mixed-void maps the template branches at render time on
+  // `isVoidResolved`: the void branch self-closes, the non-void branch renders
+  // children. Both branches resolve the tag via `:is` so consumer-supplied
+  // attrs land on the correct element.
+  const mixedTemplate = isMixedVoid
+    ? (() => {
+        const opener = (closing: "self" | "open") =>
+          isExpr
+            ? `<component :is="${isExpr}" class="${rootClass}" v-bind="attrs"${closing === "self" ? " />" : ">"}`
+            : `<${componentTag} class="${rootClass}" v-bind="attrs"${closing === "self" ? " />" : ">"}`;
+        const closer = isExpr ? `</component>` : `</${componentTag}>`;
+        const voidLine = `  <template v-if="isVoidResolved">\n    ${opener("self")}\n  </template>`;
+        const nonVoidLine = `  <template v-else>\n    ${opener("open")}\n${bodyBlock}\n    ${closer}\n  </template>`;
+        return `${voidLine}\n${nonVoidLine}`;
+      })()
+    : null;
+
   const rootOpen = isVoid
     ? isExpr
       ? `<component :is="${isExpr}" class="${rootClass}" v-bind="attrs" />`
@@ -122,6 +194,14 @@ export function renderAtomicVueWrapper(
   ]
     .filter((l): l is string => l !== null)
     .join("\n");
+
+  const templateBody = mixedTemplate
+    ? mixedTemplate
+    : isVoid
+      ? `  ${rootOpen}`
+      : `  ${rootOpen}
+${bodyBlock}
+  ${rootClose}`;
 
   return `<!-- AUTOGENERATED by gen-vue. Do not edit. -->
 <!-- Source: specs/${spec.name}.yaml -->
@@ -144,13 +224,7 @@ ${attrEntries}
 </script>
 
 <template>
-${
-  isVoid
-    ? `  ${rootOpen}`
-    : `  ${rootOpen}
-${bodyBlock}
-  ${rootClose}`
-}
+${templateBody}
 </template>
 `;
 }

--- a/scripts/codegen/src/lib/html-void-elements.test.ts
+++ b/scripts/codegen/src/lib/html-void-elements.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { HTML_VOID_ELEMENTS, isVoidElement } from "./html-void-elements.ts";
+import {
+  HTML_VOID_ELEMENTS,
+  isVoidElement,
+  specVoidStatus,
+  voidTagsInMap,
+} from "./html-void-elements.ts";
 
 describe("isVoidElement", () => {
   it("returns true for the canonical void tags", () => {
@@ -24,5 +29,54 @@ describe("isVoidElement", () => {
 describe("HTML_VOID_ELEMENTS", () => {
   it("contains exactly the 14 WHATWG void elements", () => {
     expect(HTML_VOID_ELEMENTS.size).toBe(14);
+  });
+});
+
+describe("specVoidStatus", () => {
+  it("returns 'never' when no element or elementByProp is set", () => {
+    expect(specVoidStatus({})).toBe("never");
+  });
+
+  it("returns 'all' when spec.element is void", () => {
+    expect(specVoidStatus({ element: "hr" })).toBe("all");
+    expect(specVoidStatus({ element: "img" })).toBe("all");
+  });
+
+  it("returns 'never' when spec.element is non-void", () => {
+    expect(specVoidStatus({ element: "div" })).toBe("never");
+  });
+
+  it("returns 'all' when every elementByProp.map value is void", () => {
+    expect(specVoidStatus({ elementByProp: { prop: "kind", map: { a: "hr", b: "br" } } })).toBe(
+      "all",
+    );
+  });
+
+  it("returns 'never' when every elementByProp.map value is non-void", () => {
+    expect(
+      specVoidStatus({ elementByProp: { prop: "level", map: { "1": "h1", "2": "h2" } } }),
+    ).toBe("never");
+  });
+
+  it("returns 'mixed' when elementByProp.map has both void and non-void values", () => {
+    expect(
+      specVoidStatus({
+        elementByProp: { prop: "orientation", map: { horizontal: "hr", vertical: "div" } },
+      }),
+    ).toBe("mixed");
+  });
+
+  it("returns 'never' on an empty elementByProp.map", () => {
+    expect(specVoidStatus({ elementByProp: { prop: "x", map: {} } })).toBe("never");
+  });
+});
+
+describe("voidTagsInMap", () => {
+  it("returns the distinct void tags from the map, preserving order", () => {
+    expect(voidTagsInMap({ a: "hr", b: "div", c: "br", d: "hr" })).toEqual(["hr", "br"]);
+  });
+
+  it("returns an empty array when the map has no void values", () => {
+    expect(voidTagsInMap({ "1": "h1", "2": "h2" })).toEqual([]);
   });
 });

--- a/scripts/codegen/src/lib/html-void-elements.ts
+++ b/scripts/codegen/src/lib/html-void-elements.ts
@@ -25,3 +25,50 @@ export const HTML_VOID_ELEMENTS = new Set([
 export function isVoidElement(tag: string): boolean {
   return HTML_VOID_ELEMENTS.has(tag.toLowerCase());
 }
+
+/** Subset of a spec the void-status check inspects. */
+type SpecRootTag = {
+  element?: string;
+  elementByProp?: { prop: string; map: Record<string, string> };
+};
+
+/**
+ * Classify an atomic spec's root tag by its void-ness:
+ * - `never`: no void branches (renders with children)
+ * - `all`: every possible root tag is void (self-closing always, `children?: never`)
+ * - `mixed`: `elementByProp.map` has both void and non-void branches (runtime-branched)
+ *
+ * `spec.element` is checked first; with `elementByProp` the result is derived
+ * from the map's values.
+ */
+export function specVoidStatus(spec: SpecRootTag): "never" | "all" | "mixed" {
+  if (spec.element) {
+    return isVoidElement(spec.element) ? "all" : "never";
+  }
+  if (spec.elementByProp) {
+    const tags = Object.values(spec.elementByProp.map);
+    if (tags.length === 0) return "never";
+    const voidCount = tags.filter((t) => isVoidElement(t)).length;
+    if (voidCount === 0) return "never";
+    if (voidCount === tags.length) return "all";
+    return "mixed";
+  }
+  return "never";
+}
+
+/**
+ * Distinct void tag values from `elementByProp.map`, preserving first
+ * occurrence. Used by generators to emit the `isVoidResolved` runtime check
+ * for `mixed` specs (e.g. `resolved === 'hr' || resolved === 'br'`).
+ */
+export function voidTagsInMap(map: Record<string, string>): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const tag of Object.values(map)) {
+    if (!isVoidElement(tag)) continue;
+    if (seen.has(tag)) continue;
+    seen.add(tag);
+    out.push(tag);
+  }
+  return out;
+}

--- a/scripts/codegen/src/lib/jsdoc-shape.ts
+++ b/scripts/codegen/src/lib/jsdoc-shape.ts
@@ -1,5 +1,5 @@
 import type { FlatSpec } from "./flatten.ts";
-import { isVoidElement } from "./html-void-elements.ts";
+import { specVoidStatus } from "./html-void-elements.ts";
 
 /**
  * Minimal shape of a spec example used by JSDoc rendering. Matches
@@ -92,7 +92,11 @@ export function renderComponentJsDoc(spec: FlatSpec, Name: string, flavor: JsDoc
   const examples = (spec.examples ?? []).slice(0, 3);
   const isCompositeList =
     spec.kind === "composite" && Array.isArray(spec.repeating) && spec.repeating.length > 0;
-  const isVoidAtomic = spec.kind === "atomic" && !!spec.element && isVoidElement(spec.element);
+  // Atomic specs whose root is a void HTML element — directly via `element`
+  // or via every branch of an `elementByProp` map — emit self-closing example
+  // tags. Mixed maps (some void, some non-void) keep the open-tag form so
+  // the non-void branches still show a child label in the snippet.
+  const isVoidAtomic = spec.kind === "atomic" && specVoidStatus(spec) === "all";
   const selfClosing = isCompositeList || isVoidAtomic;
   const lines: string[] = ["/**"];
   if (description) lines.push(` * ${description}`);


### PR DESCRIPTION
## What

Extend atomic codegen with three interlocking capabilities required by Divider (#903):

- `specVoidStatus(spec)` classifies a spec's root tag as `never` / `all` / `mixed`, walking `elementByProp.map` instead of inspecting `element` alone.
- `mixed` maps (one void branch + one non-void branch, e.g. `hr` / `div`) render a runtime-branched JSX / template: void resolved tag → self-closing; non-void resolved tag → with-children.
- `asChild` on a `mixed` map applies Slot only on the non-void branch — the void path renders straight HTML so Slot never wraps a void tag.
- Boolean spec props (e.g. `decorative: boolean`) emit `data-{name}` flags on the root. The `elementByProp` controller, `disabled` / `loading`, controllable booleans, and responsive booleans keep their dedicated paths.

## Why

Wave 1 dispatch for Divider held out three substrate gaps: void+non-void `elementByProp` detection, runtime asChild gating per branch, and boolean state attribute emission. Closing #924 unblocks Divider (#903).

## Test plan

- `pnpm test` — 1302 tests pass (incl. 13 new unit tests under `gen-react/kinds/atomic.test.ts`, `gen-vue/kinds/atomic.test.ts`, `lib/html-void-elements.test.ts`).
- `pnpm typecheck`, `pnpm lint` — clean.
- `pnpm gen` regenerates existing atomic specs with no behavioral diff (no current spec hits the new paths).
- Throwaway fixture specs in the unit tests exercise both branches of a mixed `hr`/`div` map plus boolean state prop emission.

## Out of scope

- Heterogeneous non-void `elementByProp` map polymorphism (Text-style `span` / `p` / `em` `as` prop combos).
- Boolean-typed `elementByProp.prop` (List's `ordered: boolean`).
- Divider spec rewrite (separate PR on top of this).
- Semantic-check rejection of `loading: boolean` on void / mixed-void specs.

Closes #924