### PR TITLE
feat(spec): formControl atomic kind with shared HTML form-association contract

### DIFF
--- a/scripts/codegen/src/generators/gen-docs.ts
+++ b/scripts/codegen/src/generators/gen-docs.ts
@@ -8,6 +8,7 @@ import {
   buildTokenMap,
 } from "../../../../packages/css/postcss-teseor-floor.ts";
 import { flattenSpec } from "../lib/flatten.ts";
+import { loadVocabulary } from "../lib/vocabulary.ts";
 import type { GeneratorContext, GeneratorReport } from "../registry.ts";
 import { registerGenerator } from "../registry.ts";
 import { Spec as SpecSchema } from "../schema.ts";
@@ -111,12 +112,14 @@ async function docsGenerator(ctx: GeneratorContext): Promise<GeneratorReport> {
   const tokensCss = await readFile(TOKENS_CSS, "utf8");
   const tokens = buildTokenMap(tokensCss);
   const fcTokens = buildForcedColorsTokenMap(tokensCss);
+  const vocabulary = await loadVocabulary();
 
   await mkdir(DOCS_PAGES_DIR, { recursive: true });
   for (const name of targets) {
     const spec = await loadSpec(name);
     spec.bundleSizes = await readBundleSizes(name);
     spec.forcedColors = await readForcedColors(name, tokens, fcTokens);
+    spec.formControlContract = vocabulary.formControl;
     const outPath = resolve(DOCS_PAGES_DIR, `${name}.astro`);
     await writeFile(outPath, renderDocsPage(spec), "utf8");
     filesWritten.push(outPath);

--- a/scripts/codegen/src/generators/gen-docs/_shared/sections.test.ts
+++ b/scripts/codegen/src/generators/gen-docs/_shared/sections.test.ts
@@ -6,6 +6,7 @@ import {
   renderBundleSize,
   renderConstraints,
   renderForcedColors,
+  renderFormControlContract,
   renderNamed,
   renderProps,
   renderRepeatingItems,
@@ -610,5 +611,45 @@ describe("renderStateMachineDiagrams", () => {
     };
     const out = renderStateMachineDiagrams(spec);
     expect(out).toContain("Part: <Code>inner</Code>");
+  });
+});
+
+describe("renderFormControlContract", () => {
+  const contract = {
+    elements: ["input", "textarea", "select"],
+    props: {
+      name: { type: "string" as const, description: "HTML form field name." },
+      required: { type: "boolean" as const, description: "Required for submission." },
+    },
+  };
+
+  test("returns empty string when the spec is not a form-control", () => {
+    const spec = atomicSpec({ formControlContract: contract });
+    expect(renderFormControlContract(spec)).toBe("");
+  });
+
+  test("returns empty string when the contract is missing", () => {
+    const spec = atomicSpec({ formControl: true });
+    expect(renderFormControlContract(spec)).toBe("");
+  });
+
+  test("renders one row per shared contract prop on a form-control spec", () => {
+    const spec = atomicSpec({ formControl: true, formControlContract: contract });
+    const out = renderFormControlContract(spec);
+    expect(out).toContain("<h2>Form-control attributes</h2>");
+    expect(out).toContain("<Code>name</Code>");
+    expect(out).toContain("HTML form field name.");
+    expect(out).toContain("<Code>required</Code>");
+    expect(out).toContain("Required for submission.");
+  });
+
+  test("returns empty string for a composite spec even when formControl is set", () => {
+    const compositeSpec = {
+      ...atomicSpec(),
+      kind: "composite" as const,
+      formControl: true,
+      formControlContract: contract,
+    };
+    expect(renderFormControlContract(compositeSpec as DocsSpec)).toBe("");
   });
 });

--- a/scripts/codegen/src/generators/gen-docs/_shared/sections.ts
+++ b/scripts/codegen/src/generators/gen-docs/_shared/sections.ts
@@ -1,6 +1,7 @@
 import { pascalCase } from "../../../lib/pascal-case.ts";
 import { itemTypeName } from "../../../lib/repeating-naming.ts";
 import { esc, formatValue } from "../../../lib/text-escape.ts";
+import type { FormControlContract } from "../../../lib/vocabulary.ts";
 import type { Spec } from "../../gen-contract.ts";
 import { renderTable, section } from "./table-printer.ts";
 
@@ -16,6 +17,10 @@ export type DocsSpec = Spec & {
   // differs from the default branch. Injected by gen-docs.ts. Absent when the
   // component references no remapped semantic token (scale-only or no CSS).
   forcedColors?: Array<{ token: string; default: string; forced: string }>;
+  // Shared form-control contract (`specs/_vocabulary.yaml#formControl`)
+  // injected by gen-docs.ts. Read by `renderFormControlContract` to render the
+  // "Form-control attributes" section on `formControl: true` specs.
+  formControlContract?: FormControlContract;
 };
 
 function formatKb(bytes: number): string {
@@ -199,6 +204,29 @@ export function renderProps(spec: DocsSpec): string {
   return section(
     "Props",
     renderTable(["Prop", "Type", "Responsive", "Default", "Description"], rows),
+  );
+}
+
+/**
+ * Form-control specs receive the shared HTML form-association contract
+ * through the rendered element's native HTML attribute surface (React's
+ * `ComponentProps<element>` / Vue's HTML attribute fallthrough), not via
+ * declared props. The contract is the single source of truth in
+ * `specs/_vocabulary.yaml#formControl`; the docs section restates it here
+ * for the consumer. Per-spec redeclaration is rejected by `pnpm lint:spec`.
+ */
+export function renderFormControlContract(spec: DocsSpec): string {
+  if (spec.kind !== "atomic" || spec.formControl !== true) return "";
+  const contract = spec.formControlContract;
+  if (!contract) return "";
+  const rows = Object.entries(contract.props).map(([name, def]) => [
+    `<Code>${esc(name)}</Code>`,
+    `<Code>${esc(def.type)}</Code>`,
+    esc(def.description),
+  ]);
+  return section(
+    "Form-control attributes",
+    renderTable(["Attribute", "Type", "Description"], rows),
   );
 }
 

--- a/scripts/codegen/src/generators/gen-docs/kinds/atomic.ts
+++ b/scripts/codegen/src/generators/gen-docs/kinds/atomic.ts
@@ -7,6 +7,7 @@ import {
   renderBundleSize,
   renderConstraints,
   renderForcedColors,
+  renderFormControlContract,
   renderNamed,
   renderProps,
   renderStates,
@@ -20,6 +21,7 @@ export function renderAtomicDocsPage(spec: DocsSpec): string {
   const sections = [
     renderExamples(spec, Name, { isComposite: false }),
     renderProps(spec),
+    renderFormControlContract(spec),
     renderNamed("Variants", spec.variants),
     renderNamed("Intents", spec.intents),
     renderNamed("Sizes", spec.sizes),

--- a/scripts/codegen/src/lib/flatten.test.ts
+++ b/scripts/codegen/src/lib/flatten.test.ts
@@ -312,3 +312,30 @@ describe("flattenSpec — repeating parts (#687, RFC-0005)", () => {
     expect(flat.repeating).toBeUndefined();
   });
 });
+
+describe("flattenSpec — formControl flag (#693)", () => {
+  test("passes `formControl: true` through to the flat spec", () => {
+    const spec = makeSpec({
+      name: "input",
+      kind: "atomic",
+      element: "input",
+      rootClass: "t-input",
+      formControl: true,
+      examples: [{ id: "default" }],
+    });
+    const flat = flattenSpec(spec);
+    expect(flat.formControl).toBe(true);
+  });
+
+  test("leaves `formControl` undefined when the spec doesn't opt in", () => {
+    const spec = makeSpec({
+      name: "button",
+      kind: "atomic",
+      element: "button",
+      rootClass: "t-button",
+      examples: [{ id: "default" }],
+    });
+    const flat = flattenSpec(spec);
+    expect(flat.formControl).toBeUndefined();
+  });
+});

--- a/scripts/codegen/src/lib/flatten.ts
+++ b/scripts/codegen/src/lib/flatten.ts
@@ -85,6 +85,10 @@ export type FlatSpec = {
   /** Atomic-only: when `'asChild'`, the wrapper accepts an `asChild?: boolean`
    *  prop and renders via the shared Slot helper instead of the root element. */
   polymorphic?: "asChild";
+  /** Atomic-only: when `true`, the spec is a form-control atom. The shared
+   *  contract (props + valid root elements) lives in
+   *  `specs/_vocabulary.yaml#formControl` and is enforced by `pnpm lint:spec`. */
+  formControl?: boolean;
   /** Atomic-only: when set, the rendered tag is resolved at runtime from the
    *  named prop's value via `map`. Mutually exclusive with `element`. */
   elementByProp?: { prop: string; map: Record<string, string> };
@@ -146,6 +150,7 @@ export function flattenSpec(spec: Spec): FlatSpec {
       element: spec.element,
       slotElement: spec.slotElement,
       polymorphic: spec.polymorphic,
+      formControl: spec.formControl,
       elementByProp: spec.elementByProp,
       rootClass: spec.rootClass,
       variants: spec.variants,

--- a/scripts/codegen/src/lib/vocabulary.ts
+++ b/scripts/codegen/src/lib/vocabulary.ts
@@ -13,6 +13,20 @@ export type EventVocabulary = {
   builtins: Record<string, string>;
 };
 
+export type FormControlPropEntry = {
+  type: "string" | "boolean" | "number";
+  description: string;
+};
+
+export type FormControlContract = {
+  /** HTML tags allowed as the form-control root (or as branches of an
+   *  `elementByProp` map). */
+  elements: string[];
+  /** Shared props injected/forbidden-from-redeclaration on every
+   *  `formControl: true` spec. */
+  props: Record<string, FormControlPropEntry>;
+};
+
 export type Vocabulary = {
   components: string[];
   props: string[];
@@ -26,6 +40,7 @@ export type Vocabulary = {
   events: EventVocabulary;
   dom_events: Record<string, string>;
   keys: Record<string, string>;
+  formControl: FormControlContract;
 };
 
 let cached: Vocabulary | null = null;

--- a/scripts/codegen/src/schema.test.ts
+++ b/scripts/codegen/src/schema.test.ts
@@ -433,4 +433,27 @@ describe("Spec schema — shape layer", () => {
     });
     expect(result.success).toBe(false);
   });
+
+  test("accepts `formControl: true` on an atomic spec", () => {
+    const result = Spec.safeParse({
+      ...minimalAtomic(),
+      name: "input",
+      element: "input",
+      rootClass: "t-input",
+      formControl: true,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  test("rejects `formControl: true` on a composite spec", () => {
+    const result = Spec.safeParse({
+      name: "combobox",
+      kind: "composite",
+      formControl: true,
+      parts: {
+        root: { element: "div", rootClass: "t-combobox" },
+      },
+    });
+    expect(result.success).toBe(false);
+  });
 });

--- a/scripts/codegen/src/schema.ts
+++ b/scripts/codegen/src/schema.ts
@@ -292,6 +292,14 @@ const atomicSpec = z.strictObject({
   ...componentNodeFields,
   slotElement: z.string().optional(),
   polymorphic: z.enum(["asChild"]).optional(),
+  /** Marks the spec as a form-control atom (Input / Textarea / Select / …).
+   *  Shared HTML-attr props (name, form, required, readOnly, disabled) and
+   *  cross-prop constraints come from `specs/_vocabulary.yaml#formControl`;
+   *  per-spec redeclaration of any shared prop is rejected by
+   *  `pnpm lint:spec`. The rendered root tag (or every branch of an
+   *  `elementByProp` map) must be one of `formControl.elements`. Composite
+   *  form-controls aren't supported in v0. */
+  formControl: z.boolean().optional(),
 });
 
 const compositeSpec = z.strictObject({

--- a/scripts/codegen/src/semantic-checks.test.ts
+++ b/scripts/codegen/src/semantic-checks.test.ts
@@ -15,6 +15,7 @@ import {
   checkEventsRuntimeSupport,
   checkExamplesPresent,
   checkExamplesReferences,
+  checkFormControl,
   checkMotionSymmetry,
   checkPolymorphicAtomic,
   checkPrivateTokens,
@@ -83,6 +84,16 @@ const vocabulary: Vocabulary = {
     escape: "Escape key.",
     enter: "Enter key.",
     tab: "Tab key.",
+  },
+  formControl: {
+    elements: ["input", "textarea", "select"],
+    props: {
+      name: { type: "string", description: "HTML form field name." },
+      form: { type: "string", description: "Form id association." },
+      required: { type: "boolean", description: "Required field." },
+      readOnly: { type: "boolean", description: "Read-only field." },
+      disabled: { type: "boolean", description: "Disabled field." },
+    },
   },
 };
 
@@ -2814,5 +2825,107 @@ describe("checkStateMachines (RFC-0007)", () => {
       },
     });
     expect(checkStateMachines(spec, vocabulary)).toEqual([]);
+  });
+});
+
+describe("checkFormControl", () => {
+  function makeFormControl(overrides: Partial<Record<string, unknown>> = {}): Spec {
+    return Spec.parse({
+      name: "input",
+      kind: "atomic",
+      element: "input",
+      rootClass: "t-input",
+      formControl: true,
+      examples: [{ id: "default" }],
+      ...overrides,
+    });
+  }
+
+  test("accepts a minimal form-control spec on <input>", () => {
+    expect(checkFormControl(makeFormControl(), vocabulary)).toEqual([]);
+  });
+
+  test("accepts a form-control on <textarea>", () => {
+    const spec = makeFormControl({ element: "textarea", rootClass: "t-textarea" });
+    expect(checkFormControl(spec, vocabulary)).toEqual([]);
+  });
+
+  test("accepts a form-control on <select>", () => {
+    const spec = makeFormControl({ element: "select", rootClass: "t-select" });
+    expect(checkFormControl(spec, vocabulary)).toEqual([]);
+  });
+
+  test("ignores specs without formControl: true", () => {
+    const spec = Spec.parse({
+      name: "button",
+      kind: "atomic",
+      element: "button",
+      rootClass: "t-button",
+      examples: [{ id: "default" }],
+    });
+    expect(checkFormControl(spec, vocabulary)).toEqual([]);
+  });
+
+  test("flags a form-control whose root is not in the allowed elements set", () => {
+    const spec = makeFormControl({ element: "div", rootClass: "t-input" });
+    const issues = checkFormControl(spec, vocabulary);
+    expect(issues).toHaveLength(1);
+    expect(issues[0]?.path).toBe("element");
+    expect(issues[0]?.message).toMatch(/requires <div> to be one of/);
+  });
+
+  test("flags a form-control with redeclared shared props", () => {
+    const spec = makeFormControl({
+      props: {
+        name: { type: "string", description: "Override.", responsive: false },
+        required: { type: "boolean", description: "Override.", responsive: false },
+      },
+    });
+    const issues = checkFormControl(spec, vocabulary);
+    expect(issues).toHaveLength(2);
+    expect(issues.map((i) => i.path).sort()).toEqual(["props.name", "props.required"]);
+    for (const issue of issues) {
+      expect(issue.message).toMatch(/part of the shared form-control contract/);
+    }
+  });
+
+  test("flags a form-control whose elementByProp map mixes non-allowed tags", () => {
+    const spec = Spec.parse({
+      name: "input",
+      kind: "atomic",
+      formControl: true,
+      rootClass: "t-input",
+      examples: [{ id: "default" }],
+      elementByProp: {
+        prop: "as",
+        map: { single: "input", multi: "div" },
+      },
+      props: {
+        as: {
+          type: "string",
+          description: "Render mode.",
+          responsive: false,
+          values: ["single", "multi"],
+        },
+      },
+    });
+    const issues = checkFormControl(spec, vocabulary);
+    expect(issues).toHaveLength(1);
+    expect(issues[0]?.path).toBe("elementByProp.map");
+    expect(issues[0]?.message).toMatch(/requires <div> to be one of/);
+  });
+
+  test("allows per-spec props that don't collide with the shared contract", () => {
+    const spec = makeFormControl({
+      props: {
+        type: {
+          type: "string",
+          description: "Input type.",
+          responsive: false,
+          values: ["text", "email"],
+        },
+      },
+    });
+    expect(checkFormControl(spec, vocabulary)).toEqual([]);
   });
 });

--- a/scripts/codegen/src/semantic-checks.ts
+++ b/scripts/codegen/src/semantic-checks.ts
@@ -1125,6 +1125,71 @@ export function checkPolymorphicAtomic(spec: Spec): Issue[] {
   return issues;
 }
 
+// ── `formControl: true` shared-contract enforcement ────────────────────────
+
+/**
+ * Form-control atoms (Input / Textarea / Select / Switch / Checkbox / Radio)
+ * share an HTML form-association contract — `name`, `form`, `required`,
+ * `readOnly`, plus the universal `disabled`. The shared contract lives in
+ * `specs/_vocabulary.yaml#formControl` and is the single source of truth;
+ * specs receive it through React's `ComponentProps<element>` (or Vue's HTML
+ * attribute fallthrough) on the rendered root. Three rules:
+ *
+ * - `formControl: true` requires `kind: atomic`. Composite form-controls
+ *   (Combobox, DatePicker) split the contract across parts and are out of
+ *   scope until a future kind lands.
+ * - The rendered root tag — `element`, or every branch of an `elementByProp`
+ *   map — must be one of `formControl.elements` (defaults: input, textarea,
+ *   select). A non-form-control root would silently drop the shared HTML
+ *   attrs at runtime.
+ * - The spec's `props:` block must NOT redeclare any name in
+ *   `formControl.props`. Redeclaration drifts the contract per-spec.
+ */
+export function checkFormControl(spec: Spec, vocabulary: Vocabulary): Issue[] {
+  if (!isAtomic(spec)) return [];
+  if (spec.formControl !== true) return [];
+  const issues: Issue[] = [];
+  const allowedElements = vocabulary.formControl.elements;
+  const sharedPropNames = Object.keys(vocabulary.formControl.props);
+  const rootTags = spec.elementByProp
+    ? Object.values(spec.elementByProp.map)
+    : spec.element
+      ? [spec.element]
+      : [];
+  if (rootTags.length === 0) {
+    issues.push(
+      issue(
+        spec.name,
+        "formControl",
+        `\`formControl: true\` requires a rendered root element from {${allowedElements.join(", ")}}`,
+      ),
+    );
+  }
+  for (const tag of rootTags) {
+    if (!allowedElements.includes(tag.toLowerCase())) {
+      issues.push(
+        issue(
+          spec.name,
+          spec.elementByProp ? `elementByProp.map` : "element",
+          `\`formControl: true\` requires <${tag}> to be one of {${allowedElements.join(", ")}}`,
+        ),
+      );
+    }
+  }
+  for (const propName of sharedPropNames) {
+    if (spec.props && propName in spec.props) {
+      issues.push(
+        issue(
+          spec.name,
+          `props.${propName}`,
+          `'${propName}' is part of the shared form-control contract — remove the per-spec declaration; the prop reaches the root via the rendered element's HTML attribute surface`,
+        ),
+      );
+    }
+  }
+  return issues;
+}
+
 // ── Void HTML elements reject child-bearing prop declarations ───────────────
 
 /**
@@ -2571,6 +2636,7 @@ export function runSemanticChecks(
     ...checkElementByProp(spec),
     ...checkA11yRefs(spec),
     ...checkPolymorphicAtomic(spec),
+    ...checkFormControl(spec, ctx.vocabulary),
     ...checkVoidElementConstraints(spec),
     ...checkRepeatingParts(spec),
     ...checkExamplesPresent(spec),

--- a/specs/_vocabulary.yaml
+++ b/specs/_vocabulary.yaml
@@ -73,6 +73,10 @@ props:
   - density
   - layout
   - align
+  - name
+  - form
+  - required
+  - readOnly
 
 # Canonical descriptions for props with fixed meaning across components.
 # Per-spec props override these in spec.props.<name>.description.
@@ -88,6 +92,40 @@ propDescriptions:
   disabled: Disables interaction.
   loading: Shows loading; disables interaction.
   error: Error state.
+  name: HTML form field name (submitted with the form).
+  form: Associates the control with a form element by id.
+  required: Marks the control as required for form submission.
+  readOnly: Prevents editing while keeping the value submitted.
+
+# Shared contract for atomic specs with `formControl: true`. The contract is
+# defined ONCE here; per-spec redeclaration of any prop name listed below is
+# rejected by `pnpm lint:spec`. Form-control HTML attributes (name, form,
+# required, readOnly, plus the universal `disabled`) reach the rendered root
+# via React's `ComponentProps<element>` / Vue's HTML attribute fallthrough —
+# generators don't synthesize per-prop emission. `elements:` lists the only
+# tag names allowed as the form-control root (or every branch of an
+# `elementByProp` map, when used).
+formControl:
+  elements:
+    - input
+    - textarea
+    - select
+  props:
+    name:
+      type: string
+      description: HTML form field name (submitted with the form).
+    form:
+      type: string
+      description: Associates the control with a form element by id.
+    required:
+      type: boolean
+      description: Marks the control as required for form submission.
+    readOnly:
+      type: boolean
+      description: Prevents editing while keeping the value submitted.
+    disabled:
+      type: boolean
+      description: Disables interaction and excludes the value from form submission.
 
 # Variant values. Canonical superset: visual hierarchy (solid|outline|ghost|link)
 # plus semantic-color (default|muted|highlight). Each spec declares its own


### PR DESCRIPTION
## What

Adds `formControl: true` to the atomic spec schema. Marking a spec as a form-control atom (Input / Textarea / Select / Switch / Checkbox / Radio) opts it into a shared HTML form-association contract — `name`, `form`, `required`, `readOnly`, plus the universal `disabled` — defined once in `specs/_vocabulary.yaml#formControl`.

The shared props reach the rendered root via the element's native HTML attribute surface (React's `ComponentProps<element>` / Vue's HTML attribute fallthrough). Per-spec redeclaration of any shared prop is rejected by `pnpm lint:spec`. `formControl: true` requires the rendered root tag (or every branch of an `elementByProp` map) to be one of `{input, textarea, select}`.

Generated docs pages surface the contract as a "Form-control attributes" section so consumers see the additional HTML attrs that come with the component.

## Why

The form-atom loop (Input → Textarea → Switch → Checkbox → Radio → Select) needs a substrate that defines the form-association contract once. Without it, every form atom would redeclare the same props/descriptions and drift in subtle ways. The substrate lands the schema flag + canonical contract + lint discipline + docs surface so the form atoms ship as near-mechanical PRs against a single source of truth.

State→ARIA mapping (`error` → `aria-invalid`, `required` → `aria-required`) is out of scope for this PR; it belongs with the ARIA-relationships work tracked under #692.

## Test plan

- [x] `pnpm test` — 1359 tests pass.
- [x] `pnpm gen` — no diff under `packages/` (no spec uses the flag yet).
- [x] `pnpm typecheck` — clean across all workspaces.
- [x] `node scripts/lint/run.ts --spec` — 17 specs ok.
- [x] `node scripts/lint/run.ts --biome` — clean.
- [x] Pre-push gates (contract-snapshots, gen-drift, lint, test, typecheck) — green.
- [x] Codegen-surface audit ack stamped in `.claude/codegen-audit-ack`.

## Out of scope

- Filing actual form-atom specs (Input / Textarea / Switch / Checkbox / Radio / Select) — those follow in the form-atom loop now that the substrate is in place.
- ARIA-relationship wiring (`error` → `aria-invalid`, etc.) — tracked under #692.
- Composite form-controls (Combobox, DatePicker) — out of v0; the flag is atomic-only.
- React Hook Form / Tanstack Form integration adapters — out of v0.3.

Closes #693