### PR TITLE
feat(repo): codegen-import-direction lint rule (47c #2)

### DIFF
--- a/scripts/lint/cross-file/codegen-import-direction.test.ts
+++ b/scripts/lint/cross-file/codegen-import-direction.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import { extractImports, pluginOf, resolveImport } from "./codegen-import-direction.ts";
+
+describe("pluginOf", () => {
+  it("returns the plugin folder name for a file under plugins/<name>/", () => {
+    expect(pluginOf("scripts/codegen/src/plugins/events/check.ts")).toBe("events");
+  });
+
+  it("returns the plugin folder name for a nested file", () => {
+    expect(pluginOf("scripts/codegen/src/plugins/events/check/runtime-support.ts")).toBe("events");
+  });
+
+  it("returns undefined for non-plugin paths", () => {
+    expect(pluginOf("scripts/codegen/src/core/registry.ts")).toBeUndefined();
+  });
+
+  it("returns undefined for the plugins root itself", () => {
+    expect(pluginOf("scripts/codegen/src/plugins")).toBeUndefined();
+  });
+});
+
+describe("extractImports", () => {
+  it("captures plain string imports", () => {
+    expect(extractImports(`import { x } from "./a.ts";`)).toEqual(["./a.ts"]);
+  });
+
+  it("captures type-only imports", () => {
+    expect(extractImports(`import type { X } from "../core/schema.ts";`)).toEqual([
+      "../core/schema.ts",
+    ]);
+  });
+
+  it("captures re-exports", () => {
+    expect(extractImports(`export { x } from "./helpers.ts";`)).toEqual(["./helpers.ts"]);
+  });
+
+  it("captures multiple imports", () => {
+    const source = `
+      import { a } from "./a.ts";
+      import { b } from "../core/b.ts";
+      import { c } from "zod";
+    `;
+    expect(extractImports(source)).toEqual(["./a.ts", "../core/b.ts", "zod"]);
+  });
+});
+
+describe("resolveImport", () => {
+  it("resolves a sibling import", () => {
+    const target = resolveImport("scripts/codegen/src/plugins/events/check.ts", "./schema.ts");
+    expect(target).toBe("scripts/codegen/src/plugins/events/schema.ts");
+  });
+
+  it("resolves a parent-folder import", () => {
+    const target = resolveImport(
+      "scripts/codegen/src/plugins/events/check.ts",
+      "../../core/schema.ts",
+    );
+    expect(target).toBe("scripts/codegen/src/core/schema.ts");
+  });
+
+  it("resolves a nested-file parent-folder import", () => {
+    const target = resolveImport(
+      "scripts/codegen/src/plugins/events/check/index.ts",
+      "../../../core/schema.ts",
+    );
+    expect(target).toBe("scripts/codegen/src/core/schema.ts");
+  });
+
+  it("returns undefined for npm-package imports", () => {
+    expect(resolveImport("scripts/codegen/src/plugins/events/check.ts", "zod")).toBeUndefined();
+  });
+
+  it("flags a sibling-plugin path when resolving plugin → plugin", () => {
+    const target = resolveImport(
+      "scripts/codegen/src/plugins/events/check.ts",
+      "../parts/check.ts",
+    );
+    expect(target).toBe("scripts/codegen/src/plugins/parts/check.ts");
+  });
+});

--- a/scripts/lint/cross-file/codegen-import-direction.ts
+++ b/scripts/lint/cross-file/codegen-import-direction.ts
@@ -1,0 +1,91 @@
+// Enforces the substrate plugin architecture's directional import rule:
+// a plugin cannot import from another plugin. Plugin isolation is the
+// substrate invariant — plugins compose via `core/registry.ts`, not via
+// direct symbol references.
+//
+// Allowed cross-folder imports from `scripts/codegen/src/plugins/<name>/`:
+//   - own folder (`./`, `./<sub>/`)
+//   - core/ (`../../core/`, `../../../core/` from nested files)
+//   - lib/ (`../../lib/`, `../../../lib/` from nested files)
+//
+// Disallowed:
+//   - `../../<other-plugin>/...`
+//   - `../../../<other-plugin>/...` (from nested files)
+import { readFileSync } from "node:fs";
+import { dirname, normalize, relative, resolve } from "node:path";
+import { lsFiles } from "../../lib/enumerate.ts";
+import { REPO_ROOT } from "../../lib/paths.ts";
+import type { ViolationDetail, WorkspaceCheck } from "../registry.ts";
+
+const PLUGIN_ROOT = "scripts/codegen/src/plugins";
+const TRIGGERS = [`${PLUGIN_ROOT}/**/*.ts`] as const;
+
+const IMPORT_RE = /\bfrom\s+["']([^"']+)["']/g;
+
+/** The plugin folder name a file lives in, e.g. `events` for
+ *  `scripts/codegen/src/plugins/events/check/index.ts`. */
+export function pluginOf(relPath: string): string | undefined {
+  const parts = relPath.split("/");
+  const idx = parts.indexOf("plugins");
+  if (idx < 0 || idx + 1 >= parts.length) return undefined;
+  return parts[idx + 1];
+}
+
+/** Resolve a relative `from "..."` specifier against the importing file's
+ *  directory. Returns the repo-relative path of the target, or undefined for
+ *  non-relative specifiers (npm packages). */
+export function resolveImport(fromFile: string, specifier: string): string | undefined {
+  if (!specifier.startsWith(".")) return undefined;
+  const fromAbs = resolve(REPO_ROOT, fromFile);
+  const targetAbs = resolve(dirname(fromAbs), specifier);
+  return relative(REPO_ROOT, normalize(targetAbs));
+}
+
+/** Returns the import specifiers extracted from a TS source. Comments and
+ *  string literals embedded in code can produce false positives in pathological
+ *  cases; for `scripts/codegen/src/plugins/**` the trade-off is acceptable
+ *  (the directory is curated, no exotic string content). */
+export function extractImports(source: string): string[] {
+  const out: string[] = [];
+  for (const m of source.matchAll(IMPORT_RE)) {
+    if (m[1] !== undefined) out.push(m[1]);
+  }
+  return out;
+}
+
+function checkPluginImportDirection(): ViolationDetail[] {
+  const out: ViolationDetail[] = [];
+  const files = lsFiles(TRIGGERS, REPO_ROOT);
+  for (const rel of files) {
+    const sourcePlugin = pluginOf(rel);
+    if (sourcePlugin === undefined) continue;
+    let source: string;
+    try {
+      source = readFileSync(resolve(REPO_ROOT, rel), "utf8");
+    } catch {
+      continue;
+    }
+    for (const specifier of extractImports(source)) {
+      const target = resolveImport(rel, specifier);
+      if (target === undefined) continue;
+      const targetPlugin = pluginOf(target);
+      if (targetPlugin === undefined) continue;
+      if (targetPlugin === sourcePlugin) continue;
+      out.push({
+        file: rel,
+        message: `imports from sibling plugin "${targetPlugin}" via \`${specifier}\` — plugins must not import each other (compose via core/registry.ts).`,
+      });
+    }
+  }
+  return out;
+}
+
+export const rule: WorkspaceCheck = {
+  kind: "workspace",
+  triggers: TRIGGERS,
+  run: checkPluginImportDirection,
+  hint:
+    "Plugin isolation is the substrate architecture's invariant (ADR-0025).\n" +
+    "If two plugins need shared logic, lift it to scripts/codegen/src/core/ or scripts/codegen/src/lib/.\n" +
+    "If they need shared schema fragments, register them under their respective scopes — composeFragments merges them.",
+};

--- a/scripts/lint/registry.ts
+++ b/scripts/lint/registry.ts
@@ -11,6 +11,7 @@
 //
 // No package.json edit, no lefthook edit, no new top-level script.
 
+import { rule as codegenImportDirection } from "./cross-file/codegen-import-direction.ts";
 import { rule as configPaths } from "./cross-file/config-paths.ts";
 import { rule as contractSnapshots } from "./cross-file/contract-snapshots.ts";
 import { rule as docPaths } from "./cross-file/doc-paths.ts";
@@ -139,5 +140,6 @@ export const REGISTRY: Readonly<Record<string, Check>> = {
   "config-paths": configPaths,
   "label-sync": labelSync,
   "codegen-tests": codegenTests,
+  "codegen-import-direction": codegenImportDirection,
   changeset: changeset,
 };


### PR DESCRIPTION
Closes #992.
Ticks off rule 2 of 6 in #989.

## What

Adds `scripts/lint/cross-file/codegen-import-direction.ts` — a workspace-shape check that walks `scripts/codegen/src/plugins/**/*.ts` and reports any file that imports from a sibling plugin folder.

## Why

Plugin isolation is the substrate architecture's central invariant. Plugins compose through `core/registry.ts`; a stray `from "../parts/check.ts"` inside `plugins/events/check.ts` would silently re-introduce coupling across substrate boundaries. The rule was hand-followed during the substrate migration; this commit codifies it.

The rule's hint points users at the right escape valve when two plugins seem to need shared logic: lift it to `core/` or `lib/`, or register schema fragments under their respective plugins so `composeFragments` merges them.

Branched off `main` (independent of #990).

## Test plan

- [x] 13 unit tests cover `pluginOf`, `extractImports`, `resolveImport` (sibling, parent, nested, npm, plugin → plugin)
- [x] `node scripts/lint/run.ts --codegen-import-direction` reports clean on current `main`
- [x] `pnpm lint` clean (the new rule registered alongside existing ones)
- [x] `pnpm typecheck` clean (9/9 workspaces)

## Out of scope

- The 4 remaining lint guardrails listed in #989: file/folder LOC limits, single-export-barrel detection, top-level orphan allowlist, knip for dead exports.