### PR TITLE
feat(codegen): props schema accepts record-shape values + per-entry tokens

### DIFF
--- a/codegen/src/plugins/props/schema.test.ts
+++ b/codegen/src/plugins/props/schema.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, test } from "vitest";
+import { propEntry } from "./schema.ts";
+
+describe("propEntry — array-form values", () => {
+  test("accepts `type: string` with array values + description", () => {
+    const result = propEntry.safeParse({
+      type: "string",
+      values: ["solid", "outline"],
+      description: "Visual weight.",
+    });
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.type).toBe("string");
+    expect(result.data.values).toEqual(["solid", "outline"]);
+    expect(result.data.valueDocs).toBeUndefined();
+  });
+
+  test("accepts `type: boolean` without values", () => {
+    const result = propEntry.safeParse({
+      type: "boolean",
+      description: "Disables the control.",
+    });
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.type).toBe("boolean");
+    expect(result.data.values).toBeUndefined();
+    expect(result.data.valueDocs).toBeUndefined();
+  });
+
+  test("accepts `type: number` without values", () => {
+    const result = propEntry.safeParse({
+      type: "number",
+      description: "Numeric input.",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  test("rejects array values without `type:`", () => {
+    const result = propEntry.safeParse({
+      values: ["a", "b"],
+      description: "missing type",
+    });
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error.issues.some((i) => i.path.includes("type"))).toBe(true);
+  });
+
+  test("rejects `type:` without description", () => {
+    const result = propEntry.safeParse({
+      type: "string",
+      values: ["a", "b"],
+    });
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error.issues.some((i) => i.path.includes("description"))).toBe(true);
+  });
+});
+
+describe("propEntry — record-form values", () => {
+  test("accepts record values with per-entry description only", () => {
+    const result = propEntry.safeParse({
+      default: "solid",
+      values: {
+        solid: { description: "Filled background." },
+        outline: { description: "Transparent with border." },
+      },
+    });
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.values).toEqual(["solid", "outline"]);
+    expect(result.data.valueDocs).toEqual({
+      solid: { description: "Filled background." },
+      outline: { description: "Transparent with border." },
+    });
+  });
+
+  test("accepts per-entry tokens with valid CSS variable names", () => {
+    const result = propEntry.safeParse({
+      default: "neutral",
+      values: {
+        neutral: {
+          description: "Default semantic color.",
+          tokens: { bg: "--t-surface-muted", fg: "--t-on-surface" },
+        },
+        primary: {
+          description: "Accent color.",
+          tokens: { bg: "--t-accent", fg: "--t-on-accent" },
+        },
+      },
+    });
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.valueDocs?.neutral?.tokens).toEqual({
+      bg: "--t-surface-muted",
+      fg: "--t-on-surface",
+    });
+  });
+
+  test("auto-derives `type: 'string'` on the normalized output", () => {
+    const result = propEntry.safeParse({
+      values: { sm: { description: "Small." } },
+    });
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.type).toBe("string");
+  });
+
+  test("accepts `responsive: true` alongside record values", () => {
+    const result = propEntry.safeParse({
+      default: "md",
+      responsive: true,
+      values: {
+        sm: { description: "Small." },
+        md: { description: "Medium." },
+        lg: { description: "Large." },
+      },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  test("rejects `type:` when values is a record", () => {
+    const result = propEntry.safeParse({
+      type: "string",
+      values: { a: { description: "A." } },
+    });
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error.issues.some((i) => i.path.includes("type"))).toBe(true);
+  });
+
+  test("rejects per-entry description that is empty", () => {
+    const result = propEntry.safeParse({
+      values: { a: { description: "" } },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects per-entry tokens with invalid CSS-variable names", () => {
+    const result = propEntry.safeParse({
+      values: {
+        a: { description: "A.", tokens: { bg: "not-a-css-var" } },
+      },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects extra fields inside a value entry (strictObject)", () => {
+    const result = propEntry.safeParse({
+      values: { a: { description: "A.", unknown: true } },
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("propEntry — shared fields pass through", () => {
+  test("preserves `default`, `responsive`, `slot`, `pattern` on legacy shape", () => {
+    const result = propEntry.safeParse({
+      type: "boolean",
+      default: false,
+      responsive: false,
+      pattern: "controllable",
+      description: "Open state.",
+    });
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.default).toBe(false);
+    expect(result.data.responsive).toBe(false);
+    expect(result.data.pattern).toBe("controllable");
+  });
+
+  test("rejects an unknown top-level field", () => {
+    const result = propEntry.safeParse({
+      type: "string",
+      description: "x",
+      unknown: true,
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/codegen/src/plugins/props/schema.ts
+++ b/codegen/src/plugins/props/schema.ts
@@ -1,11 +1,68 @@
 import { z } from "zod";
 
-export const propEntry = z.strictObject({
-  type: z.enum(["string", "boolean", "number"]),
-  default: z.unknown().optional(),
+const tokenName = z.string().regex(/^--[A-Za-z0-9_-]+$/);
+
+const propValueEntry = z.strictObject({
   description: z.string().min(1),
+  tokens: z.record(z.string(), tokenName).optional(),
+});
+
+const propEntryInput = z.strictObject({
+  type: z.enum(["string", "boolean", "number"]).optional(),
+  default: z.unknown().optional(),
+  description: z.string().min(1).optional(),
   responsive: z.boolean().optional(),
   slot: z.boolean().optional(),
-  values: z.array(z.string()).optional(),
+  values: z.union([z.array(z.string()), z.record(z.string(), propValueEntry)]).optional(),
   pattern: z.literal("controllable").optional(),
 });
+
+export const propEntry = propEntryInput
+  .superRefine((data, ctx) => {
+    const valuesIsRecord = data.values !== undefined && !Array.isArray(data.values);
+    if (valuesIsRecord) {
+      if (data.type !== undefined) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message:
+            "`type:` must be omitted when `values:` is a record — the TS type is the union of value keys, not bare string",
+          path: ["type"],
+        });
+      }
+    } else {
+      if (data.type === undefined) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: "`type:` is required when `values:` is absent or an array",
+          path: ["type"],
+        });
+      }
+      if (data.description === undefined) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: "`description:` is required when `values:` is absent or an array",
+          path: ["description"],
+        });
+      }
+    }
+  })
+  .transform((data) => {
+    let valueKeys: string[] | undefined;
+    let valueDocs: Record<string, z.infer<typeof propValueEntry>> | undefined;
+    if (Array.isArray(data.values)) {
+      valueKeys = data.values;
+    } else if (data.values !== undefined) {
+      valueKeys = Object.keys(data.values);
+      valueDocs = data.values;
+    }
+    return {
+      type: data.type ?? ("string" as const),
+      default: data.default,
+      description: data.description,
+      responsive: data.responsive,
+      slot: data.slot,
+      values: valueKeys,
+      valueDocs,
+      pattern: data.pattern,
+    };
+  });

--- a/docs/ADR/0026-props-record-values.md
+++ b/docs/ADR/0026-props-record-values.md
@@ -1,0 +1,149 @@
+# ADR-0026 — Top-level variants/intents/sizes consolidate into `props:` (inline-object values; type derived from value keys)
+
+- **Status:** Proposed.
+- **Deciders:** repo owner (letanure).
+
+## Decision
+
+Top-level spec blocks `variants:`, `intents:`, and `sizes:` retire. The props
+they conceptually represent (`variant`, `intent`, `size`) move under `props:`.
+A `propEntry` whose `values:` is a record uses the inline-object form: each
+value is `{ description, tokens? }`. Per-value CSS-token maps live INSIDE the
+value entry (today's intents/sizes `tokens:` field), not as a sibling block.
+When `values:` is present, the TS type emitted by `gen-contract` is the
+union of value keys; the `type:` field is omitted (it was a misnomer — bare
+`string` doesn't describe the constraint). `type:` stays on non-enum scalar
+props (`boolean`, `number`, open-set `string`). The legacy array form
+(`values: [a, b, c]`) and `type: string + values: [...]` shape retire with
+the migration so every enum prop reads the same way.
+
+```yaml
+props:
+  variant:
+    default: solid
+    values:
+      solid:
+        description: Filled background with the intent color; default visual weight.
+      outline:
+        description: Transparent background with intent-colored border and label.
+      ghost:
+        description: Transparent background, no border, intent-colored label.
+
+  intent:
+    default: neutral
+    values:
+      neutral:
+        description: Default semantic color; non-emphasized metadata badges.
+        tokens: { bg: --t-surface-muted, fg: --t-on-surface }
+      primary:
+        description: Accent-colored badge; matches the page's primary action.
+        tokens: { bg: --t-accent, fg: --t-on-accent }
+      success:
+        description: Positive status (active, online, completed).
+        tokens: { bg: --t-success, fg: --t-on-success }
+
+  size:
+    default: md
+    responsive: true
+    values:
+      sm:
+        description: Compact density; inline with small prose.
+        tokens: { font-size: --t-text-xs }
+      md:
+        description: Default size; matches body text.
+        tokens: { font-size: --t-text-sm }
+      lg:
+        description: Emphatic; for hero callouts and prominent surfaces.
+        tokens: { font-size: --t-text-base }
+
+  shape:
+    default: rounded
+    values:
+      rounded:
+        description: Token-controlled radius corners (default).
+      pill:
+        description: Fully rounds the inline ends for chip-style badges.
+
+  disabled:
+    type: boolean
+    default: false
+    description: Disables the interactive control.
+
+  gap:
+    type: string
+    description: Inline-direction spacing token (open-set; accepts any spacing-token suffix).
+```
+
+`visualStates:` keeps its current top-level position — it describes runtime
+states (`:hover`, `:focus-visible`, …) of the rendered element, not props.
+
+## Why inline-object values, dropped `type:`, and not the alternatives
+
+- **Not sibling-keyed tokens (`values: { a: "..." }` + `tokens: { a: { ... }, b: { ... } }`).**
+  Value names repeat between blocks. Adding a value is two edits; forgetting
+  one is silent drift that only the schema check catches. Inline-object form
+  is one edit per value. See memory `feedback_sync_safety_over_visual_brevity`.
+- **Not parallel-shape (array OR record).** Legacy `values: [a, b, c]` is kept
+  valid only for the migration window. Long-term, two shapes for the same
+  field is a cognitive tax with no benefit — every consumer branches,
+  authors guess which form to use. Uniform record form is the post-migration
+  end state.
+- **Not array-of-objects (`- name: solid, description: …`).** Loses YAML's
+  natural key uniqueness, forces every consumer (vocabulary check, examples
+  reference check, contract emit) to lookup-by-field-name instead of direct
+  property access, and breaks symmetry with `props:`, `tokens:`, `examples:`
+  (all keyed records today).
+- **Not keeping `type: string` on enum props.** ADR-0006 kept `type: string`
+  because the runtime contract is a string (CSS attribute selector), but at
+  the schema/TS level the type is the union of value keys, not bare string.
+  Dropping `type:` when `values:` is present is the honest shape. The CSS
+  runtime contract doesn't change — only the schema representation.
+- **Not keeping the top-level blocks.** `variants:` / `intents:` / `sizes:`
+  each emit an auto-derived wrapper prop (`variant`, `intent`, `size`)
+  rendered at the head of the docs Props table. Splitting "prop surface"
+  across `props:` + three sibling blocks adds three reading paths for one
+  conceptual surface and three special-case branches in
+  `codegen/src/lib/flatten.ts` and
+  `codegen/src/generators/gen-docs/_shared/sections.ts`. Co-locating is the
+  simplification.
+
+## Consequences
+
+- **Localization is mechanical.** Translators copy `values:` from the base
+  spec and edit only `description:` fields. `tokens:` entries are obvious
+  CSS variables and stay untouched. Programmatic extraction: "the
+  `.description` field of each value entry is the localizable surface."
+- **Add-a-value is one edit.** A new `info` intent means one entry under
+  `props.intent.values:` carrying both its description and its token map.
+  No second block to remember.
+- **`responsive: true` becomes explicit on `size`.** The
+  `RESPONSIVE_BLOCK_PROPS = new Set(["size"])` heuristic in
+  `codegen/src/lib/responsive-blocks.ts` retires; each prop declares its
+  own responsiveness.
+- **Per-value descriptions are richer documentation.** Replacing prop-level
+  one-liners like *"Corner shape. `rounded` is the default..."* with
+  per-value entries is a strict improvement for the docs Props table and
+  for IDE hover text.
+- **Migration is snapshot-gated.** Phase 2 converts `badge.yaml` as the
+  canonical reference; `pnpm gen` + the `contract-snapshots` Playwright
+  suite catch any drift. Phases 3 and 4 fan out across the remaining 16
+  specs in small PRs.
+- **Old code paths delete cleanly.** The `variantsPlugin` schema's
+  atomic/part `variants:` / `intents:` / `sizes:` records collapse to just
+  `visualStates:`. The flatten branches, the special-case docs rendering in
+  `codegen/src/generators/gen-docs/_shared/sections.ts`, the vocabulary
+  check, the token usage check, the events generic-aliases check, and the
+  `codegen/src/lib/responsive-blocks.ts` heuristic all simplify.
+- **ADR-0006 is amended, not superseded.** The "constrain string props via
+  `values:`" decision stands; the shape of `values:` becomes a record of
+  inline objects (was an array), and the `type: string` marker drops when
+  `values:` is present. Same underlying intent: closed-set string at runtime,
+  narrowed TS type at compile time.
+
+## References
+
+- ADR-0006 — Enum-typed string props (this ADR amends the shape).
+- ADR-0008 — Token-driven component CSS (the tokens consumer).
+- Issue #1000 — tracking issue + phase plan.
+- Memory `feedback_sync_safety_over_visual_brevity` — the principle behind
+  inline-object over sibling-keyed maps.

--- a/docs/ADR/README.md
+++ b/docs/ADR/README.md
@@ -32,6 +32,8 @@ a numbered, durable file.
 | [0022](0022-minimal-when-guard-grammar.md) | Minimal `when:` guard grammar | Accepted |
 | [0023](0023-state-machine-runtime-in-primitives.md) | State-machine runtime lives in `@teseor/primitives` | Accepted |
 | [0024](0024-part-name-uniqueness.md) | Part names are unique across the parts tree | Accepted |
+| [0025](0025-substrate-plugin-architecture.md) | Substrate plugin architecture | Accepted |
+| [0026](0026-props-record-values.md) | Top-level variants/intents/sizes consolidate into `props:` | Proposed |
 
 ## When to write one
 


### PR DESCRIPTION
## What

Extend `codegen/src/plugins/props/schema.ts` so `propEntry` accepts a new record-shape `values:` field where each value is `{ description, tokens? }`. When `values:` is a record, prop-level `type:` is omitted (the TS type is the union of value keys); per-value `description` carries documentation and optional `tokens:` carries the CSS-variable map. The existing array-form `values: [a, b, c]` stays valid alongside the new shape so the 15+ specs that already use it keep parsing while the migration runs.

The schema's Zod `.transform()` normalizes both input shapes to the same internal output: `type` always present (auto-derived to `"string"` for record-shape props), `values: string[] | undefined` (the keys), plus a new `valueDocs: Record<string, { description, tokens? }> | undefined` carrying the rich per-value metadata for downstream consumers. This keeps every current generator/check that reads `propDef.values` / `propDef.type` working without modification.

ADR-0026 (Proposed) records the design and the rejected alternatives. Lands here so reviewers see the rule alongside the schema that enforces it.

## Why

`variants:` / `intents:` / `sizes:` are top-level spec blocks today because the current `propEntry` schema can't carry per-value descriptions or per-value token maps. Splitting "prop surface" across `props:` plus three sibling blocks costs three reading paths for one conceptual surface and three special-case branches in `codegen/src/lib/flatten.ts` and `codegen/src/generators/gen-docs/_shared/sections.ts`. Co-locating under `props:` is the simplification; this PR adds the schema room so the consolidation can proceed.

The shape is inline-object (single field) rather than sibling-keyed maps — adding a value is one edit, not two. See ADR-0026's "Why" section and memory `feedback_sync_safety_over_visual_brevity`.

## Test plan

- `pnpm test codegen/src/plugins/props/schema.test.ts` — new file: 15 cases covering array-form acceptance, record-form acceptance with and without `tokens:`, auto-derived `type: "string"` on the normalized output, refinement rejections (`type:` present with record values, `type:` missing with array values, `description:` missing on the prop, empty per-value description, invalid CSS-variable token name, extra fields).
- `pnpm test` — full suite (1617 tests) still passes; no consumer needs to change because the transform normalizes to the pre-existing output shape.
- `pnpm typecheck` — clean.
- `pnpm lint` — clean (including `doc-paths`, `knip`, `codegen-tests`, `codegen-import-direction`).
- `pnpm gen` — no codegen drift; the schema change is invisible to generators because no spec uses the new shape yet.

## Out of scope

- Migrating any spec to the record form (`badge.yaml` migration is the next step, separate PR).
- Removing the array-form `values: string[]` from the schema (lands after every spec has migrated, separate PR).
- Touching generators / linters / consumers (the normalizing transform makes that unnecessary here).
- Retiring `RESPONSIVE_BLOCK_PROPS` (per-prop `responsive:` already works; the heuristic retires when the top-level `sizes:` block does).

Refs #1000.