### PR TITLE
feat(codegen): emit role and aria props on atomic root from spec.a11y

### DIFF
--- a/.changeset/944-codegen-atomic-a11y.md
+++ b/.changeset/944-codegen-atomic-a11y.md
@@ -1,0 +1,6 @@
+---
+"@teseor/react": minor
+"@teseor/vue": minor
+---
+
+Atomic codegen now emits `role`, `aria-{prop}` (per `spec.a11y.ariaProps`), and a `decorativeProp`-driven `aria-hidden` / `role="none"` toggle from the spec's `a11y` block. Existing specs with `a11y.role` (`Button`) gain a static `role` attr on the rendered root. `Cluster` and `Stack` drop their docs-only `role: generic` entries.

--- a/apps/docs/src/pages/components/cluster.astro
+++ b/apps/docs/src/pages/components/cluster.astro
@@ -89,10 +89,6 @@ import Base from "../../layouts/Base.astro";
       </table>
     </section>
     <section class="t-stack" data-gap="3">
-      <h2>Accessibility</h2>
-      <p>Role: <Code>generic</Code></p>
-    </section>
-    <section class="t-stack" data-gap="3">
       <h2>Bundle size</h2>
       <table>
         <thead><tr><th>Artifact</th><th>Raw</th><th>Gzip</th><th>Brotli</th></tr></thead>

--- a/apps/docs/src/pages/components/stack.astro
+++ b/apps/docs/src/pages/components/stack.astro
@@ -80,10 +80,6 @@ import Base from "../../layouts/Base.astro";
       </table>
     </section>
     <section class="t-stack" data-gap="3">
-      <h2>Accessibility</h2>
-      <p>Role: <Code>generic</Code></p>
-    </section>
-    <section class="t-stack" data-gap="3">
       <h2>Bundle size</h2>
       <table>
         <thead><tr><th>Artifact</th><th>Raw</th><th>Gzip</th><th>Brotli</th></tr></thead>

--- a/packages/react/src/Button.tsx
+++ b/packages/react/src/Button.tsx
@@ -87,6 +87,7 @@ export function Button(props: ButtonProps) {
       {...rest}
       ref={ref}
       className={mergedClassName}
+      role="button"
       data-variant={variant}
       data-intent={intent}
       {...responsiveDataAttrs("size", size)}

--- a/packages/vue/src/Button.vue
+++ b/packages/vue/src/Button.vue
@@ -68,6 +68,7 @@ const isButton = computed(() => as === "button");
 const inactive = computed(() => disabled || loading);
 
 const attrs = computed(() => ({
+  role: "button",
   "data-variant": variant,
   "data-intent": intent,
   ...responsiveDataAttrs("size", size),

--- a/scripts/codegen/__tests__/__snapshots__/gen-docs.test.ts.snap
+++ b/scripts/codegen/__tests__/__snapshots__/gen-docs.test.ts.snap
@@ -263,10 +263,6 @@ import Base from "../../layouts/Base.astro";
         </tbody>
       </table>
     </section>
-    <section class="t-stack" data-gap="3">
-      <h2>Accessibility</h2>
-      <p>Role: <Code>generic</Code></p>
-    </section>
   </main>
 </Base>
 "
@@ -353,10 +349,6 @@ import Base from "../../layouts/Base.astro";
         <tr><td><Code>--t-stack-align</Code></td><td><Code>stretch</Code></td><td>Default inline-axis alignment when \`align\` is unset; overridable via \`--t-stack-align\`.</td></tr>
         </tbody>
       </table>
-    </section>
-    <section class="t-stack" data-gap="3">
-      <h2>Accessibility</h2>
-      <p>Role: <Code>generic</Code></p>
     </section>
   </main>
 </Base>

--- a/scripts/codegen/__tests__/__snapshots__/gen-react.test.ts.snap
+++ b/scripts/codegen/__tests__/__snapshots__/gen-react.test.ts.snap
@@ -90,6 +90,7 @@ export function Button(props: ButtonProps) {
       {...rest}
       ref={ref}
       className={mergedClassName}
+      role="button"
       data-variant={variant}
       data-intent={intent}
       {...responsiveDataAttrs("size", size)}

--- a/scripts/codegen/__tests__/__snapshots__/gen-vue.test.ts.snap
+++ b/scripts/codegen/__tests__/__snapshots__/gen-vue.test.ts.snap
@@ -71,6 +71,7 @@ const isButton = computed(() => as === "button");
 const inactive = computed(() => disabled || loading);
 
 const attrs = computed(() => ({
+  role: "button",
   "data-variant": variant,
   "data-intent": intent,
   ...responsiveDataAttrs("size", size),

--- a/scripts/codegen/src/generators/gen-docs/_shared/sections.ts
+++ b/scripts/codegen/src/generators/gen-docs/_shared/sections.ts
@@ -358,6 +358,8 @@ export function renderTokens(spec: DocsSpec): string {
 
 export function renderA11y(spec: DocsSpec): string {
   const role = spec.a11y?.role;
+  const ariaProps = spec.a11y?.ariaProps ?? [];
+  const decorativeProp = spec.a11y?.decorativeProp;
   const declaredKeyboard: Array<[string, string]> = Object.entries(spec.a11y?.keyboard ?? {});
   // Spec-declared rows win when the key collides — a spec that goes out of its
   // way to redeclare `Escape` or `Outside pointer-down` keeps its wording, and
@@ -367,10 +369,20 @@ export function renderA11y(spec: DocsSpec): string {
     ? OVERLAY_KEYBOARD_ROWS.filter(([key]) => !declaredKeys.has(key))
     : [];
   const keyboard = [...declaredKeyboard, ...overlayKeyboard];
-  if (!role && keyboard.length === 0) return "";
+  if (!role && keyboard.length === 0 && ariaProps.length === 0 && !decorativeProp) return "";
   const lines: string[] = [];
   if (role) {
     lines.push(`      <p>Role: <Code>${esc(role)}</Code></p>`);
+  }
+  for (const propName of ariaProps) {
+    lines.push(
+      `      <p>Forwards <Code>aria-${esc(propName)}</Code> from the <Code>${esc(propName)}</Code> prop.</p>`,
+    );
+  }
+  if (decorativeProp) {
+    lines.push(
+      `      <p>Set <Code>${esc(decorativeProp)}</Code> to remove the element from the accessibility tree (<Code>role="none"</Code> + <Code>aria-hidden="true"</Code>).</p>`,
+    );
   }
   if (keyboard.length > 0) {
     // Header is `Interaction`, not `Key` — overlay specs inject a

--- a/scripts/codegen/src/generators/gen-react/_shared/attrs.test.ts
+++ b/scripts/codegen/src/generators/gen-react/_shared/attrs.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "vitest";
 import type { Spec } from "../../gen-contract.ts";
-import { renderDataAttrs, renderStateAttrs } from "./attrs.ts";
+import { renderA11yAttrs, renderDataAttrs, renderStateAttrs } from "./attrs.ts";
 
 function atomicSpec(overrides: Partial<Spec> = {}): Spec {
   return {
@@ -65,5 +65,32 @@ describe("renderStateAttrs", () => {
 
   test("renders an empty string when there is no disabled or loading state", () => {
     expect(renderStateAttrs(false, false, false)).toBe("");
+  });
+});
+
+describe("renderA11yAttrs", () => {
+  test("emits a static role when only role is set", () => {
+    expect(renderA11yAttrs("separator", [], undefined)).toBe(`      role="separator"`);
+  });
+
+  test("emits aria-{prop}={prop} per entry in ariaProps", () => {
+    const out = renderA11yAttrs("separator", ["orientation"], undefined);
+    expect(out).toContain(`aria-orientation={orientation}`);
+  });
+
+  test("toggles role to none and adds aria-hidden when decorativeProp is set", () => {
+    const out = renderA11yAttrs("separator", [], "decorative");
+    expect(out).toContain(`role={decorative === true ? "none" : "separator"}`);
+    expect(out).toContain(`aria-hidden={decorative === true ? "true" : undefined}`);
+  });
+
+  test("emits only aria-hidden when decorativeProp is set without a role", () => {
+    const out = renderA11yAttrs(undefined, [], "decorative");
+    expect(out).not.toContain(`role=`);
+    expect(out).toContain(`aria-hidden={decorative === true ? "true" : undefined}`);
+  });
+
+  test("renders an empty string when nothing is declared", () => {
+    expect(renderA11yAttrs(undefined, [], undefined)).toBe("");
   });
 });

--- a/scripts/codegen/src/generators/gen-react/_shared/attrs.ts
+++ b/scripts/codegen/src/generators/gen-react/_shared/attrs.ts
@@ -24,6 +24,30 @@ export function renderDataAttrs(
     .join("\n");
 }
 
+/** Emit the JSX-attribute lines for the spec's a11y block: a static `role`
+ *  (overridden to `"none"` when `decorativeProp` is true), an `aria-{name}`
+ *  per entry in `ariaProps`, and `aria-hidden` when `decorativeProp` is
+ *  declared and true. Static-empty when no a11y block is set. */
+export function renderA11yAttrs(
+  role: string | undefined,
+  ariaProps: readonly string[],
+  decorativeProp: string | undefined,
+): string {
+  return [
+    role !== undefined && decorativeProp !== undefined
+      ? `      role={${decorativeProp} === true ? "none" : ${quote(role)}}`
+      : role !== undefined
+        ? `      role=${quote(role)}`
+        : null,
+    ...ariaProps.map((name) => `      aria-${name}={${name}}`),
+    decorativeProp !== undefined
+      ? `      aria-hidden={${decorativeProp} === true ? "true" : undefined}`
+      : null,
+  ]
+    .filter((line): line is string => line !== null)
+    .join("\n");
+}
+
 /** Emit the JSX-attribute lines for the disabled / aria-disabled / aria-busy
  *  state attrs. The disabled pair branches on whether the element is
  *  polymorphic via `as` — buttons get `disabled`, anything else gets

--- a/scripts/codegen/src/generators/gen-react/kinds/atomic.test.ts
+++ b/scripts/codegen/src/generators/gen-react/kinds/atomic.test.ts
@@ -320,5 +320,47 @@ describe("renderAtomicReactWrapper", () => {
         expect(out).not.toContain(`data-compact={compact === true ?`);
       });
     });
+
+    describe("a11y emission", () => {
+      test("emits a static role on the root from spec.a11y.role", () => {
+        const out = renderAtomicReactWrapper(
+          atomicSpec({ element: "div", a11y: { role: "separator" } }),
+          {},
+        );
+        expect(out).toContain(`role="separator"`);
+      });
+
+      test("forwards each ariaProps entry as `aria-{prop}={prop}`", () => {
+        const out = renderAtomicReactWrapper(
+          atomicSpec({
+            element: "div",
+            props: {
+              orientation: prop({
+                type: "string",
+                values: ["horizontal", "vertical"],
+                responsive: false,
+                description: "",
+              }),
+            },
+            a11y: { ariaProps: ["orientation"] },
+          }),
+          {},
+        );
+        expect(out).toContain(`aria-orientation={orientation}`);
+      });
+
+      test("toggles role to none and adds aria-hidden when decorativeProp is set", () => {
+        const out = renderAtomicReactWrapper(
+          atomicSpec({
+            element: "div",
+            props: { decorative: prop({ type: "boolean", description: "" }) },
+            a11y: { role: "separator", decorativeProp: "decorative" },
+          }),
+          {},
+        );
+        expect(out).toContain(`role={decorative === true ? "none" : "separator"}`);
+        expect(out).toContain(`aria-hidden={decorative === true ? "true" : undefined}`);
+      });
+    });
   });
 });

--- a/scripts/codegen/src/generators/gen-react/kinds/atomic.ts
+++ b/scripts/codegen/src/generators/gen-react/kinds/atomic.ts
@@ -4,7 +4,7 @@ import { specVoidStatus, voidTagsInMap } from "../../../lib/html-void-elements.t
 import { reactJsDocFlavor, renderComponentJsDoc } from "../../../lib/jsdoc-shape.ts";
 import { pascalCase } from "../../../lib/pascal-case.ts";
 import type { Spec } from "../../gen-contract.ts";
-import { renderDataAttrs, renderStateAttrs } from "../_shared/attrs.ts";
+import { renderA11yAttrs, renderDataAttrs, renderStateAttrs } from "../_shared/attrs.ts";
 import {
   renderDestructure,
   renderOwnProps,
@@ -143,10 +143,12 @@ export function renderAtomicReactWrapper(
     .filter((l): l is string => l !== null)
     .join("\n");
 
+  const a11y = spec.kind === "atomic" ? spec.a11y : undefined;
   const attrBlock = [
     `      {...rest}`,
     `      ref={ref}`,
     `      className={mergedClassName}`,
+    renderA11yAttrs(a11y?.role, a11y?.ariaProps ?? [], a11y?.decorativeProp) || null,
     renderDataAttrs(spec, responsiveProps, hasLoading, booleanStateProps) || null,
     renderStateAttrs(hasAs, hasDisabled, hasLoading) || null,
   ]

--- a/scripts/codegen/src/generators/gen-vue/_shared/attrs.test.ts
+++ b/scripts/codegen/src/generators/gen-vue/_shared/attrs.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "vitest";
 import type { Spec } from "../../gen-contract.ts";
-import { renderAttrEntries } from "./attrs.ts";
+import { renderA11yAttrEntries, renderAttrEntries } from "./attrs.ts";
 
 function atomicSpec(overrides: Partial<Spec> = {}): Spec {
   return {
@@ -51,5 +51,32 @@ describe("renderAttrEntries", () => {
     const out = renderAttrEntries(atomicSpec(), [], false, false, false, ["decorative", "compact"]);
     expect(out).toContain(`"data-decorative": decorative ? "true" : undefined,`);
     expect(out).toContain(`"data-compact": compact ? "true" : undefined,`);
+  });
+});
+
+describe("renderA11yAttrEntries", () => {
+  test("emits a static role when only role is set", () => {
+    expect(renderA11yAttrEntries("separator", [], undefined)).toBe(`  role: "separator",`);
+  });
+
+  test('emits "aria-{prop}": prop per entry in ariaProps', () => {
+    const out = renderA11yAttrEntries("separator", ["orientation"], undefined);
+    expect(out).toContain(`"aria-orientation": orientation,`);
+  });
+
+  test("toggles role to none and adds aria-hidden when decorativeProp is set", () => {
+    const out = renderA11yAttrEntries("separator", [], "decorative");
+    expect(out).toContain(`role: decorative ? "none" : "separator",`);
+    expect(out).toContain(`"aria-hidden": decorative ? "true" : undefined,`);
+  });
+
+  test("emits only aria-hidden when decorativeProp is set without a role", () => {
+    const out = renderA11yAttrEntries(undefined, [], "decorative");
+    expect(out).not.toContain(`role:`);
+    expect(out).toContain(`"aria-hidden": decorative ? "true" : undefined,`);
+  });
+
+  test("renders an empty string when nothing is declared", () => {
+    expect(renderA11yAttrEntries(undefined, [], undefined)).toBe("");
   });
 });

--- a/scripts/codegen/src/generators/gen-vue/_shared/attrs.ts
+++ b/scripts/codegen/src/generators/gen-vue/_shared/attrs.ts
@@ -1,6 +1,30 @@
 import type { Spec } from "../../gen-contract.ts";
 import { quote } from "./type-printer.ts";
 
+/** Emit the entries of the `attrs` computed object for the spec's a11y
+ *  block: a static `role` (overridden to `"none"` when `decorativeProp` is
+ *  true), an `aria-{name}` per entry in `ariaProps`, and `aria-hidden` when
+ *  `decorativeProp` is declared and true. */
+export function renderA11yAttrEntries(
+  role: string | undefined,
+  ariaProps: readonly string[],
+  decorativeProp: string | undefined,
+): string {
+  return [
+    role !== undefined && decorativeProp !== undefined
+      ? `  role: ${decorativeProp} ? "none" : ${quote(role)},`
+      : role !== undefined
+        ? `  role: ${quote(role)},`
+        : null,
+    ...ariaProps.map((name) => `  "aria-${name}": ${name},`),
+    decorativeProp !== undefined
+      ? `  "aria-hidden": ${decorativeProp} ? "true" : undefined,`
+      : null,
+  ]
+    .filter((line): line is string => line !== null)
+    .join("\n");
+}
+
 /** Emit the entries of the `attrs` computed object for an atomic wrapper.
  *  Combines variant/intent data-attrs, responsive data-attr spreads, the
  *  loading flag, per-prop `data-*` flags for boolean state props, and the

--- a/scripts/codegen/src/generators/gen-vue/kinds/atomic.test.ts
+++ b/scripts/codegen/src/generators/gen-vue/kinds/atomic.test.ts
@@ -217,5 +217,47 @@ describe("renderAtomicVueWrapper", () => {
         expect(out).not.toContain(`"data-ordered":`);
       });
     });
+
+    describe("a11y emission", () => {
+      test("emits a static role on the root from spec.a11y.role", () => {
+        const out = renderAtomicVueWrapper(
+          atomicSpec({ element: "div", a11y: { role: "separator" } }),
+          {},
+        );
+        expect(out).toContain(`role: "separator",`);
+      });
+
+      test('forwards each ariaProps entry as `"aria-{prop}": prop`', () => {
+        const out = renderAtomicVueWrapper(
+          atomicSpec({
+            element: "div",
+            props: {
+              orientation: prop({
+                type: "string",
+                values: ["horizontal", "vertical"],
+                responsive: false,
+                description: "",
+              }),
+            },
+            a11y: { ariaProps: ["orientation"] },
+          }),
+          {},
+        );
+        expect(out).toContain(`"aria-orientation": orientation,`);
+      });
+
+      test("toggles role to none and adds aria-hidden when decorativeProp is set", () => {
+        const out = renderAtomicVueWrapper(
+          atomicSpec({
+            element: "div",
+            props: { decorative: prop({ type: "boolean", description: "" }) },
+            a11y: { role: "separator", decorativeProp: "decorative" },
+          }),
+          {},
+        );
+        expect(out).toContain(`role: decorative ? "none" : "separator",`);
+        expect(out).toContain(`"aria-hidden": decorative ? "true" : undefined,`);
+      });
+    });
   });
 });

--- a/scripts/codegen/src/generators/gen-vue/kinds/atomic.ts
+++ b/scripts/codegen/src/generators/gen-vue/kinds/atomic.ts
@@ -4,7 +4,7 @@ import { specVoidStatus, voidTagsInMap } from "../../../lib/html-void-elements.t
 import { renderComponentJsDoc, vueJsDocFlavor } from "../../../lib/jsdoc-shape.ts";
 import { pascalCase } from "../../../lib/pascal-case.ts";
 import type { Spec } from "../../gen-contract.ts";
-import { renderAttrEntries } from "../_shared/attrs.ts";
+import { renderA11yAttrEntries, renderAttrEntries } from "../_shared/attrs.ts";
 import { renderPropsBlock, renderPropsType } from "../_shared/props.ts";
 import { renderBody, renderSlotsType } from "../_shared/slots.ts";
 
@@ -126,14 +126,19 @@ export function renderAtomicVueWrapper(
     .filter((l): l is string => l !== null)
     .join("\n");
 
-  const attrEntries = renderAttrEntries(
-    spec,
-    responsiveProps,
-    hasLoading,
-    hasDisabled,
-    hasAs,
-    booleanStateProps,
+  const a11y = spec.kind === "atomic" ? spec.a11y : undefined;
+  const a11yEntries = renderA11yAttrEntries(
+    a11y?.role,
+    a11y?.ariaProps ?? [],
+    a11y?.decorativeProp,
   );
+  const attrEntries = [
+    a11yEntries || null,
+    renderAttrEntries(spec, responsiveProps, hasLoading, hasDisabled, hasAs, booleanStateProps) ||
+      null,
+  ]
+    .filter((l): l is string => l !== null && l !== "")
+    .join("\n");
 
   const propEnumTypes = Object.entries(spec.props ?? {})
     .filter(([, d]) => Array.isArray(d.values) && d.values.length > 0)

--- a/scripts/codegen/src/lib/flatten.ts
+++ b/scripts/codegen/src/lib/flatten.ts
@@ -57,6 +57,8 @@ export type FlatA11y = {
   role?: string;
   keyboard?: Record<string, string>;
   states?: Record<string, string>;
+  ariaProps?: string[];
+  decorativeProp?: string;
 };
 
 export type FlatMotion = {

--- a/scripts/codegen/src/schema.ts
+++ b/scripts/codegen/src/schema.ts
@@ -51,6 +51,15 @@ const a11yBlock = z.strictObject({
   role: z.string().optional(),
   keyboard: a11yKeyboard.optional(),
   states: z.record(z.string(), z.string()).optional(),
+  /** Forwards a declared prop's runtime value as an `aria-{prop}` attribute on
+   *  the root element. Names are bare prop names (e.g. `orientation`);
+   *  generators emit `aria-orientation={orientation}`. The prop must be
+   *  declared, `type: string`, and `responsive: false`. */
+  ariaProps: z.array(z.string().min(1)).optional(),
+  /** Names a declared `type: boolean` prop. When that prop is `true` at
+   *  runtime the root emits `role="none"` (overriding any static `role`) and
+   *  `aria-hidden="true"`, removing the element from the accessibility tree. */
+  decorativeProp: z.string().min(1).optional(),
 });
 
 const constraintEntry = z.strictObject({
@@ -170,6 +179,8 @@ type ComponentPart = {
     role?: string;
     keyboard?: Record<string, string>;
     states?: Record<string, string>;
+    ariaProps?: string[];
+    decorativeProp?: string;
   };
   constraints?: Array<{
     when: Record<string, unknown>;

--- a/scripts/codegen/src/semantic-checks.test.ts
+++ b/scripts/codegen/src/semantic-checks.test.ts
@@ -3,6 +3,7 @@ import type { TokenDictionary } from "./lib/token-dictionary.ts";
 import type { Vocabulary } from "./lib/vocabulary.ts";
 import { Spec } from "./schema.ts";
 import {
+  checkA11yRefs,
   checkAsIsConstrained,
   checkConstraintsAgainstCoverage,
   checkConstraintsAgainstExamples,
@@ -966,6 +967,98 @@ describe("checkElementByProp", () => {
     });
     const issues = checkElementByProp(spec);
     expect(issues.some((i) => i.path === "parts.title.elementByProp.map")).toBe(true);
+  });
+});
+
+describe("checkA11yRefs", () => {
+  function dividerSpec(overrides: Record<string, unknown> = {}): Spec {
+    return makeSpec({
+      name: "divider",
+      kind: "atomic",
+      rootClass: "t-divider",
+      element: "div",
+      props: {
+        orientation: {
+          type: "string",
+          values: ["horizontal", "vertical"],
+          responsive: false,
+          description: "Axis.",
+        },
+        decorative: {
+          type: "boolean",
+          responsive: false,
+          description: "Decorative.",
+        },
+      },
+      a11y: {
+        role: "separator",
+        ariaProps: ["orientation"],
+        decorativeProp: "decorative",
+      },
+      ...overrides,
+    });
+  }
+
+  test("passes when ariaProps + decorativeProp reference matching props", () => {
+    expect(checkA11yRefs(dividerSpec())).toEqual([]);
+  });
+
+  test("rejects when ariaProps references an undeclared prop", () => {
+    const spec = dividerSpec({
+      a11y: { role: "separator", ariaProps: ["bogus"], decorativeProp: "decorative" },
+    });
+    const issues = checkA11yRefs(spec);
+    expect(issues.some((i) => i.path === "a11y.ariaProps")).toBe(true);
+    expect(issues.find((i) => i.path === "a11y.ariaProps")?.message).toMatch(/not declared/);
+  });
+
+  test("rejects when ariaProps references a boolean prop", () => {
+    const spec = dividerSpec({
+      a11y: { ariaProps: ["decorative"], decorativeProp: "decorative" },
+    });
+    const issues = checkA11yRefs(spec);
+    expect(issues.some((i) => i.message.includes("type: 'string'"))).toBe(true);
+  });
+
+  test("rejects when ariaProps references a responsive prop", () => {
+    const spec = dividerSpec({
+      props: {
+        orientation: {
+          type: "string",
+          values: ["horizontal", "vertical"],
+          responsive: true,
+          description: "Axis.",
+        },
+        decorative: {
+          type: "boolean",
+          responsive: false,
+          description: "Decorative.",
+        },
+      },
+    });
+    const issues = checkA11yRefs(spec);
+    expect(issues.some((i) => i.message.includes("non-responsive"))).toBe(true);
+  });
+
+  test("rejects when decorativeProp references an undeclared prop", () => {
+    const spec = dividerSpec({
+      a11y: { role: "separator", ariaProps: ["orientation"], decorativeProp: "bogus" },
+    });
+    const issues = checkA11yRefs(spec);
+    expect(issues.some((i) => i.path === "a11y.decorativeProp")).toBe(true);
+  });
+
+  test("rejects when decorativeProp references a string prop", () => {
+    const spec = dividerSpec({
+      a11y: { ariaProps: ["orientation"], decorativeProp: "orientation" },
+    });
+    const issues = checkA11yRefs(spec);
+    expect(issues.some((i) => i.message.includes("type: 'boolean'"))).toBe(true);
+  });
+
+  test("passes when only role is declared", () => {
+    const spec = dividerSpec({ a11y: { role: "separator" } });
+    expect(checkA11yRefs(spec)).toEqual([]);
   });
 });
 

--- a/scripts/codegen/src/semantic-checks.ts
+++ b/scripts/codegen/src/semantic-checks.ts
@@ -1006,6 +1006,73 @@ export function checkElementByProp(spec: Spec): Issue[] {
   return issues;
 }
 
+// ── Atomic `a11y.ariaProps` + `a11y.decorativeProp` refs ───────────────────
+
+/**
+ * `a11y.ariaProps[i]` must reference a declared `type: 'string'`, non-
+ * responsive prop on the same node — the generator emits
+ * `aria-{name}={name}` and the value flows through verbatim, so the prop's
+ * type must align with the aria attribute's enumeration domain.
+ *
+ * `a11y.decorativeProp` must reference a declared `type: 'boolean'` prop —
+ * the generator branches on `=== true` to toggle `role="none"` and
+ * `aria-hidden="true"`.
+ */
+export function checkA11yRefs(spec: Spec): Issue[] {
+  const issues: Issue[] = [];
+  visitNodes(spec, (node, path) => {
+    const a11y = node.a11y;
+    if (!a11y) return;
+    const base = path === "" ? "a11y" : `${path}.a11y`;
+    const props = node.props ?? {};
+    for (const name of a11y.ariaProps ?? []) {
+      const prop = props[name];
+      if (!prop) {
+        issues.push(
+          issue(spec.name, `${base}.ariaProps`, `prop '${name}' is not declared on this node`),
+        );
+        continue;
+      }
+      if (prop.type !== "string") {
+        issues.push(
+          issue(
+            spec.name,
+            `${base}.ariaProps`,
+            `prop '${name}' must be \`type: 'string'\`; got '${prop.type}'`,
+          ),
+        );
+      }
+      if (prop.responsive === true) {
+        issues.push(
+          issue(
+            spec.name,
+            `${base}.ariaProps`,
+            `prop '${name}' must be non-responsive (the aria attribute is emitted once on the root)`,
+          ),
+        );
+      }
+    }
+    const dec = a11y.decorativeProp;
+    if (dec !== undefined) {
+      const prop = props[dec];
+      if (!prop) {
+        issues.push(
+          issue(spec.name, `${base}.decorativeProp`, `prop '${dec}' is not declared on this node`),
+        );
+      } else if (prop.type !== "boolean") {
+        issues.push(
+          issue(
+            spec.name,
+            `${base}.decorativeProp`,
+            `prop '${dec}' must be \`type: 'boolean'\`; got '${prop.type}'`,
+          ),
+        );
+      }
+    }
+  });
+  return issues;
+}
+
 // ── Atomic `polymorphic: 'asChild'` constraints ────────────────────────────
 
 /**
@@ -2502,6 +2569,7 @@ export function runSemanticChecks(
     ...checkResponsiveExplicit(spec),
     ...checkAsIsConstrained(spec),
     ...checkElementByProp(spec),
+    ...checkA11yRefs(spec),
     ...checkPolymorphicAtomic(spec),
     ...checkVoidElementConstraints(spec),
     ...checkRepeatingParts(spec),

--- a/specs/cluster.yaml
+++ b/specs/cluster.yaml
@@ -50,9 +50,6 @@ privateTokens:
   - --_gap-7
   - --_gap-8
 
-a11y:
-  role: generic
-
 examples:
   - id: gap-3
     props: { gap: "3" }

--- a/specs/stack.yaml
+++ b/specs/stack.yaml
@@ -40,9 +40,6 @@ privateTokens:
   - --_gap-7
   - --_gap-8
 
-a11y:
-  role: generic
-
 examples:
   - id: gap-3
     props: { gap: "3" }

--- a/tests/contract/button.spec.ts-snapshots/button.html
+++ b/tests/contract/button.spec.ts-snapshots/button.html
@@ -1,86 +1,86 @@
 <!-- solid-primary -->
-<button class="t-button" data-intent="primary" data-variant="solid"><span data-button-label="">Label</span></button>
+<button class="t-button" data-intent="primary" data-variant="solid" role="button"><span data-button-label="">Label</span></button>
 
 <!-- solid-danger-md -->
-<button class="t-button" data-intent="danger" data-size="md" data-variant="solid"><span data-button-label="">Label</span></button>
+<button class="t-button" data-intent="danger" data-size="md" data-variant="solid" role="button"><span data-button-label="">Label</span></button>
 
 <!-- outline-neutral -->
-<button class="t-button" data-intent="neutral" data-variant="outline"><span data-button-label="">Label</span></button>
+<button class="t-button" data-intent="neutral" data-variant="outline" role="button"><span data-button-label="">Label</span></button>
 
 <!-- ghost-with-icon -->
-<button class="t-button" data-intent="neutral" data-variant="ghost"><span data-button-icon="" data-position="start"><span data-fixture-slot="arrow-left"></span></span><span data-button-label="">Label</span></button>
+<button class="t-button" data-intent="neutral" data-variant="ghost" role="button"><span data-button-icon="" data-position="start"><span data-fixture-slot="arrow-left"></span></span><span data-button-label="">Label</span></button>
 
 <!-- link-primary -->
-<a class="t-button" data-intent="primary" data-variant="link"><span data-button-label="">Label</span></a>
+<a class="t-button" data-intent="primary" data-variant="link" role="button"><span data-button-label="">Label</span></a>
 
 <!-- loading -->
-<button aria-busy="true" class="t-button" data-intent="primary" data-loading="true" data-variant="solid" disabled=""><span data-button-label="">Label</span><span aria-hidden="true" data-button-spinner=""></span></button>
+<button aria-busy="true" class="t-button" data-intent="primary" data-loading="true" data-variant="solid" disabled="" role="button"><span data-button-label="">Label</span><span aria-hidden="true" data-button-spinner=""></span></button>
 
 <!-- block-mobile -->
-<button class="t-button" data-block="true" data-intent="primary" data-size="lg" data-variant="solid"><span data-button-label="">Label</span></button>
+<button class="t-button" data-block="true" data-intent="primary" data-size="lg" data-variant="solid" role="button"><span data-button-label="">Label</span></button>
 
 <!-- block-responsive -->
-<button class="t-button" data-block="true" data-block-md="false" data-intent="primary" data-size="lg" data-variant="solid"><span data-button-label="">Label</span></button>
+<button class="t-button" data-block="true" data-block-md="false" data-intent="primary" data-size="lg" data-variant="solid" role="button"><span data-button-label="">Label</span></button>
 
 <!-- cov-ghost-danger-lg -->
-<button class="t-button" data-intent="danger" data-size="lg" data-variant="ghost"><span data-button-label="">Label</span></button>
+<button class="t-button" data-intent="danger" data-size="lg" data-variant="ghost" role="button"><span data-button-label="">Label</span></button>
 
 <!-- cov-outline-danger-md -->
-<button class="t-button" data-intent="danger" data-size="md" data-variant="outline"><span data-button-label="">Label</span></button>
+<button class="t-button" data-intent="danger" data-size="md" data-variant="outline" role="button"><span data-button-label="">Label</span></button>
 
 <!-- cov-solid-danger-sm -->
-<button class="t-button" data-intent="danger" data-size="sm" data-variant="solid"><span data-button-label="">Label</span></button>
+<button class="t-button" data-intent="danger" data-size="sm" data-variant="solid" role="button"><span data-button-label="">Label</span></button>
 
 <!-- cov-link-info-lg -->
-<button class="t-button" data-intent="info" data-size="lg" data-variant="link"><span data-button-label="">Label</span></button>
+<button class="t-button" data-intent="info" data-size="lg" data-variant="link" role="button"><span data-button-label="">Label</span></button>
 
 <!-- cov-solid-info-lg -->
-<button class="t-button" data-intent="info" data-size="lg" data-variant="solid"><span data-button-label="">Label</span></button>
+<button class="t-button" data-intent="info" data-size="lg" data-variant="solid" role="button"><span data-button-label="">Label</span></button>
 
 <!-- cov-ghost-info-md -->
-<button class="t-button" data-intent="info" data-size="md" data-variant="ghost"><span data-button-label="">Label</span></button>
+<button class="t-button" data-intent="info" data-size="md" data-variant="ghost" role="button"><span data-button-label="">Label</span></button>
 
 <!-- cov-outline-info-sm -->
-<button class="t-button" data-intent="info" data-size="sm" data-variant="outline"><span data-button-label="">Label</span></button>
+<button class="t-button" data-intent="info" data-size="sm" data-variant="outline" role="button"><span data-button-label="">Label</span></button>
 
 <!-- cov-outline-neutral-lg -->
-<button class="t-button" data-intent="neutral" data-size="lg" data-variant="outline"><span data-button-label="">Label</span></button>
+<button class="t-button" data-intent="neutral" data-size="lg" data-variant="outline" role="button"><span data-button-label="">Label</span></button>
 
 <!-- cov-solid-neutral-lg -->
-<button class="t-button" data-intent="neutral" data-size="lg" data-variant="solid"><span data-button-label="">Label</span></button>
+<button class="t-button" data-intent="neutral" data-size="lg" data-variant="solid" role="button"><span data-button-label="">Label</span></button>
 
 <!-- cov-link-neutral-md -->
-<button class="t-button" data-intent="neutral" data-size="md" data-variant="link"><span data-button-label="">Label</span></button>
+<button class="t-button" data-intent="neutral" data-size="md" data-variant="link" role="button"><span data-button-label="">Label</span></button>
 
 <!-- cov-ghost-neutral-sm -->
-<button class="t-button" data-intent="neutral" data-size="sm" data-variant="ghost"><span data-button-label="">Label</span></button>
+<button class="t-button" data-intent="neutral" data-size="sm" data-variant="ghost" role="button"><span data-button-label="">Label</span></button>
 
 <!-- cov-outline-primary-lg -->
-<button class="t-button" data-intent="primary" data-size="lg" data-variant="outline"><span data-button-label="">Label</span></button>
+<button class="t-button" data-intent="primary" data-size="lg" data-variant="outline" role="button"><span data-button-label="">Label</span></button>
 
 <!-- cov-solid-primary-lg -->
-<button class="t-button" data-intent="primary" data-size="lg" data-variant="solid"><span data-button-label="">Label</span></button>
+<button class="t-button" data-intent="primary" data-size="lg" data-variant="solid" role="button"><span data-button-label="">Label</span></button>
 
 <!-- cov-ghost-primary-md -->
-<button class="t-button" data-intent="primary" data-size="md" data-variant="ghost"><span data-button-label="">Label</span></button>
+<button class="t-button" data-intent="primary" data-size="md" data-variant="ghost" role="button"><span data-button-label="">Label</span></button>
 
 <!-- cov-link-primary-sm -->
-<button class="t-button" data-intent="primary" data-size="sm" data-variant="link"><span data-button-label="">Label</span></button>
+<button class="t-button" data-intent="primary" data-size="sm" data-variant="link" role="button"><span data-button-label="">Label</span></button>
 
 <!-- cov-ghost-success-lg -->
-<button class="t-button" data-intent="success" data-size="lg" data-variant="ghost"><span data-button-label="">Label</span></button>
+<button class="t-button" data-intent="success" data-size="lg" data-variant="ghost" role="button"><span data-button-label="">Label</span></button>
 
 <!-- cov-solid-success-md -->
-<button class="t-button" data-intent="success" data-size="md" data-variant="solid"><span data-button-label="">Label</span></button>
+<button class="t-button" data-intent="success" data-size="md" data-variant="solid" role="button"><span data-button-label="">Label</span></button>
 
 <!-- cov-outline-success-sm -->
-<button class="t-button" data-intent="success" data-size="sm" data-variant="outline"><span data-button-label="">Label</span></button>
+<button class="t-button" data-intent="success" data-size="sm" data-variant="outline" role="button"><span data-button-label="">Label</span></button>
 
 <!-- cov-ghost-warning-lg -->
-<button class="t-button" data-intent="warning" data-size="lg" data-variant="ghost"><span data-button-label="">Label</span></button>
+<button class="t-button" data-intent="warning" data-size="lg" data-variant="ghost" role="button"><span data-button-label="">Label</span></button>
 
 <!-- cov-outline-warning-md -->
-<button class="t-button" data-intent="warning" data-size="md" data-variant="outline"><span data-button-label="">Label</span></button>
+<button class="t-button" data-intent="warning" data-size="md" data-variant="outline" role="button"><span data-button-label="">Label</span></button>
 
 <!-- cov-solid-warning-sm -->
-<button class="t-button" data-intent="warning" data-size="sm" data-variant="solid"><span data-button-label="">Label</span></button>
+<button class="t-button" data-intent="warning" data-size="sm" data-variant="solid" role="button"><span data-button-label="">Label</span></button>


### PR DESCRIPTION
## What

Atomic codegen now reads three fields on `spec.a11y` and emits them on the wrapper root:

- `role: string` → `role="..."` static attr.
- `ariaProps: string[]` → `aria-{prop}={prop}` per entry. The prop must be a declared `type: 'string'`, non-responsive prop on the same node.
- `decorativeProp: string` → names a declared `type: 'boolean'` prop. When `true` at runtime the root emits `role="none"` (overriding any static role) and `aria-hidden="true"`.

Semantic checks (`checkA11yRefs`) reject undeclared / wrong-typed / responsive refs.

`gen-docs` adds matching lines in the Accessibility section for each forwarded aria attr and for the decorative-prop toggle.

## Why

Divider (#903) needs `<div role="separator" aria-orientation="vertical">` for the vertical branch and the `decorative` boolean to hide the element from AT. The atomic codegen had no path for static or conditional ARIA — the `a11y` block existed but only `gen-docs` read it. With this in, Divider can ship in the next PR using the spec block alone.

Generalising also activates Button's long-declared `a11y.role: button` — the generated wrapper now emits `role="button"` (load-bearing when Button renders as `<a>`).

## Side effects

- `Button.tsx` / `Button.vue` gain `role="button"` on the root.
- `Cluster` and `Stack` lose `a11y.role: generic` from their specs (and the matching A11y section in their docs pages). `role="generic"` on a `<div>` is biome-flagged as redundant, and the entries were docs-only no-ops.

## Test plan

- [x] `pnpm test` — adds 17 new tests across `renderA11yAttrs` (React), `renderA11yAttrEntries` (Vue), `renderAtomicReactWrapper`/`renderAtomicVueWrapper` integration, and `checkA11yRefs`.
- [x] `pnpm typecheck`, `pnpm lint`, `pnpm gen` clean.
- [x] Existing snapshots updated for Button (gains `role="button"`) and for Cluster/Stack docs (loses the A11y section).

## Codegen-surface audit

1. **schema-accepts / codegen-drops** — `ariaProps`, `decorativeProp` both emit in React, Vue, and gen-docs. ✓
2. **raw-string-as-identifier** — `ariaProps` values double as JS identifiers (the destructured prop name) and as the `aria-{name}` attr suffix. Prop names are already required to be valid identifiers by every other generator surface; no extra check needed. ✓
3. **inherited-type collisions** — `aria-{name}` attrs are already part of `AriaAttributes` on the inherited `ComponentProps<...>` type; consumer overrides via `{...rest}` still spread before the generated attr, so the spec-declared value wins (intended). ✓
4. **doc symmetry** — `gen-docs` renders the new fields in the A11y section. ✓

## Out of scope

- Composite-spec a11y emission (this PR is atomic-only).
- An implicit-role lookup table to skip emission when redundant — specs that declare `role: generic` on a `<div>` should drop the entry; biome's `noRedundantRoles` flags the alternative.

Closes #944