### PR TITLE
fix(codegen): kebab-case data-attr names for multi-word props

### DIFF
--- a/.changeset/970-codegen-kebab-data-attrs.md
+++ b/.changeset/970-codegen-kebab-data-attrs.md
@@ -1,0 +1,6 @@
+---
+"@teseor/react": patch
+"@teseor/vue": patch
+---
+
+Kebab-case multi-word prop names when emitting `data-*` attributes — wrappers no longer trigger React 19 DEV warnings and CSS selectors match the DOM-canonical attribute form (`data-min-height` instead of `data-minHeight`). Single-word prop names are unchanged.

--- a/scripts/codegen/src/generators/gen-docs/_shared/examples.ts
+++ b/scripts/codegen/src/generators/gen-docs/_shared/examples.ts
@@ -63,17 +63,19 @@ export function renderExamples(spec: Spec, Name: string, opts: { isComposite: bo
     const sourceOpenTag = [Name, ...sourceAttrs].join(" ");
     const defaults = specDefaultChildren(spec);
     const defaultChildrenMarkup =
-      defaults && defaults.length > 0 ? defaults.map(renderChildElement).join("") : null;
+      defaults !== undefined && defaults.length > 0
+        ? defaults.map(renderChildElement).join("")
+        : null;
     const sourceLines = isList
       ? [`<${sourceOpenTag} />`]
       : isComposite && trigger
         ? [`<${sourceOpenTag}>`, `  ${trigger}`, `</${Name}>`]
         : isVoidAtomic
           ? [`<${sourceOpenTag} />`]
-          : defaultChildrenMarkup
+          : defaults !== undefined && defaults.length > 0
             ? [
                 `<${sourceOpenTag}>`,
-                ...defaults!.map((c) => `  ${renderChildElement(c)}`),
+                ...defaults.map((c) => `  ${renderChildElement(c)}`),
                 `</${Name}>`,
               ]
             : [`<${sourceOpenTag}>${Name}</${Name}>`];

--- a/scripts/codegen/src/generators/gen-react/_shared/attrs.test.ts
+++ b/scripts/codegen/src/generators/gen-react/_shared/attrs.test.ts
@@ -49,6 +49,13 @@ describe("renderDataAttrs", () => {
   test("renders an empty string when no attrs are needed", () => {
     expect(renderDataAttrs(atomicSpec(), [], false, [], [])).toBe("");
   });
+
+  test("kebab-cases multi-word prop names in the emitted data-attr name", () => {
+    const out = renderDataAttrs(atomicSpec(), ["minHeight"], false, ["isPrimary"], ["maxWidth"]);
+    expect(out).toContain(`{...responsiveDataAttrs("min-height", minHeight)}`);
+    expect(out).toContain(`data-max-width={maxWidth}`);
+    expect(out).toContain(`data-is-primary={isPrimary === true ? "true" : undefined}`);
+  });
 });
 
 describe("renderStateAttrs", () => {

--- a/scripts/codegen/src/generators/gen-react/_shared/attrs.ts
+++ b/scripts/codegen/src/generators/gen-react/_shared/attrs.ts
@@ -1,3 +1,4 @@
+import { kebabCase } from "../../../lib/kebab-case.ts";
 import type { Spec } from "../../gen-contract.ts";
 import { quote } from "./type-printer.ts";
 
@@ -16,11 +17,13 @@ export function renderDataAttrs(
   return [
     spec.variants ? `      data-variant={variant}` : null,
     spec.intents ? `      data-intent={intent}` : null,
-    ...responsiveProps.map((name) => `      {...responsiveDataAttrs(${quote(name)}, ${name})}`),
-    ...stringEnumStateProps.map((name) => `      data-${name}={${name}}`),
+    ...responsiveProps.map(
+      (name) => `      {...responsiveDataAttrs(${quote(kebabCase(name))}, ${name})}`,
+    ),
+    ...stringEnumStateProps.map((name) => `      data-${kebabCase(name)}={${name}}`),
     hasLoading ? `      data-loading={loading === true ? "true" : undefined}` : null,
     ...booleanStateProps.map(
-      (name) => `      data-${name}={${name} === true ? "true" : undefined}`,
+      (name) => `      data-${kebabCase(name)}={${name} === true ? "true" : undefined}`,
     ),
   ]
     .filter((line): line is string => line !== null)

--- a/scripts/codegen/src/generators/gen-vue/_shared/attrs.test.ts
+++ b/scripts/codegen/src/generators/gen-vue/_shared/attrs.test.ts
@@ -74,6 +74,21 @@ describe("renderAttrEntries", () => {
     expect(out).toContain(`"data-resize": resize,`);
     expect(out).toContain(`"data-appearance": appearance,`);
   });
+
+  test("kebab-cases multi-word prop names in the emitted data-attr name", () => {
+    const out = renderAttrEntries(
+      atomicSpec(),
+      ["minHeight"],
+      false,
+      false,
+      false,
+      ["isPrimary"],
+      ["maxWidth"],
+    );
+    expect(out).toContain(`...responsiveDataAttrs("min-height", minHeight),`);
+    expect(out).toContain(`"data-max-width": maxWidth,`);
+    expect(out).toContain(`"data-is-primary": isPrimary ? "true" : undefined,`);
+  });
 });
 
 describe("renderA11yAttrEntries", () => {

--- a/scripts/codegen/src/generators/gen-vue/_shared/attrs.ts
+++ b/scripts/codegen/src/generators/gen-vue/_shared/attrs.ts
@@ -1,3 +1,4 @@
+import { kebabCase } from "../../../lib/kebab-case.ts";
 import type { Spec } from "../../gen-contract.ts";
 import { quote } from "./type-printer.ts";
 
@@ -43,10 +44,14 @@ export function renderAttrEntries(
   return [
     spec.variants ? `  "data-variant": variant,` : null,
     spec.intents ? `  "data-intent": intent,` : null,
-    ...responsiveProps.map((name) => `  ...responsiveDataAttrs(${quote(name)}, ${name}),`),
-    ...stringEnumStateProps.map((name) => `  "data-${name}": ${name},`),
+    ...responsiveProps.map(
+      (name) => `  ...responsiveDataAttrs(${quote(kebabCase(name))}, ${name}),`,
+    ),
+    ...stringEnumStateProps.map((name) => `  "data-${kebabCase(name)}": ${name},`),
     hasLoading ? `  "data-loading": loading ? "true" : undefined,` : null,
-    ...booleanStateProps.map((name) => `  "data-${name}": ${name} ? "true" : undefined,`),
+    ...booleanStateProps.map(
+      (name) => `  "data-${kebabCase(name)}": ${name} ? "true" : undefined,`,
+    ),
     hasDisabled && hasAs ? `  disabled: isButton.value ? inactive.value : undefined,` : null,
     hasDisabled && hasAs
       ? `  "aria-disabled": !isButton.value && inactive.value ? "true" : undefined,`

--- a/scripts/codegen/src/lib/kebab-case.test.ts
+++ b/scripts/codegen/src/lib/kebab-case.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { kebabCase } from "./kebab-case.ts";
+
+describe("kebabCase", () => {
+  it("leaves single-word lowercase names unchanged", () => {
+    expect(kebabCase("size")).toBe("size");
+    expect(kebabCase("variant")).toBe("variant");
+  });
+
+  it("converts camelCase", () => {
+    expect(kebabCase("minHeight")).toBe("min-height");
+    expect(kebabCase("aspectRatio")).toBe("aspect-ratio");
+  });
+
+  it("converts PascalCase", () => {
+    expect(kebabCase("MinHeight")).toBe("min-height");
+  });
+
+  it("converts snake_case", () => {
+    expect(kebabCase("min_height")).toBe("min-height");
+  });
+
+  it("collapses runs of separators", () => {
+    expect(kebabCase("min   height")).toBe("min-height");
+    expect(kebabCase("min__height")).toBe("min-height");
+  });
+
+  it("handles digit boundaries", () => {
+    expect(kebabCase("size2X")).toBe("size2-x");
+    expect(kebabCase("v1Major")).toBe("v1-major");
+  });
+});

--- a/scripts/codegen/src/lib/kebab-case.ts
+++ b/scripts/codegen/src/lib/kebab-case.ts
@@ -1,0 +1,12 @@
+/**
+ * Convert camelCase, PascalCase, or snake_case to kebab-case. Used when a
+ * spec's camelCase prop name (`minHeight`) is interpolated into a DOM
+ * `data-*` attribute name (`data-min-height`) — HTML lowercases the attribute
+ * in the DOM and React 19 DEV warns on the camelCase form.
+ */
+export function kebabCase(name: string): string {
+  return name
+    .replace(/([a-z0-9])([A-Z])/g, "$1-$2")
+    .replace(/[_\s]+/g, "-")
+    .toLowerCase();
+}


### PR DESCRIPTION
## What

Kebab-case multi-word prop names when interpolating them into `data-*` attribute names. Adds a `kebabCase` helper and threads it through React + Vue `_shared/attrs.ts` for the three call sites (responsive spread, string-enum state, boolean state).

## Why

The Center atom (#953) blocked on this: its locked `minHeight` prop emitted `data-minHeight`, which React 19 DEV-warns and the DOM lowercases to `data-minheight`. Single-word prop names are unchanged — `pnpm gen` is a no-op for every shipped spec. Unblocks Center and any future multi-word prop (`aspectRatio`, `maxWidth`, `paddingX`, etc.).

Also folds a small Biome warning cleanup in `gen-docs/_shared/examples.ts` — replaces a non-null assertion left over from #968 with a typescript-narrowing check.

## Test plan

- [ ] pnpm test
- [ ] pnpm typecheck
- [ ] pnpm lint
- [ ] pnpm gen produces zero diff for existing specs
- [ ] new kebab-case unit test + multi-word data-attr unit tests pass

## Out of scope

- The substrate consolidation ADR (escape-hatch fields → orthogonal primitives) — tracked separately, after the Wave 2 substrate PRs land.
- Resuming Center (#953) — separate PR, builds on this.

Closes #970