### PR TITLE
fix(ci): rebuild @teseor/css dist on post-merge when CSS sources change

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -64,3 +64,15 @@ pre-push:
       run: pnpm -r --if-present run build && node scripts/hooks/verify-no-dev-leak.js
     measure:
       run: pnpm build:css && pnpm size
+
+# `packages/css/dist/**` is gitignored, so pulling/merging new CSS sources
+# leaves it stale relative to `packages/css/src/**`. Consumers that import
+# `@teseor/css/components/<name>.css` (the wrappers, the docs, the harness)
+# then fail to resolve. This hook rebuilds dist whenever the merged range
+# changed CSS sources — runs ~1s and only when the glob matches.
+post-merge:
+  files: git diff-tree -r --name-only --no-commit-id ORIG_HEAD HEAD
+  commands:
+    rebuild-css:
+      glob: "packages/css/src/**"
+      run: pnpm build:css


### PR DESCRIPTION
## What

Adds a `post-merge` lefthook hook that runs `pnpm build:css` when the merged commit range touched `packages/css/src/**`.

## Why

After today's Wave 2 fast-forward merge, `packages/react/src/Dot.tsx` failed to resolve `@teseor/css/components/dot.css`. Root cause: `packages/css/dist/**` is gitignored. The merging clone's dist only contains whatever was last built locally, so pulling new CSS sources leaves dist behind. `pnpm test`, `pnpm typecheck`, IDE resolvers, and Astro reloads all assume dist is fresh and fail otherwise.

The hook is glob-filtered, so pulls that don't touch CSS sources are free.

## Test plan

- [x] `pnpm exec lefthook dump` shows the parsed `post-merge` block.
- [x] `pnpm exec lefthook install --force` writes `.git/hooks/post-merge`.
- [x] Existing pre-commit / pre-push gates unchanged.
- [ ] Reviewer: pull this branch into a clone with stale `packages/css/dist/`; merging confirms `build:css` runs once.

## Out of scope

- Symmetric coverage of `post-checkout` (branch switch) and `post-rewrite` (rebase). Add only if the bug recurs from those vectors.
- Restructuring dist as a checked-in artifact.

Closes #979