### PR TITLE
feat(repo): pre-push runs contract snapshots on DOM-affecting changes

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -50,6 +50,16 @@ pre-push:
     sync-labels-drift:
       glob: "specs/*.yaml"
       run: node scripts/repo/sync-labels.ts --check
+    contract-snapshots:
+      glob:
+        - "specs/**/*.yaml"
+        - "scripts/codegen/**"
+        - "apps/harness/src/fixtures/**"
+        - "packages/primitives/src/**"
+        - "packages/react/src/**/*.tsx"
+        - "packages/vue/src/**/*.vue"
+        - "tests/contract/**"
+      run: pnpm test:e2e tests/contract --project=chromium
     verify-no-dev-leak:
       run: pnpm -r --if-present run build && node scripts/hooks/verify-no-dev-leak.js
     measure:


### PR DESCRIPTION
## What

Adds a `contract-snapshots` pre-push hook that runs `pnpm test:e2e tests/contract --project=chromium` when the push touches files that can drift the rendered DOM contract.

## Why

#945 shipped a codegen change that added `role="button"` to the Button DOM. The Button contract snapshot drifted, but `lint`/`typecheck`/`test`/`gen-drift`/`verify-no-dev-leak` all passed locally — Playwright-driven contract assertions live in `tests/contract` and only ran in CI, so the drift was a CI roundtrip away from being visible. This hook closes that gap by running the same suite locally before the push leaves the maintainer's machine.

## Test plan

- [x] Drift a snapshot (rename a class in `tests/contract/divider.spec.ts-snapshots/divider.html`), run `pnpm test:e2e tests/contract --project=chromium` → fails with a clear diff.
- [x] Restore the snapshot, push the lefthook.yml change → hook skips (no globbed file in this PR's diff).
- [x] Hot-cache local run: 115 tests in ~9s.

## Deviations from #946 sketch

- Dropped `packages/css/src/components/**` from the trigger glob. Contract snapshots are pure DOM (`tests/contract/_contract.ts` serializes `tagName` + sorted attributes + text recursively) — computed styles don't reach the snapshot, so CSS-only changes can't drift it.
- Added `apps/harness/src/fixtures/**` (where the rendered React/Vue trees come from) and `packages/primitives/src/**` (Slot prop-merging affects `asChild` composites). Both can drift the contract independently of specs/codegen.
- Skipped the `pnpm playwright install --with-deps chromium` step. Idempotent isn't free (~1–2s even when cached) and `--with-deps` shells out to apt on Linux. Browsers are already installed on any clone that has run `pnpm test:e2e` once; if missing, Playwright errors clearly with the right install command.
- Dropped the `--` separator in `pnpm test:e2e -- tests/contract …`: pnpm 11 silently swallows the filter and runs the full 184-test suite. `pnpm test:e2e tests/contract --project=chromium` works correctly.

## Out of scope

- Full `tests/**/*.spec.ts` in pre-push. Docs grid-rhythm / visual / a11y suites stay CI-only.
- Auto-installing Playwright browsers — see deviations.

Closes #946