### PR TITLE
feat(codegen): a11y.labelProp substrate for decorative-by-default atoms

### DIFF
--- a/.changeset/972-codegen-a11y-label-prop.md
+++ b/.changeset/972-codegen-a11y-label-prop.md
@@ -1,0 +1,6 @@
+---
+"@teseor/react": patch
+"@teseor/vue": patch
+---
+
+Add `a11y.labelProp` substrate for decorative-by-default atomic specs. Names a `type: string`, non-responsive prop whose presence flips the root from decorative (`aria-hidden="true"`, role overridden to `"none"`) to meaningful (`aria-label={prop}`, declared role intact). Mirror of `decorativeProp` but inverted — opt-in to meaningful instead of opt-in to decorative. Mutually exclusive with `decorativeProp`. No diff for existing specs; unblocks Dot (#950) and Icon (#952).

--- a/scripts/codegen/src/generators/gen-react/_shared/attrs.test.ts
+++ b/scripts/codegen/src/generators/gen-react/_shared/attrs.test.ts
@@ -99,4 +99,18 @@ describe("renderA11yAttrs", () => {
   test("renders an empty string when nothing is declared", () => {
     expect(renderA11yAttrs(undefined, [], undefined)).toBe("");
   });
+
+  test("with labelProp set, emits aria-label and conditional aria-hidden", () => {
+    const out = renderA11yAttrs(undefined, [], undefined, "label");
+    expect(out).toContain(`aria-label={label}`);
+    expect(out).toContain(`aria-hidden={label === undefined ? "true" : undefined}`);
+    expect(out).not.toContain(`role=`);
+  });
+
+  test("with labelProp + base role, role toggles to none when label is unset", () => {
+    const out = renderA11yAttrs("img", [], undefined, "label");
+    expect(out).toContain(`role={label === undefined ? "none" : "img"}`);
+    expect(out).toContain(`aria-label={label}`);
+    expect(out).toContain(`aria-hidden={label === undefined ? "true" : undefined}`);
+  });
 });

--- a/scripts/codegen/src/generators/gen-react/_shared/attrs.ts
+++ b/scripts/codegen/src/generators/gen-react/_shared/attrs.ts
@@ -28,24 +28,28 @@ export function renderDataAttrs(
 }
 
 /** Emit the JSX-attribute lines for the spec's a11y block: a static `role`
- *  (overridden to `"none"` when `decorativeProp` is true), an `aria-{name}`
- *  per entry in `ariaProps`, and `aria-hidden` when `decorativeProp` is
- *  declared and true. Static-empty when no a11y block is set. The optional
- *  `roleBiomeIgnore` injects a `// biome-ignore` line directly above `role=`
- *  for combinations Biome can't see across (e.g. `aria-checked` implicit on
- *  `<input type="checkbox" role="switch">`). */
+ *  (overridden to `"none"` when `decorativeProp` is true, or when `labelProp`
+ *  is unset), an `aria-{name}` per entry in `ariaProps`, `aria-label` from
+ *  `labelProp` when set, and `aria-hidden` driven by either `decorativeProp`
+ *  (true) or `labelProp` (undefined). Static-empty when no a11y block is
+ *  set. The optional `roleBiomeIgnore` injects a `// biome-ignore` line
+ *  directly above `role=` for combinations Biome can't see across (e.g.
+ *  `aria-checked` implicit on `<input type="checkbox" role="switch">`). */
 export function renderA11yAttrs(
   role: string | undefined,
   ariaProps: readonly string[],
   decorativeProp: string | undefined,
+  labelProp?: string,
   roleBiomeIgnore?: string,
 ): string {
   const roleLine =
     role !== undefined && decorativeProp !== undefined
       ? `      role={${decorativeProp} === true ? "none" : ${quote(role)}}`
-      : role !== undefined
-        ? `      role=${quote(role)}`
-        : null;
+      : role !== undefined && labelProp !== undefined
+        ? `      role={${labelProp} === undefined ? "none" : ${quote(role)}}`
+        : role !== undefined
+          ? `      role=${quote(role)}`
+          : null;
   const roleWithIgnore =
     roleLine !== null && roleBiomeIgnore
       ? `      // biome-ignore ${roleBiomeIgnore}\n${roleLine}`
@@ -53,8 +57,12 @@ export function renderA11yAttrs(
   return [
     roleWithIgnore,
     ...ariaProps.map((name) => `      aria-${name}={${name}}`),
+    labelProp !== undefined ? `      aria-label={${labelProp}}` : null,
     decorativeProp !== undefined
       ? `      aria-hidden={${decorativeProp} === true ? "true" : undefined}`
+      : null,
+    labelProp !== undefined
+      ? `      aria-hidden={${labelProp} === undefined ? "true" : undefined}`
       : null,
   ]
     .filter((line): line is string => line !== null)

--- a/scripts/codegen/src/generators/gen-react/kinds/atomic.ts
+++ b/scripts/codegen/src/generators/gen-react/kinds/atomic.ts
@@ -203,8 +203,13 @@ export function renderAtomicReactWrapper(
     `      ref={${refExpr}}`,
     `      className={mergedClassName}`,
     htmlAttrLines || null,
-    renderA11yAttrs(a11y?.role, a11y?.ariaProps ?? [], a11y?.decorativeProp, roleBiomeIgnore) ||
-      null,
+    renderA11yAttrs(
+      a11y?.role,
+      a11y?.ariaProps ?? [],
+      a11y?.decorativeProp,
+      a11y?.labelProp,
+      roleBiomeIgnore,
+    ) || null,
     renderDataAttrs(spec, responsiveProps, hasLoading, booleanStateProps, stringEnumStateProps) ||
       null,
     renderStateAttrs(hasAs, hasDisabled, hasLoading) || null,

--- a/scripts/codegen/src/generators/gen-vue/_shared/attrs.test.ts
+++ b/scripts/codegen/src/generators/gen-vue/_shared/attrs.test.ts
@@ -101,4 +101,18 @@ describe("renderA11yAttrEntries", () => {
   test("renders an empty string when nothing is declared", () => {
     expect(renderA11yAttrEntries(undefined, [], undefined)).toBe("");
   });
+
+  test("with labelProp set, emits aria-label entry and conditional aria-hidden", () => {
+    const out = renderA11yAttrEntries(undefined, [], undefined, "label");
+    expect(out).toContain(`"aria-label": label,`);
+    expect(out).toContain(`"aria-hidden": label === undefined ? "true" : undefined,`);
+    expect(out).not.toContain(`role:`);
+  });
+
+  test("with labelProp + base role, role toggles to none when label is unset", () => {
+    const out = renderA11yAttrEntries("img", [], undefined, "label");
+    expect(out).toContain(`role: label === undefined ? "none" : "img",`);
+    expect(out).toContain(`"aria-label": label,`);
+    expect(out).toContain(`"aria-hidden": label === undefined ? "true" : undefined,`);
+  });
 });

--- a/scripts/codegen/src/generators/gen-vue/_shared/attrs.ts
+++ b/scripts/codegen/src/generators/gen-vue/_shared/attrs.ts
@@ -3,22 +3,30 @@ import { quote } from "./type-printer.ts";
 
 /** Emit the entries of the `attrs` computed object for the spec's a11y
  *  block: a static `role` (overridden to `"none"` when `decorativeProp` is
- *  true), an `aria-{name}` per entry in `ariaProps`, and `aria-hidden` when
- *  `decorativeProp` is declared and true. */
+ *  true, or when `labelProp` is unset), an `aria-{name}` per entry in
+ *  `ariaProps`, `aria-label` from `labelProp` when set, and `aria-hidden`
+ *  driven by either `decorativeProp` (true) or `labelProp` (undefined). */
 export function renderA11yAttrEntries(
   role: string | undefined,
   ariaProps: readonly string[],
   decorativeProp: string | undefined,
+  labelProp?: string,
 ): string {
   return [
     role !== undefined && decorativeProp !== undefined
       ? `  role: ${decorativeProp} ? "none" : ${quote(role)},`
-      : role !== undefined
-        ? `  role: ${quote(role)},`
-        : null,
+      : role !== undefined && labelProp !== undefined
+        ? `  role: ${labelProp} === undefined ? "none" : ${quote(role)},`
+        : role !== undefined
+          ? `  role: ${quote(role)},`
+          : null,
     ...ariaProps.map((name) => `  "aria-${name}": ${name},`),
+    labelProp !== undefined ? `  "aria-label": ${labelProp},` : null,
     decorativeProp !== undefined
       ? `  "aria-hidden": ${decorativeProp} ? "true" : undefined,`
+      : null,
+    labelProp !== undefined
+      ? `  "aria-hidden": ${labelProp} === undefined ? "true" : undefined,`
       : null,
   ]
     .filter((line): line is string => line !== null)

--- a/scripts/codegen/src/generators/gen-vue/kinds/atomic.ts
+++ b/scripts/codegen/src/generators/gen-vue/kinds/atomic.ts
@@ -165,6 +165,7 @@ export function renderAtomicVueWrapper(
     a11y?.role,
     a11y?.ariaProps ?? [],
     a11y?.decorativeProp,
+    a11y?.labelProp,
   );
   // Vue's v-bind="attrs" emits these as literal attributes on the rendered
   // element — same role as the consumer-spread + lock pattern on the React

--- a/scripts/codegen/src/lib/flatten.ts
+++ b/scripts/codegen/src/lib/flatten.ts
@@ -59,6 +59,7 @@ export type FlatA11y = {
   states?: Record<string, string>;
   ariaProps?: string[];
   decorativeProp?: string;
+  labelProp?: string;
 };
 
 export type FlatMotion = {

--- a/scripts/codegen/src/schema.ts
+++ b/scripts/codegen/src/schema.ts
@@ -60,6 +60,12 @@ const a11yBlock = z.strictObject({
    *  runtime the root emits `role="none"` (overriding any static `role`) and
    *  `aria-hidden="true"`, removing the element from the accessibility tree. */
   decorativeProp: z.string().min(1).optional(),
+  /** Names a declared `type: string`, non-responsive prop. The root is
+   *  decorative by default (`aria-hidden="true"` and, if `role` is set,
+   *  role overridden to `"none"`). When the prop has a value at runtime
+   *  the root emits `aria-label={prop}` and the decorative attrs drop.
+   *  Mutually exclusive with `decorativeProp`. */
+  labelProp: z.string().min(1).optional(),
 });
 
 const constraintEntry = z.strictObject({
@@ -181,6 +187,7 @@ type ComponentPart = {
     states?: Record<string, string>;
     ariaProps?: string[];
     decorativeProp?: string;
+    labelProp?: string;
   };
   constraints?: Array<{
     when: Record<string, unknown>;

--- a/scripts/codegen/src/semantic-checks.test.ts
+++ b/scripts/codegen/src/semantic-checks.test.ts
@@ -1072,6 +1072,78 @@ describe("checkA11yRefs", () => {
     const spec = dividerSpec({ a11y: { role: "separator" } });
     expect(checkA11yRefs(spec)).toEqual([]);
   });
+
+  function dotSpec(overrides: Record<string, unknown> = {}): Spec {
+    return makeSpec({
+      name: "dot",
+      kind: "atomic",
+      rootClass: "t-dot",
+      element: "span",
+      props: {
+        label: {
+          type: "string",
+          responsive: false,
+          description: "Accessible name when meaningful.",
+        },
+      },
+      a11y: {
+        role: "img",
+        labelProp: "label",
+      },
+      ...overrides,
+    });
+  }
+
+  test("passes when labelProp references a non-responsive string prop", () => {
+    expect(checkA11yRefs(dotSpec())).toEqual([]);
+  });
+
+  test("rejects when labelProp references an undeclared prop", () => {
+    const spec = dotSpec({ a11y: { role: "img", labelProp: "bogus" } });
+    const issues = checkA11yRefs(spec);
+    expect(issues.some((i) => i.path === "a11y.labelProp")).toBe(true);
+    expect(issues.find((i) => i.path === "a11y.labelProp")?.message).toMatch(/not declared/);
+  });
+
+  test("rejects when labelProp references a boolean prop", () => {
+    const spec = dotSpec({
+      props: {
+        label: {
+          type: "boolean",
+          responsive: false,
+          description: "Wrong type.",
+        },
+      },
+    });
+    const issues = checkA11yRefs(spec);
+    expect(issues.some((i) => i.message.includes("type: 'string'"))).toBe(true);
+  });
+
+  test("rejects when labelProp references a responsive prop", () => {
+    const spec = dotSpec({
+      props: {
+        label: {
+          type: "string",
+          responsive: true,
+          description: "Should be non-responsive.",
+        },
+      },
+    });
+    const issues = checkA11yRefs(spec);
+    expect(issues.some((i) => i.message.includes("non-responsive"))).toBe(true);
+  });
+
+  test("rejects when both decorativeProp and labelProp are declared", () => {
+    const spec = dotSpec({
+      props: {
+        label: { type: "string", responsive: false, description: "Accessible name." },
+        decorative: { type: "boolean", responsive: false, description: "Decorative." },
+      },
+      a11y: { role: "img", labelProp: "label", decorativeProp: "decorative" },
+    });
+    const issues = checkA11yRefs(spec);
+    expect(issues.some((i) => i.message.includes("mutually exclusive"))).toBe(true);
+  });
 });
 
 describe("checkPolymorphicAtomic", () => {

--- a/scripts/codegen/src/semantic-checks.ts
+++ b/scripts/codegen/src/semantic-checks.ts
@@ -1006,7 +1006,7 @@ export function checkElementByProp(spec: Spec): Issue[] {
   return issues;
 }
 
-// ── Atomic `a11y.ariaProps` + `a11y.decorativeProp` refs ───────────────────
+// ── Atomic `a11y.ariaProps` + `a11y.decorativeProp` + `a11y.labelProp` refs ──
 
 /**
  * `a11y.ariaProps[i]` must reference a declared `type: 'string'`, non-
@@ -1017,6 +1017,13 @@ export function checkElementByProp(spec: Spec): Issue[] {
  * `a11y.decorativeProp` must reference a declared `type: 'boolean'` prop —
  * the generator branches on `=== true` to toggle `role="none"` and
  * `aria-hidden="true"`.
+ *
+ * `a11y.labelProp` must reference a declared `type: 'string'`, non-
+ * responsive prop — the generator emits `aria-label={prop}` when set and
+ * `aria-hidden="true"` (plus role override to `"none"` when a base role is
+ * declared) when unset. Mutually exclusive with `decorativeProp` — the two
+ * encode opposite a11y defaults (meaningful-by-default vs decorative-by-
+ * default) and would contradict each other on the same root.
  */
 export function checkA11yRefs(spec: Spec): Issue[] {
   const issues: Issue[] = [];
@@ -1065,6 +1072,43 @@ export function checkA11yRefs(spec: Spec): Issue[] {
             spec.name,
             `${base}.decorativeProp`,
             `prop '${dec}' must be \`type: 'boolean'\`; got '${prop.type}'`,
+          ),
+        );
+      }
+    }
+    const lbl = a11y.labelProp;
+    if (lbl !== undefined) {
+      const prop = props[lbl];
+      if (!prop) {
+        issues.push(
+          issue(spec.name, `${base}.labelProp`, `prop '${lbl}' is not declared on this node`),
+        );
+      } else {
+        if (prop.type !== "string") {
+          issues.push(
+            issue(
+              spec.name,
+              `${base}.labelProp`,
+              `prop '${lbl}' must be \`type: 'string'\`; got '${prop.type}'`,
+            ),
+          );
+        }
+        if (prop.responsive === true) {
+          issues.push(
+            issue(
+              spec.name,
+              `${base}.labelProp`,
+              `prop '${lbl}' must be non-responsive (aria-label is emitted once on the root)`,
+            ),
+          );
+        }
+      }
+      if (dec !== undefined) {
+        issues.push(
+          issue(
+            spec.name,
+            `${base}`,
+            `'decorativeProp' and 'labelProp' are mutually exclusive — pick one (decorative-by-default vs meaningful-by-default)`,
           ),
         );
       }


### PR DESCRIPTION
## What

Add `a11y.labelProp: <prop-name>` on atomic specs. The named prop is `type: string`, non-responsive. Generator emits a conditional pair on the root:

- Set value → `aria-label={labelProp}`, no `aria-hidden`, `role` stays at declared value.
- Unset → `aria-hidden="true"`, role overridden to `"none"` when a base role is declared.

Mirror of `decorativeProp` but inverted (opt-in to meaningful instead of opt-in to decorative). Mutually exclusive with `decorativeProp` (semantic check rejects co-declaration).

## Why

Dot (#950) and Icon (#952) both lock "decorative by default; consumer supplies a `label` to make it meaningful." Current substrate had no path:

- `decorativeProp` is boolean-only and inverse.
- `htmlAttrs` emits after `{...rest}` so consumer can't override.
- `ariaProps` forwards a string value but doesn't toggle `aria-hidden`.

`labelProp` is the symmetric counterpart. One field, two-line emission per framework, zero diff for existing specs.

## Test plan

- [ ] pnpm test
- [ ] pnpm typecheck
- [ ] pnpm lint
- [ ] pnpm gen produces zero diff for existing specs
- [ ] semantic-checks reject undeclared / wrong-type / responsive / mutex-with-decorativeProp

## Out of scope

- Re-dispatching Dot + Icon agents on the new substrate.
- Substrate consolidation ADR (escape hatches → orthogonal primitives) — tracked separately.

Closes #972