### PR TITLE
fix(docs): make sidenav scrollable when items exceed viewport

### DIFF
--- a/apps/docs/src/layouts/Base.astro
+++ b/apps/docs/src/layouts/Base.astro
@@ -48,6 +48,8 @@ const isDev = import.meta.env.DEV;
         position: sticky;
         inset-block-start: 0;
         block-size: 100vh;
+        overflow-y: auto;
+        overscroll-behavior: contain;
       }
 
       .sidenav h2 {


### PR DESCRIPTION
## What

Adds `overflow-y: auto` + `overscroll-behavior: contain` to `.sidenav` in `apps/docs/src/layouts/Base.astro`.

## Why

The sticky sidenav has `block-size: 100vh` and no `overflow-y`. With 19 components plus Home / Themes / the dev grid-toggle button, the bottom items get clipped on shorter viewports — and no scrollbar appears, so they're undiscoverable.

`overscroll-behavior: contain` stops the scroll from chaining into the main content once the sidenav reaches its top/bottom edge.

## Test plan

- [ ] `pnpm dev` (docs), resize to a short window, confirm sidebar scrolls and every component link is reachable.
- [ ] At tall window heights, the sidebar still doesn't scroll (content fits, no scrollbar).
- [ ] Scrolling at the sidebar's edges does not jump the main content area.

## Out of scope

- Replacing the temporary `<aside class="sidenav">` shell with the upcoming Sidebar primitive.
- Visual restyle of the scrollbar.

Closes #942